### PR TITLE
fixes to struct servent and test for LookupService

### DIFF
--- a/libc/dns/gethostbyaddr.c
+++ b/libc/dns/gethostbyaddr.c
@@ -31,9 +31,9 @@
 
 struct hostent *gethostbyaddr(const void *s_addr, socklen_t len, int type) {
   static struct hostent *ptr1, he1;
-  static char h_name[DNS_NAME_MAX+1];
-  static char* h_aliases[1];
-  static char* h_addr_list[2];
+  static char h_name[DNS_NAME_MAX + 1];
+  static char *h_aliases[1];
+  static char *h_addr_list[2];
   static char h_addr_list0[4];
 
   struct sockaddr_in addr;

--- a/libc/dns/getservbyname.c
+++ b/libc/dns/getservbyname.c
@@ -31,21 +31,19 @@
 
 struct servent *getservbyname(const char *name, const char *proto) {
   static struct servent *ptr0, se0;
+  static char s_name[DNS_NAME_MAX + 1];
   char *localproto = proto;
   int p;
 
   if (!ptr0) {
-    se0.s_name = NULL;
-    se0.s_aliases = (char **)malloc(sizeof(char *) * 1);
-    if (!se0.s_aliases) return NULL;
-    se0.s_aliases[0] = NULL;
-
+    se0.s_name = s_name;
+    if (!(se0.s_aliases = calloc(1, sizeof(char *)))) return NULL;
     se0.s_port = 0;
     se0.s_proto = NULL;
     ptr0 = &se0;
   }
 
-  p = LookupServicesByName(name, &localproto);
+  p = LookupServicesByName(name, &localproto, ptr0->s_name, DNS_NAME_MAX, NULL);
   if (p == -1) {
     // localproto got alloc'd during the lookup?
     if (!proto && localproto != proto) free(localproto);
@@ -53,9 +51,6 @@ struct servent *getservbyname(const char *name, const char *proto) {
   }
 
   ptr0->s_port = p;
-  if (ptr0->s_name) free(ptr0->s_name);
-  ptr0->s_name = strdup(name);
-
   if (ptr0->s_proto) free(ptr0->s_proto);
   ptr0->s_proto = strdup(localproto);
 

--- a/libc/dns/getservbyport.c
+++ b/libc/dns/getservbyport.c
@@ -30,30 +30,25 @@
 
 struct servent *getservbyport(int port, const char *proto) {
   static struct servent *ptr1, se1;
-  char name[DNS_NAME_MAX];
+  static char s_name[DNS_NAME_MAX + 1];
   char *localproto = proto;
 
   if (!ptr1) {
-    se1.s_name = NULL;
-    se1.s_aliases = (char **)malloc(sizeof(char *) * 1);
-    if (!se1.s_aliases) return NULL;
-    se1.s_aliases[0] = NULL;
-
+    se1.s_name = s_name;
+    if (!(se1.s_aliases = calloc(1, sizeof(char *)))) return NULL;
     se1.s_port = 0;
     se1.s_proto = NULL;
     ptr1 = &se1;
   }
 
-  if (LookupServicesByPort(port, &localproto, name, sizeof(name)) == -1) {
+  if (LookupServicesByPort(port, &localproto, ptr1->s_name, DNS_NAME_MAX,
+                           NULL) == -1) {
     // localproto got alloc'd during the lookup?
     if (!proto && localproto != proto) free(localproto);
     return NULL;
   }
 
   ptr1->s_port = port;
-  if (ptr1->s_name) free(ptr1->s_name);
-  ptr1->s_name = strdup(name);
-
   if (ptr1->s_proto) free(ptr1->s_proto);
   ptr1->s_proto = strdup(localproto);
 

--- a/libc/dns/servicestxt.c
+++ b/libc/dns/servicestxt.c
@@ -65,51 +65,54 @@ static textwindows noinline char *GetNtServicesTxtPath(char *pathbuf,
  *
  * @param servport is the port number (in network byte order)
  * @param servproto is a pointer to a string (*servproto can be NULL)
- * @param buf is a buffer to store the resulting name
+ * @param buf is a buffer to store the official name of the service
  * @param bufsize is the size of buf
+ * @param filepath is the location of the services file
+ *          (if NULL, uses /etc/services)
  * @returns 0 on success, -1 on error
  *
  * @note aliases are not read from the file.
  */
 int LookupServicesByPort(const int servport, char **servproto, char *buf,
-                         size_t bufsize) {
+                         size_t bufsize, const char *filepath) {
   FILE *f;
   char *line;
   char pathbuf[PATH_MAX];
   const char *path;
   size_t linesize;
-  int count, found;
+  int found;
   char *name, *port, *proto, *comment, *tok;
 
-  path = "/etc/services";
-  if (IsWindows()) {
-    path = firstnonnull(GetNtServicesTxtPath(pathbuf, ARRAYLEN(pathbuf)), path);
+  if (!(path = filepath)) {
+    path = "/etc/services";
+    if (IsWindows()) {
+      path =
+          firstnonnull(GetNtServicesTxtPath(pathbuf, ARRAYLEN(pathbuf)), path);
+    }
   }
+
   if (bufsize == 0 || !(f = fopen(path, "r"))) {
     return -1;
   }
   line = NULL;
   linesize = 0;
-  count = 0;
   found = 0;
 
   while (found == 0 && (getline(&line, &linesize, f)) != -1) {
     if ((comment = strchr(line, '#'))) *comment = '\0';
     name = strtok_r(line, " \t\r\n\v", &tok);
     port = strtok_r(NULL, "/ \t\r\n\v", &tok);
-    if (name && port && servport == htons(atoi(port))) {
-      if (!(proto = strtok_r(NULL, " \t\r\n\v", &tok)))
-        continue;
-      else if (!servproto[0]) {
+    proto = strtok_r(NULL, " \t\r\n\v", &tok);
+    if (name && port && proto && servport == htons(atoi(port))) {
+      if (!servproto[0]) {
         servproto[0] = strdup(proto);
         strncpy(buf, name, bufsize);
         found = 1;
-      } else if (strcmp(proto, servproto[0]) == 0) {
+      } else if (strcasecmp(proto, servproto[0]) == 0) {
         strncpy(buf, name, bufsize);
         found = 1;
       }
     }
-    count++;
   }
   free(line);
 
@@ -129,32 +132,39 @@ int LookupServicesByPort(const int servport, char **servproto, char *buf,
  *
  * @param servname is a NULL-terminated string
  * @param servproto is a pointer to a string (*servproto can be NULL)
+ * @param buf is a buffer to store the official name of the service
+ * @param bufsize is the size of buf
+ * @param filepath is the location of services file
+ *          (if NULL, uses /etc/services)
  * @returns -1 on error, or
  *          positive port number (in network byte order)
  *
- * @note aliases are not read from the file.
+ * @note aliases are read from file for comparison, but not returned.
  * @see LookupServicesByPort
  */
-int LookupServicesByName(const char *servname, char **servproto) {
+int LookupServicesByName(const char *servname, char **servproto, char *buf,
+                         size_t bufsize, const char *filepath) {
   FILE *f;
   char *line;
   char pathbuf[PATH_MAX];
   const char *path;
   size_t linesize;
-  int count, found, result;
-  char *name, *port, *proto, *comment, *tok;
+  int found, result;
+  char *name, *port, *proto, *alias, *comment, *tok;
 
-  path = "/etc/services";
-
-  if (IsWindows()) {
-    path = firstnonnull(GetNtServicesTxtPath(pathbuf, ARRAYLEN(pathbuf)), path);
+  if (!(path = filepath)) {
+    path = "/etc/services";
+    if (IsWindows()) {
+      path =
+          firstnonnull(GetNtServicesTxtPath(pathbuf, ARRAYLEN(pathbuf)), path);
+    }
   }
-  if (!(f = fopen(path, "r"))) {
+
+  if (bufsize == 0 || !(f = fopen(path, "r"))) {
     return -1;
   }
   line = NULL;
   linesize = 0;
-  count = 0;
   found = 0;
   result = -1;
 
@@ -162,19 +172,26 @@ int LookupServicesByName(const char *servname, char **servproto) {
     if ((comment = strchr(line, '#'))) *comment = '\0';
     name = strtok_r(line, " \t\r\n\v", &tok);
     port = strtok_r(NULL, "/ \t\r\n\v", &tok);
-    if (name && port && strcmp(name, servname) == 0) {
-      if (!(proto = strtok_r(NULL, " \t\r\n\v", &tok)))
-        continue;
-      else if (!servproto[0]) {
-        servproto[0] = strdup(proto);
-        result = htons(atoi(port));
-        found = 1;
-      } else if (strcmp(proto, servproto[0]) == 0) {
-        result = htons(atoi(port));
-        found = 1;
+    proto = strtok_r(NULL, " \t\r\n\v", &tok);
+    if (name && port && proto) {
+      alias = name;
+      while (alias && strcasecmp(alias, servname) != 0)
+        alias = strtok_r(NULL, " \t\r\n\v", &tok);
+
+      if (alias) /* alias matched with servname */
+      {
+        if (!servproto[0]) {
+          servproto[0] = strdup(proto);
+          result = htons(atoi(port));
+          strncpy(buf, name, bufsize);
+          found = 1;
+        } else if (strcasecmp(proto, servproto[0]) == 0) {
+          result = htons(atoi(port));
+          strncpy(buf, name, bufsize);
+          found = 1;
+        }
       }
     }
-    count++;
   }
   free(line);
 

--- a/libc/dns/servicestxt.h
+++ b/libc/dns/servicestxt.h
@@ -6,9 +6,10 @@
 #if !(__ASSEMBLER__ + __LINKER__ + 0)
 COSMOPOLITAN_C_START_
 
-int LookupServicesByPort(const int, char **, char *, size_t)
+int LookupServicesByPort(const int, char **, char *, size_t, const char *)
     paramsnonnull((2, 3));
-int LookupServicesByName(const char *, char **) paramsnonnull((1, 2));
+int LookupServicesByName(const char *, char **, char *, size_t, const char *)
+    paramsnonnull((1, 2, 3));
 
 /* TODO: implement like struct HostsTxt? */
 

--- a/test/libc/dns/servicestxt_test.c
+++ b/test/libc/dns/servicestxt_test.c
@@ -1,0 +1,135 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│vi: set net ft=c ts=2 sts=2 sw=2 fenc=utf-8                                :vi│
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ This is free and unencumbered software released into the public domain.      │
+│                                                                              │
+│ Anyone is free to copy, modify, publish, use, compile, sell, or              │
+│ distribute this software, either in source code form or as a compiled        │
+│ binary, for any purpose, commercial or non-commercial, and by any            │
+│ means.                                                                       │
+│                                                                              │
+│ In jurisdictions that recognize copyright laws, the author or authors        │
+│ of this software dedicate any and all copyright interest in the              │
+│ software to the public domain. We make this dedication for the benefit       │
+│ of the public at large and to the detriment of our heirs and                 │
+│ successors. We intend this dedication to be an overt act of                  │
+│ relinquishment in perpetuity of all present and future rights to this        │
+│ software under copyright law.                                                │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,              │
+│ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF           │
+│ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.       │
+│ IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR            │
+│ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,        │
+│ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR        │
+│ OTHER DEALINGS IN THE SOFTWARE.                                              │
+│                                                                              │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "libc/dns/servicestxt.h"
+
+#include "libc/dns/dns.h"
+#include "libc/dns/ent.h"
+#include "libc/calls/calls.h"
+#include "libc/testlib/testlib.h"
+
+char testlib_enable_tmp_setup_teardown;
+
+void SetUp() {
+  int fd;
+  const char* sample = "\
+# skip comment string\n\
+chargen		19/tcp		ttytst source\n\
+chargen		19/udp		ttytst source\n\
+ssh		    22/tcp		# SSH Remote Login Protocol";
+
+  ASSERT_NE(-1, (fd = creat("services", 0755)));
+  ASSERT_NE(-1, write(fd, sample, strlen(sample)));
+  ASSERT_NE(-1, close(fd));
+}
+
+TEST(LookupServicesByPort, GetNameWhenPortCorrect) {
+  char name[16]; /* sample has only names of length 3 */
+  char proto1[] = "tcp";
+  char proto2[] = "udp";
+  char* localproto[1];
+
+  localproto[0] = NULL;
+  ASSERT_EQ(
+      -1, /* non existent port */
+      LookupServicesByPort(965, localproto, name, sizeof(name), "services"));
+  ASSERT_EQ(NULL, localproto[0]);
+
+  ASSERT_EQ(
+      -1, /* port not in network byte order */
+      LookupServicesByPort(22, localproto, name, sizeof(name), "services"));
+  ASSERT_EQ(NULL, localproto[0]);
+
+  localproto[0] = proto2;
+  ASSERT_EQ(-1, /* port ok but wrong protocol */
+            LookupServicesByPort(htons(22), localproto, name, sizeof(name),
+                                 "services"));
+  ASSERT_EQ(localproto[0], proto2);
+
+  localproto[0] = proto1;
+  ASSERT_EQ(0, LookupServicesByPort(htons(22), localproto, name, sizeof(name),
+                                    "services"));
+  ASSERT_STREQ(name, "ssh");
+  ASSERT_EQ(localproto[0], proto1);
+
+  localproto[0] = proto2;
+  ASSERT_EQ(0, LookupServicesByPort(htons(19), localproto, name,
+                                    sizeof(name), "services"));
+  ASSERT_STREQ(name, "chargen");
+  ASSERT_EQ(localproto[0], proto2);
+
+  localproto[0] = NULL;
+  ASSERT_EQ(0, /* pick first matching protocol */
+            LookupServicesByPort(htons(19), localproto, name, sizeof(name),
+                                 "services"));
+  ASSERT_STREQ(name, "chargen");
+  ASSERT_NE(NULL, localproto[0]); /* got alloc'd during the call */
+  ASSERT_STREQ(localproto[0], "tcp");
+  free(localproto[0]);
+}
+
+TEST(LookupServicesByName, GetPortWhenNameOrAlias) {
+  char name[16]; /* sample has only names of length 3 */
+  char proto1[] = "tcp";
+  char proto2[] = "udp";
+  char* localproto[1];
+
+  localproto[0] = NULL;
+  ASSERT_EQ(
+      -1, /* non-existent name */
+      LookupServicesByName("http", localproto, name, sizeof(name), "services"));
+  ASSERT_EQ(NULL, localproto[0]);
+
+  localproto[0] = proto2;
+  ASSERT_EQ(
+      -1, /* name exists but wrong protocol */
+      LookupServicesByName("ssh", localproto, name, sizeof(name), "services"));
+  ASSERT_EQ(localproto[0], proto2);
+
+  localproto[0] = proto1;
+  ASSERT_EQ(
+      htons(22), /* in network byte order */
+      LookupServicesByName("ssh", localproto, name, sizeof(name), "services"));
+  ASSERT_STREQ(name, "ssh"); /* official name written to buffer */
+  ASSERT_EQ(localproto[0], proto1);
+
+  localproto[0] = proto2;
+  ASSERT_EQ(htons(19), /* works if alias provided */
+            LookupServicesByName("ttytst", localproto, name, sizeof(name),
+                                 "services"));
+  ASSERT_STREQ(name, "chargen"); /* official name written to buffer */
+  ASSERT_EQ(localproto[0], proto2);
+
+  localproto[0] = NULL;
+  ASSERT_EQ(htons(19), /* pick first matching protocol */
+            LookupServicesByName("source", localproto, name, sizeof(name),
+                                 "services"));
+  ASSERT_STREQ(name, "chargen");
+  ASSERT_NE(NULL, localproto[0]); /* got alloc'd during the call */
+  ASSERT_STREQ(localproto[0], "tcp");
+  free(localproto[0]);
+}

--- a/test/libc/dns/test.mk
+++ b/test/libc/dns/test.mk
@@ -23,6 +23,7 @@ TEST_LIBC_DNS_CHECKS =					\
 	$(TEST_LIBC_DNS_SRCS_TEST:%.c=o/$(MODE)/%.com.runs)
 
 TEST_LIBC_DNS_DIRECTDEPS =				\
+	LIBC_CALLS					\
 	LIBC_DNS					\
 	LIBC_FMT					\
 	LIBC_INTRIN					\


### PR DESCRIPTION
This PR adds necessary changes from the comments in #204, and adds tests for the `LookupService` pair of functions.
The tests run without any error.