### PR TITLE
fflush: remove now-unused variable

### DIFF
--- a/libc/stdio/fflush.c
+++ b/libc/stdio/fflush.c
@@ -36,12 +36,12 @@
  */
 int fflush(FILE *f) {
   size_t i;
-  int rc, wrote;
+  int rc;
   rc = 0;
   if (!f) {
     for (i = __fflush.handles.i; i; --i) {
       if ((f = __fflush.handles.p[i - 1])) {
-        if ((wrote = fflush(f)) == -1) {
+        if (fflush(f) == -1) {
           rc = -1;
           break;
         }


### PR DESCRIPTION
Minor update to ab64ef7364ab2e63b19a40a97f402a40f72a5105 to remove the now-unused `wrote`.