### PR TITLE
redbean.c: remove duplicate png content-types

### DIFF
--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -180,9 +180,6 @@ static const struct ContentTypeExtension {
     {"otf", "font/otf"},                  //
     {"pdf", "application/pdf"},           //
     {"png", "image/png"},                 //
-    {"png", "image/png"},                 //
-    {"png", "image/png"},                 //
-    {"png", "image/png"},                 //
     {"s", "text/plain"},                  //
     {"svg", "image/svg+xml"},             //
     {"tiff", "image/tiff"},               //


### PR DESCRIPTION
Hello. The duplicate `{"png", "image/png"}` entries look useless. That won't change much regarding performance because a binary search is used on this array, but it eats 48 bytes for nothing ; unless you noticed a performance or code compression improvement with the duplication.

