### PR TITLE
Add noreturn macro

### DIFF
--- a/libc/isystem/stdnoreturn.h
+++ b/libc/isystem/stdnoreturn.h
@@ -1,0 +1,15 @@
+#ifndef LIBC_ISYSTEM_STDNORETURN_H_
+#define LIBC_ISYSTEM_STDNORETURN_H_
+
+#if !(__ASSEMBLER__ + __LINKER__ + 0)
+#if __STDC_VERSION__ + 0 >= 201112
+COSMOPOLITAN_C_START_
+
+#define noreturn _Noreturn
+
+COSMOPOLITAN_C_END_
+
+#endif /* C11 */
+#endif /* !(__ASSEMBLER__ + __LINKER__ + 0) */
+
+#endif

--- a/libc/isystem/stdnoreturn.h
+++ b/libc/isystem/stdnoreturn.h
@@ -1,15 +1,10 @@
 #ifndef LIBC_ISYSTEM_STDNORETURN_H_
 #define LIBC_ISYSTEM_STDNORETURN_H_
 
-#if !(__ASSEMBLER__ + __LINKER__ + 0)
-#if __STDC_VERSION__ + 0 >= 201112
 COSMOPOLITAN_C_START_
 
-#define noreturn _Noreturn
+#define noreturn wontreturn
 
 COSMOPOLITAN_C_END_
-
-#endif /* C11 */
-#endif /* !(__ASSEMBLER__ + __LINKER__ + 0) */
 
 #endif


### PR DESCRIPTION
C11 defines `noreturn` as a macro to `_Noreturn` in the `stdnoreturn.h` header.