### PR TITLE
Added strxfrm

### DIFF
--- a/libc/str/str.h
+++ b/libc/str/str.h
@@ -156,6 +156,7 @@ char16_t *strcat16(char16_t *, const char16_t *) memcpyesque;
 wchar_t *wcscat(wchar_t *, const wchar_t *) memcpyesque;
 size_t strlcpy(char *, const char *, size_t);
 size_t strlcat(char *, const char *, size_t);
+size_t strxfrm(char *, const char *, size_t);
 char *strcpy(char *, const char *) memcpyesque;
 char16_t *strcpy16(char16_t *, const char16_t *) memcpyesque;
 wchar_t *wcscpy(wchar_t *, const wchar_t *) memcpyesque;

--- a/libc/str/strxfrm.c
+++ b/libc/str/strxfrm.c
@@ -1,0 +1,48 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│vi: set net ft=c ts=2 sts=2 sw=2 fenc=utf-8                                :vi│
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ This is free and unencumbered software released into the public domain.      │
+│                                                                              │
+│ Anyone is free to copy, modify, publish, use, compile, sell, or              │
+│ distribute this software, either in source code form or as a compiled        │
+│ binary, for any purpose, commercial or non-commercial, and by any            │
+│ means.                                                                       │
+│                                                                              │
+│ In jurisdictions that recognize copyright laws, the author or authors        │
+│ of this software dedicate any and all copyright interest in the              │
+│ software to the public domain. We make this dedication for the benefit       │
+│ of the public at large and to the detriment of our heirs and                 │
+│ successors. We intend this dedication to be an overt act of                  │
+│ relinquishment in perpetuity of all present and future rights to this        │
+│ software under copyright law.                                                │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,              │
+│ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF           │
+│ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.       │
+│ IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR            │
+│ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,        │
+│ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR        │
+│ OTHER DEALINGS IN THE SOFTWARE.                                              │
+│                                                                              │
+╚─────────────────────────────────────────────────────────────────────────────*/
+
+#include "libc/assert.h"
+#include "libc/str/str.h"
+
+/**
+ * transforms strings into the current C locale.
+ * calling strcmp() on two strxfrm()-ed strings
+ * is same as calling strcoll() on the originals.
+ *
+ * @param dest is buffer which needn't be initialized
+ * @param src is a NUL-terminated string
+ * @param count is number of bytes to write to destination
+ * @return length of transformed string
+ * @note dest and src can't overlap
+ * @note dest array size should be greater than count
+ * @note if dest is NULL, count has to be zero
+ */
+size_t strxfrm(char *dest, const char *src, size_t count) {
+  assert(dest == NULL ? count == 0 : 1);
+  return strlcpy(dest, src, count);
+}


### PR DESCRIPTION
One of the missing functions in #141: `strxfrm` transforms a string src 
into a string dest such that calling `strcmp(dest1, dest2)` is same as 
calling `strcoll(src1, src2)`. `strxfrm` calls `strlcpy` internally because 
cosmopolitan libc does not support locales.

Reference: [CPPReference page for `strxfrm`](https://en.cppreference.com/w/c/string/byte/strxfrm)