### PR TITLE
Added macro to alias eai2str to gai_strerror

### DIFF
--- a/libc/dns/dns.h
+++ b/libc/dns/dns.h
@@ -47,9 +47,7 @@ struct addrinfo {
 int getaddrinfo(const char *, const char *, const struct addrinfo *,
                 struct addrinfo **) paramsnonnull((4));
 int freeaddrinfo(struct addrinfo *);
-const char *gai_strerror(int errcode);
-const char *eai2str(int);
-#define gai_strerror        eai2str
+const char *gai_strerror(int);
 int dnsnamecmp(const char *, const char *) paramsnonnull();
 int pascalifydnsname(uint8_t *, size_t, const char *) paramsnonnull();
 int resolvedns(const struct ResolvConf *, int, const char *, struct sockaddr *,

--- a/libc/dns/dns.h
+++ b/libc/dns/dns.h
@@ -47,7 +47,9 @@ struct addrinfo {
 int getaddrinfo(const char *, const char *, const struct addrinfo *,
                 struct addrinfo **) paramsnonnull((4));
 int freeaddrinfo(struct addrinfo *);
+const char *gai_strerror(int errcode);
 const char *eai2str(int);
+#define gai_strerror        eai2str
 int dnsnamecmp(const char *, const char *) paramsnonnull();
 int pascalifydnsname(uint8_t *, size_t, const char *) paramsnonnull();
 int resolvedns(const struct ResolvConf *, int, const char *, struct sockaddr *,

--- a/libc/dns/gai_strerror.c
+++ b/libc/dns/gai_strerror.c
@@ -21,7 +21,7 @@
 /**
  * Turns getaddrinfo() return code into string.
  */
-const char *eai2str(int code) {
+const char *gai_strerror(int code) {
   switch (code) {
     case EAI_ADDRFAMILY:
       return "ADDRFAMILY";

--- a/tool/build/runit.c
+++ b/tool/build/runit.c
@@ -260,7 +260,7 @@ void Connect(void) {
   struct addrinfo *ai;
   if ((rc = getaddrinfo(g_hostname, gc(xasprintf("%hu", g_runitdport)),
                         &kResolvHints, &ai)) != 0) {
-    FATALF("%s:%hu: EAI_%s %m", g_hostname, g_runitdport, eai2str(rc));
+    FATALF("%s:%hu: EAI_%s %m", g_hostname, g_runitdport, gai_strerror(rc));
     unreachable;
   }
   ip4 = (const char *)&ai->ai_addr4->sin_addr;

--- a/tool/net/dig.c
+++ b/tool/net/dig.c
@@ -44,7 +44,7 @@ void lookup(const char *name) {
       perror("getaddrinfo");
       exit(1);
     default:
-      fprintf(stderr, "getaddrinfo failed: %d (EAI_%s)\n", rc, eai2str(rc));
+      fprintf(stderr, "getaddrinfo failed: %d (EAI_%s)\n", rc, gai_strerror(rc));
       exit(1);
   }
   if (addrs) {


### PR DESCRIPTION
Apparently for Linux the correct name of the function to return a string form of the error returned by the `getaddrinfo` is called `gai_strerror` and not `eai2str` (see [man page](https://linux.die.net/man/3/gai_strerror) ).

I have just added a `#define` to alias `eai2str` to `gai_strerror` (since the signature of those functions are the same).
