### PR TITLE
Added OpenBrowser function, opens browser in Windows, GNU and XNU

### DIFF
--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -319,7 +319,6 @@ static bool terminated;
 static bool uniprocess;
 static bool invalidated;
 static bool logmessages;
-static bool launchbrowser;
 static bool checkedmethod;
 static bool connectionclose;
 static bool keyboardinterrupt;
@@ -619,8 +618,7 @@ static void GetOpts(int argc, char *argv[]) {
         logmessages = true;
         break;
       case 'b':
-        launchbrowser = true;
-        // logbodies = true;
+        logbodies = true;
         break;
       case 'z':
         printport = true;
@@ -1473,8 +1471,10 @@ static void LaunchBrowser() {
   } else {
     prog = "xdg-open";
   }
-  snprintf(openbrowsercommand, sizeof(openbrowsercommand),
-           "%s http://127.0.0.1:%d", prog, ntohs(serveraddr.sin_port));
+  struct in_addr addr = serveraddr.sin_addr;
+  if (addr.s_addr == INADDR_ANY) addr.s_addr = htonl(INADDR_LOOPBACK);
+  snprintf(openbrowsercommand, sizeof(openbrowsercommand), "%s http://%s:%d",
+           prog, inet_ntoa(addr), ntohs(serveraddr.sin_port));
   DEBUGF("Opening browser with command %s\n", openbrowsercommand);
   system(openbrowsercommand);
 }
@@ -2655,7 +2655,6 @@ void RedBean(int argc, char *argv[]) {
   inbuf.p = xvalloc(inbuf.n);
   hdrbuf.n = 4 * 1024;
   hdrbuf.p = xvalloc(hdrbuf.n);
-  if (launchbrowser) LaunchBrowser();
   while (!terminated) {
     if (zombied) {
       ReapZombies();

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -2579,6 +2579,19 @@ static void TuneServerSocket(void) {
   LOGIFNEG1(setsockopt(server, IPPROTO_TCP, TCP_QUICKACK, &yes, sizeof(yes)));
 }
 
+static void OpenBrowser(const char *serveraddrname) {
+  char openbrowsercommand[255];
+  if (IsWindows()){
+    snprintf(openbrowsercommand, sizeof(openbrowsercommand), "explorer http://%s", serveraddrname);
+  } else if (IsXnu()) {
+    snprintf(openbrowsercommand, sizeof(openbrowsercommand), "open http://%s", serveraddrname);
+  } else {
+    snprintf(openbrowsercommand, sizeof(openbrowsercommand), "xdg-open http://%s", serveraddrname);
+  }
+  DEBUGF("Opening browser with command %s\n", openbrowsercommand);
+  system(openbrowsercommand);
+}
+
 void RedBean(int argc, char *argv[]) {
   uint32_t addrsize;
   gmtoff = GetGmtOffset();
@@ -2631,6 +2644,8 @@ void RedBean(int argc, char *argv[]) {
   inbuf.p = xvalloc(inbuf.n);
   hdrbuf.n = 4 * 1024;
   hdrbuf.p = xvalloc(hdrbuf.n);
+  // TODO: Maybe make this an optional argv?
+  OpenBrowser(serveraddrstr);
   while (!terminated) {
     if (zombied) {
       ReapZombies();

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -2581,13 +2581,16 @@ static void TuneServerSocket(void) {
 
 static void OpenBrowser(const char *serveraddrname) {
   char openbrowsercommand[255];
-  if (IsWindows()){
-    snprintf(openbrowsercommand, sizeof(openbrowsercommand), "explorer http://%s", serveraddrname);
+  char *prog;
+  if (IsWindows()) {
+    prog = "explorer";
   } else if (IsXnu()) {
-    snprintf(openbrowsercommand, sizeof(openbrowsercommand), "open http://%s", serveraddrname);
+    prog = "open";
   } else {
-    snprintf(openbrowsercommand, sizeof(openbrowsercommand), "xdg-open http://%s", serveraddrname);
+    prog = "xdg-open";
   }
+  snprintf(openbrowsercommand, sizeof(openbrowsercommand), "%s http://%s", prog,
+           serveraddrname);
   DEBUGF("Opening browser with command %s\n", openbrowsercommand);
   system(openbrowsercommand);
 }


### PR DESCRIPTION
Added a simple OpenBrowser function that runs just before RedBean begins processing requests. 
Fixes #98 
Maybe this should be added to be optionally turned off, it would be quite annoying if you're just hosting a socket and don't need GUI. I think it should probably default to on though, because then a double click on the executable would open your browser, rather than clunkily opening CMD and passing the argument.
I'm not much of a C programmer (at all!) so feedback is always appreciated!
Thanks