### PR TITLE
fix strtoimax behavior when base 2 or 16 is supplied

### DIFF
--- a/libc/fmt/strtoimax.c
+++ b/libc/fmt/strtoimax.c
@@ -77,8 +77,8 @@ intmax_t strtoimax(const char *s, char **endptr, int base) {
     }
   } else if (*s == '0') {
     ++s;
-    if (base == 2 && *s == 'b' && *s == 'B') ++s;
-    if (base == 16 && *s == 'x' && *s == 'X') ++s;
+    if (base == 2 && (*s == 'b' || *s == 'B')) ++s;
+    if (base == 16 && (*s == 'x' || *s == 'X')) ++s;
   }
 
   for (;;) {

--- a/libc/fmt/strtoumax.c
+++ b/libc/fmt/strtoumax.c
@@ -51,10 +51,10 @@ uintmax_t strtoumax(const char *s, char **endptr, int base) {
     } else {
       base = 10;
     }
-  } else if (*s == '0') {
-    ++s;
-    if (base == 2 && *s == 'b' && *s == 'B') ++s;
-    if (base == 16 && *s == 'x' && *s == 'X') ++s;
+  } else if (*p == '0') {
+    ++p;
+    if (base == 2 && (*p == 'b' || *p == 'B')) ++p;
+    if (base == 16 && (*p == 'x' || *p == 'X')) ++p;
   }
 
   for (;;) {

--- a/test/libc/fmt/strtoimax_test.c
+++ b/test/libc/fmt/strtoimax_test.c
@@ -30,10 +30,17 @@ TEST(strtoimax, testDecimal) {
 
 TEST(strtoimax, testHex) {
   EXPECT_EQ(-255, strtoimax("-0xff", NULL, 0));
+  EXPECT_EQ(255, strtoimax("0xff", NULL, 16));
 }
 
 TEST(strtoimax, testOctal) {
   EXPECT_EQ(-123, strtoimax("-0173", NULL, 0));
+  EXPECT_EQ(123, strtoimax("0173", NULL, 8));
+}
+
+TEST(strtoimax, testBinary) {
+  EXPECT_EQ(-42, strtoimax("-0b101010", NULL, 0));
+  EXPECT_EQ(42, strtoimax("0b101010", NULL, 2));
 }
 
 TEST(strtoimax, testLimits) {

--- a/test/libc/fmt/strtoumax_test.c
+++ b/test/libc/fmt/strtoumax_test.c
@@ -29,9 +29,15 @@ TEST(strtoumax, testDecimal) {
 }
 TEST(strtoumax, testHex) {
   EXPECT_EQ(255, strtoumax("0xff", NULL, 0));
+  EXPECT_EQ(255, strtoumax("0xff", NULL, 16));
 }
 TEST(strtoumax, testOctal) {
   EXPECT_EQ(123, strtoumax("0173", NULL, 0));
+  EXPECT_EQ(123, strtoumax("0173", NULL, 8));
+}
+TEST(strtoumax, testBinary) {
+  EXPECT_EQ(42, strtoumax("0b101010", NULL, 0));
+  EXPECT_EQ(42, strtoumax("0b101010", NULL, 2));
 }
 
 TEST(strtoumax, testMaximum) {


### PR DESCRIPTION
While working on #104 I found that hex strings were not being parsed correctly. This was due to a typo in `strtoimax` where if base 2 or base 16 was explicitly supplied, it would not advance the pointer to the start of the number, so it would always resolve 0. I noticed `strtoumax` had a similar bug, so fixed it there too.