### PR TITLE
Added Parameter to LaunchBrowser to set path

### DIFF
--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -2003,7 +2003,7 @@ static char *GetBasicAuthorization(size_t *z) {
   }
 }
 
-static void LaunchBrowser() {
+static void LaunchBrowser(const char *path) {
   char openbrowsercommand[255];
   char *prog;
   if (IsWindows()) {
@@ -2015,8 +2015,12 @@ static void LaunchBrowser() {
   }
   struct in_addr addr = serveraddr.sin_addr;
   if (addr.s_addr == INADDR_ANY) addr.s_addr = htonl(INADDR_LOOPBACK);
-  snprintf(openbrowsercommand, sizeof(openbrowsercommand), "%s http://%s:%d",
-           prog, inet_ntoa(addr), ntohs(serveraddr.sin_port));
+  const char *pathname = path;
+  if (path == NULL) {
+    pathname = "/";
+  }
+  snprintf(openbrowsercommand, sizeof(openbrowsercommand), "%s http://%s:%d%s",
+           prog, inet_ntoa(addr), ntohs(serveraddr.sin_port), pathname);
   DEBUGF("Opening browser with command %s\n", openbrowsercommand);
   system(openbrowsercommand);
 }
@@ -3551,7 +3555,8 @@ static void LuaSetIntField(lua_State *L, const char *k, lua_Integer v) {
 }
 
 static int LuaLaunchBrowser(lua_State *L) {
-  LaunchBrowser();
+  const char *p = luaL_checkstring(L, 1);
+  LaunchBrowser(p);
   return 1;
 }
 

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -3555,7 +3555,7 @@ static void LuaSetIntField(lua_State *L, const char *k, lua_Integer v) {
 }
 
 static int LuaLaunchBrowser(lua_State *L) {
-  const char *p = luaL_checkstring(L, 1);
+  const char *p = luaL_optstring(L, 1, "/");
   LaunchBrowser(p);
   return 1;
 }


### PR DESCRIPTION
Hi!
This PR just adds a parameter to LaunchBrowser that sets the path to open.
I was distributing a small webapp to a few colleagues and it was a little bit jarring for them to be presented with the listing page and have to click "index.html".
Hope it's up to snuff, I didn't know if there was a way to allow LaunchBrowser() and LauncBrowser(pathname:string) to be called