### PR TITLE
Add ISO 646 header

### DIFF
--- a/libc/isystem/iso646.h
+++ b/libc/isystem/iso646.h
@@ -1,0 +1,16 @@
+#ifndef COSMOPOLITAN_LIBC_ISYSTEM_ISO646_H_
+#define COSMOPOLITAN_LIBC_ISYSTEM_ISO646_H_
+
+#define and &&
+#define and_eq &=
+#define bitand &
+#define bitor |
+#define compl ~
+#define not !
+#define not_eq !=
+#define or ||
+#define or_eq |=
+#define xor ^
+#define xor_eq ^=
+
+#endif


### PR DESCRIPTION
From [CPP Reference](https://en.cppreference.com/w/c/language/operator_alternative).

I read the contribution guide, and since this is a header-only patch, do I have to do anything else regarding copyright? I would be fine with just [unlicense](https://unlicense.org/)-ing this patch/future patches.