### PR TITLE
Make it easy to build in RAM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,15 @@ GNUMAKEFLAGS += --output-sync
 .FEATURES: output-sync
 .PHONY: all o bins check test depend tags
 
+# If the output directory is a symbolic link, make sure the target directory exists.
+# This makes it easy to build on tmpfs:
+#
+#     ln -s /tmp/cosmopolitan/o o
+#     ln -s $XDG_RUNTIME_DIR/cosmopolitan/o o
+#
+output_directory_link := $(shell readlink o)
+$(if $(output_directory_link),$(shell mkdir -p $(output_directory_link)))
+
 all:	o
 o:	o/$(MODE)/ape		\
 	o/$(MODE)/dsp		\


### PR DESCRIPTION
I understand the build tree is rooted at the `o` directory. Is this correct?

If so, that would make it easy to build in RAM:

    ln -s /tmp/cosmopolitan/o o

The source code will remain on disk while all build artifacts will be written to `tmpfs`. Due to the Linux page cache, all source code will eventually end up being cached in memory as well. Very fast!

I added some GNU Make logic to compute whether `o` is a symbolic link and ensure the link target directory exists. Fixed the build errors when I tried this in my own projects.