### PR TITLE
Support %lf and %lF in format string

### DIFF
--- a/libc/fmt/palandprintf.c
+++ b/libc/fmt/palandprintf.c
@@ -215,6 +215,10 @@ hidden int palandprintf(void *fn, void *arg, const char *format, va_list va) {
         signbit = sizeof(intmax_t) * 8 - 1;
         break;
       case 'l':
+        if (format[1] == 'f' || format[1] == 'F') {
+          format++;
+          break;
+        }
         if (format[1] == 'l') format++;
         /* fallthrough */
       case 't': /* ptrdiff_t */

--- a/test/libc/fmt/palandprintf_test.c
+++ b/test/libc/fmt/palandprintf_test.c
@@ -421,6 +421,7 @@ TEST(sprintf, test_float) {
   EXPECT_STREQ("+42.90", Format("%+6.2f", 42.8952));
   EXPECT_STREQ("+42.9", Format("%+5.1f", 42.9252));
   EXPECT_STREQ("42.500000", Format("%f", 42.5));
+  EXPECT_STREQ("42.500000", Format("%lf", 42.5));
   EXPECT_STREQ("42.5", Format("%.1f", 42.5));
   EXPECT_STREQ("42167.000000", Format("%f", 42167.0));
   EXPECT_STREQ("-12345.987654321", Format("%.9f", -12345.987654321));


### PR DESCRIPTION
Per C99 this should resolve to double.

This should resolve #58 