### PR TITLE
set errno when out of range in strtoimax

### DIFF
--- a/libc/fmt/strtoimax.c
+++ b/libc/fmt/strtoimax.c
@@ -17,6 +17,7 @@
 │ PERFORMANCE OF THIS SOFTWARE.                                                │
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #include "libc/fmt/conv.h"
+#include "libc/errno.h"
 #include "libc/limits.h"
 #include "libc/nexgen32e/bsr.h"
 #include "libc/str/str.h"
@@ -85,7 +86,7 @@ intmax_t strtoimax(const char *s, char **endptr, int base) {
     diglet = kBase36[*s & 0xff];
     if (!diglet || diglet > base) break;
     diglet -= 1;
-    if (!diglet || !x || (bits = bsr(diglet) + bsrmax(x)) < 127) {
+    if (!x || (bits = (diglet ? bsr(diglet) : 0) + bsrmax(x * base)) < 127) {
       s++;
       x *= base;
       x += diglet;
@@ -96,9 +97,11 @@ intmax_t strtoimax(const char *s, char **endptr, int base) {
         if (x == INTMAX_MIN) s++;
       }
       x = INTMAX_MIN;
+      errno = ERANGE;
       break;
     } else {
       x = INTMAX_MAX;
+      errno = ERANGE;
       break;
     }
   }

--- a/test/libc/fmt/strtoimax_test.c
+++ b/test/libc/fmt/strtoimax_test.c
@@ -53,9 +53,17 @@ TEST(strtoimax, testLimits) {
       strtoimax("0x7fffffffffffffffffffffffffffffff", NULL, 0));
 }
 
-TEST(strtoimax, testTwosBane) {
-  EXPECT_EQ(((uintmax_t)0x8000000000000000) << 64 | 0x0000000000000000,
-            strtoimax("0x80000000000000000000000000000000", NULL, 0));
+TEST(strtoimax, testOutsideLimit) {
+  errno = 0;
+  EXPECT_EQ(
+      ((uintmax_t)0x7fffffffffffffff) << 64 | (uintmax_t)0xffffffffffffffff,
+      strtoimax("0x80000000000000000000000000000000", NULL, 0));
+  EXPECT_EQ(ERANGE, errno);
+  errno = 0;
+  EXPECT_EQ(
+      ((uintmax_t)0x8000000000000000) << 64 | 0x0000000000000000,
+      strtoimax("-0x80000000000000000000000000000001", NULL, 0));
+  EXPECT_EQ(ERANGE, errno);
 }
 
 TEST(strtoul, neghex) {

--- a/test/libc/fmt/strtoumax_test.c
+++ b/test/libc/fmt/strtoumax_test.c
@@ -46,3 +46,8 @@ TEST(strtoumax, testMaximum) {
   EXPECT_EQ(UINTMAX_MAX,
             strtoumax("0xffffffffffffffffffffffffffffffff", NULL, 0));
 }
+
+TEST(strtoumax, testTwosBane) {
+  EXPECT_EQ(((uintmax_t)0x8000000000000000) << 64 | 0x0000000000000000,
+            strtoumax("0x80000000000000000000000000000000", NULL, 0));
+}

--- a/tool/build/calculator.c
+++ b/tool/build/calculator.c
@@ -443,7 +443,7 @@ bool ConsumeLiteral(const char *literal) {
   char *e;
   struct Value x;
   x.t = kInt;
-  x.i = strtoimax(literal, &e, 0);
+  x.i = *literal == '-' ? strtoimax(literal, &e, 0) : strtoumax(literal, &e, 0);
   if (!e || *e) {
     x.t = kFloat;
     x.f = strtod(literal, &e);

--- a/tool/build/calculator.ctest
+++ b/tool/build/calculator.ctest
@@ -81,3 +81,11 @@ false false || ! assert
 1 -1 min -1 = assert
 1 2 min 1 = assert
 rand64 rand64 rand64 rand64 != != && assert
+
+# HEX SIGN
+ -0x80000000 -2147483648 = assert
+  0x80000000  2147483648 = assert
+  0x80000001  2147483649 = assert
+  0xffffffff  4294967295 = assert
+ 0x100000000  4294967296 = assert
+-0x100000000 -4294967296 = assert


### PR DESCRIPTION
This is a follow-up to #110 in a separate PR because the change is a bit trickier to review.

The most important change is this bug fix in `strtoimax`:
```diff
-    if (!diglet || !x || (bits = bsr(diglet) + bsrmax(x)) < 127) {
+    if (!x || (bits = (diglet ? bsr(diglet) : 0) + bsrmax(x * base)) < 127) {
```

The problem is that if either `diglet` or `x` is 0, then `bsr` (or `bsrmax`) will return undefined. However, we can't just skip the check if `diglet` is 0, because when we multiply by `base` we still need to make sure that the result will be in range. The code looks a bit weird like this, but it does work.

One of the existing tests `testTwosBane` failed after changing this, but I moved it to `strtoumax` instead. What I've assumed here is that `strtoimax` should always check for overflow, but `strtoumax` is a faster implementation without bounds checking. This means that the `calculator` app needs to be updated too, so it can still perform bit-wise arithmetic on 128-bit unsigned ints. I did this by checking the first character of the token and calling `strtoimax` or `strtoumax` if it wasn't negative. That's not the cleanest solution, but I think it should work for most use cases.

The other behavior change here is that `atoi`, `atol` etc which according to the spec don't do error checking, will now still set `errno` to `ERANGE` when they go outside of the 128 bit signed int because they are backed by `strtoimax`. But... I think that should be okay.