### PR TITLE
Added missing definition for struct ip_mreq

### DIFF
--- a/libc/sock/sock.h
+++ b/libc/sock/sock.h
@@ -48,6 +48,12 @@ struct sockaddr_storage {
   };
 };
 
+struct ip_mreq  {
+  struct in_addr imr_multiaddr;   /* IP multicast address of group */
+  struct in_addr imr_interface;   /* local IP address of interface */
+};
+
+
 struct pollfd {
   int32_t fd;
   int16_t events;


### PR DESCRIPTION
`struct ip_mreq` is used by the `setsockopt()` functions `IP_ADD_MEMBERSHIP` and `IP_DROP_MEMBERSHIP`.
These functions appears to be supported by Cosmopolitan (the constants are defined), although I have not tested it yet.
The `struct ip_mreq` definition was simply missing.