### PR TITLE
Add protoent and netent

### DIFF
--- a/libc/dns/ent.h
+++ b/libc/dns/ent.h
@@ -7,6 +7,19 @@ COSMOPOLITAN_C_START_
 
 extern int h_errno;
 
+struct netent {
+  char *n_name;     /* official network name */
+  char **n_aliases; /* alias list */
+  int n_addrtype;   /* net address type */
+  uint32_t n_net;   /* network number */
+};
+
+struct protoent {
+  char *p_name;     /* official protocol name */
+  char **p_aliases; /* alias list */
+  int p_proto;      /* protocol number */
+};
+
 struct hostent {
   char *h_name;       /* official name of host */
   char **h_aliases;   /* alias list */
@@ -22,6 +35,18 @@ struct servent {
   int s_port;       /* port number (in network byte order) */
   char *s_proto;    /* protocol to use */
 };
+
+struct netent *getnetent(void);
+struct netent *getnetbyname(const char *);
+struct netent *getnetbyaddr(uint32_t, int);
+void setnetent(int);
+void endnetent(void);
+
+struct protoent *getprotoent(void);
+struct protoent *getprotobyname(const char *);
+struct protoent *getprotobynumber(int);
+void setprotoent(int);
+void endprotoent(void);
 
 struct hostent *gethostent(void);
 struct hostent *gethostbyname(const char *);

--- a/libc/dns/getaddrinfo.c
+++ b/libc/dns/getaddrinfo.c
@@ -59,6 +59,7 @@ int getaddrinfo(const char *name, const char *service,
         (hints && (hints->ai_flags & AI_PASSIVE) == AI_PASSIVE)
             ? INADDR_ANY
             : INADDR_LOOPBACK;
+    *res = ai;
     return 0;
   }
   if (inet_pton(AF_INET, name, &ai->ai_addr4->sin_addr.s_addr) == 1) {

--- a/libc/dns/getaddrinfo.c
+++ b/libc/dns/getaddrinfo.c
@@ -53,7 +53,7 @@ int getaddrinfo(const char *name, const char *service,
 
   if (!name && !service) return EAI_NONAME;
   if (!name && (hints->ai_flags & AI_CANONNAME)) return EAI_BADFLAGS;
-  if (service) {
+  if (service && (port = parseport(service)) == -1) {
     if (hints->ai_socktype == SOCK_STREAM)
       strcpy(proto, "tcp");
     else if (hints->ai_socktype == SOCK_DGRAM)
@@ -62,9 +62,8 @@ int getaddrinfo(const char *name, const char *service,
       strcpy(proto, "");
 
     if ((port = LookupServicesByName(service, proto, sizeof(proto), NULL, 0,
-                                     NULL)) == -1) {
-      if ((port = parseport(service)) == -1) return EAI_NONAME;
-    }
+                                     NULL)) == -1)
+      return EAI_NONAME;
   }
   if (!(ai = newaddrinfo(port))) return EAI_MEMORY;
   if (service) ai->ai_addr4->sin_port = htons(port);

--- a/libc/dns/getaddrinfo.c
+++ b/libc/dns/getaddrinfo.c
@@ -55,11 +55,11 @@ int getaddrinfo(const char *name, const char *service,
   if (!name && (hints->ai_flags & AI_CANONNAME)) return EAI_BADFLAGS;
   if (service) {
     if (hints->ai_socktype == SOCK_STREAM)
-      strncpy(proto, "tcp", sizeof(proto));
+      strcpy(proto, "tcp");
     else if (hints->ai_socktype == SOCK_DGRAM)
-      strncpy(proto, "udp", sizeof(proto));
+      strcpy(proto, "udp");
     else /* ai_socktype == 0 */
-      proto[0] = '\0';
+      strcpy(proto, "");
 
     if ((port = LookupServicesByName(service, proto, sizeof(proto), NULL, 0,
                                      NULL)) == -1) {

--- a/libc/dns/getprotobyname.c
+++ b/libc/dns/getprotobyname.c
@@ -26,13 +26,22 @@
 │                                                                              │
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #include "libc/dns/ent.h"
+#include "libc/dns/prototxt.h"
 
-struct protoent *getprotoent(void) {
-  return NULL;
+struct protoent *getprotobyname(const char *name) {
+  static struct protoent *ptr0, pe0;
+  static char p_name[DNS_NAME_MAX + 1];
+  
+  if (!ptr0) {
+    pe0.p_name = p_name;
+    if (!(pe0.p_aliases = calloc(1, sizeof(char *)))) return NULL;
+    pe0.p_proto = -1;
+    ptr0 = &pe0;
+  }
+
+  ptr0->p_proto = LookupProtoByName(name, ptr0->p_name, DNS_NAME_MAX, NULL);
+  if (ptr0->p_proto == -1) return NULL;
+
+  return ptr0;
 }
 
-void setprotoent(int stayopen) {
-}
-
-void endprotoent(void) {
-}

--- a/libc/dns/getprotobyname.c
+++ b/libc/dns/getprotobyname.c
@@ -31,7 +31,7 @@
 struct protoent *getprotobyname(const char *name) {
   static struct protoent *ptr0, pe0;
   static char p_name[DNS_NAME_MAX + 1];
-  
+
   if (!ptr0) {
     pe0.p_name = p_name;
     if (!(pe0.p_aliases = calloc(1, sizeof(char *)))) return NULL;
@@ -44,4 +44,3 @@ struct protoent *getprotobyname(const char *name) {
 
   return ptr0;
 }
-

--- a/libc/dns/getprotobynumber.c
+++ b/libc/dns/getprotobynumber.c
@@ -26,13 +26,22 @@
 │                                                                              │
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #include "libc/dns/ent.h"
+#include "libc/dns/prototxt.h"
 
-struct protoent *getprotoent(void) {
-  return NULL;
-}
+struct protoent *getprotobynumber(int proto) {
+  static struct protoent *ptr1, pe1;
+  static char p_name[DNS_NAME_MAX + 1];
 
-void setprotoent(int stayopen) {
-}
+  if (!ptr1) {
+    pe1.p_name = p_name;
+    if (!(pe1.p_aliases = calloc(1, sizeof(char *)))) return NULL;
+    pe1.p_proto = -1;
+    ptr1 = &pe1;
+  }
 
-void endprotoent(void) {
+  if (LookupProtoByNumber(proto, ptr1->p_name, DNS_NAME_MAX, NULL) == -1)
+    return NULL;
+
+  ptr1->p_proto = proto;
+  return ptr1;
 }

--- a/libc/dns/getservbyname.c
+++ b/libc/dns/getservbyname.c
@@ -50,7 +50,7 @@ struct servent *getservbyname(const char *name, const char *proto) {
     return NULL;
   }
 
-  ptr0->s_port = p;
+  ptr0->s_port = htons(p);
   if (ptr0->s_proto) free(ptr0->s_proto);
   ptr0->s_proto = strdup(localproto);
 

--- a/libc/dns/getservbyname.c
+++ b/libc/dns/getservbyname.c
@@ -44,8 +44,10 @@ struct servent *getservbyname(const char *name, const char *proto) {
     ptr0 = &se0;
   }
 
-  localproto[0] = '\0';
-  if (proto) strncpy(localproto, proto, DNS_NAME_MAX);
+  if (proto) {
+    if (!memccpy(localproto, proto, '\0', DNS_NAME_MAX)) return NULL;
+  } else
+    strcpy(localproto, "");
 
   p = LookupServicesByName(name, ptr0->s_proto, DNS_NAME_MAX, ptr0->s_name,
                            DNS_NAME_MAX, NULL);

--- a/libc/dns/getservbyport.c
+++ b/libc/dns/getservbyport.c
@@ -41,7 +41,7 @@ struct servent *getservbyport(int port, const char *proto) {
     ptr1 = &se1;
   }
 
-  if (LookupServicesByPort(port, &localproto, ptr1->s_name, DNS_NAME_MAX,
+  if (LookupServicesByPort(ntohs(port), &localproto, ptr1->s_name, DNS_NAME_MAX,
                            NULL) == -1) {
     // localproto got alloc'd during the lookup?
     if (!proto && localproto != proto) free(localproto);

--- a/libc/dns/getservbyport.c
+++ b/libc/dns/getservbyport.c
@@ -27,32 +27,29 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #include "libc/dns/ent.h"
 #include "libc/dns/servicestxt.h"
+#include "libc/mem/mem.h"
+#include "libc/str/str.h"
 
 struct servent *getservbyport(int port, const char *proto) {
   static struct servent *ptr1, se1;
   static char s_name[DNS_NAME_MAX + 1];
-  char *localproto = proto;
+  static char localproto[DNS_NAME_MAX + 1];
 
   if (!ptr1) {
     se1.s_name = s_name;
     if (!(se1.s_aliases = calloc(1, sizeof(char *)))) return NULL;
     se1.s_port = 0;
-    se1.s_proto = NULL;
+    se1.s_proto = localproto;
     ptr1 = &se1;
   }
 
-  if (LookupServicesByPort(ntohs(port), &localproto, ptr1->s_name, DNS_NAME_MAX,
-                           NULL) == -1) {
-    // localproto got alloc'd during the lookup?
-    if (!proto && localproto != proto) free(localproto);
+  localproto[0] = '\0';
+  if (proto) strncpy(localproto, proto, DNS_NAME_MAX);
+
+  if (LookupServicesByPort(ntohs(port), ptr1->s_proto, DNS_NAME_MAX,
+                           ptr1->s_name, DNS_NAME_MAX, NULL) == -1)
     return NULL;
-  }
 
   ptr1->s_port = port;
-  if (ptr1->s_proto) free(ptr1->s_proto);
-  ptr1->s_proto = strdup(localproto);
-
-  if (!proto && localproto != proto) free(localproto);
-
   return ptr1;
 }

--- a/libc/dns/getservbyport.c
+++ b/libc/dns/getservbyport.c
@@ -43,8 +43,10 @@ struct servent *getservbyport(int port, const char *proto) {
     ptr1 = &se1;
   }
 
-  localproto[0] = '\0';
-  if (proto) strncpy(localproto, proto, DNS_NAME_MAX);
+  if (proto) {
+    if (!memccpy(localproto, proto, '\0', DNS_NAME_MAX)) return NULL;
+  } else
+    strcpy(localproto, "");
 
   if (LookupServicesByPort(ntohs(port), ptr1->s_proto, DNS_NAME_MAX,
                            ptr1->s_name, DNS_NAME_MAX, NULL) == -1)

--- a/libc/dns/netent.c
+++ b/libc/dns/netent.c
@@ -1,0 +1,46 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│vi: set net ft=c ts=2 sts=2 sw=2 fenc=utf-8                                :vi│
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ This is free and unencumbered software released into the public domain.      │
+│                                                                              │
+│ Anyone is free to copy, modify, publish, use, compile, sell, or              │
+│ distribute this software, either in source code form or as a compiled        │
+│ binary, for any purpose, commercial or non-commercial, and by any            │
+│ means.                                                                       │
+│                                                                              │
+│ In jurisdictions that recognize copyright laws, the author or authors        │
+│ of this software dedicate any and all copyright interest in the              │
+│ software to the public domain. We make this dedication for the benefit       │
+│ of the public at large and to the detriment of our heirs and                 │
+│ successors. We intend this dedication to be an overt act of                  │
+│ relinquishment in perpetuity of all present and future rights to this        │
+│ software under copyright law.                                                │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,              │
+│ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF           │
+│ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.       │
+│ IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR            │
+│ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,        │
+│ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR        │
+│ OTHER DEALINGS IN THE SOFTWARE.                                              │
+│                                                                              │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "libc/dns/ent.h"
+
+struct netent *getnetent(void) {
+  return NULL;
+}
+
+struct netent *getnetbyname(const char *name) {
+  return NULL;
+}
+
+struct netent *getnetbyaddr(uint32_t net, int type) {
+  return NULL;
+}
+
+void setnetent(int stayopen) {
+}
+
+void endnetent(void) {
+}

--- a/libc/dns/protoent.c
+++ b/libc/dns/protoent.c
@@ -1,0 +1,46 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│vi: set net ft=c ts=2 sts=2 sw=2 fenc=utf-8                                :vi│
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ This is free and unencumbered software released into the public domain.      │
+│                                                                              │
+│ Anyone is free to copy, modify, publish, use, compile, sell, or              │
+│ distribute this software, either in source code form or as a compiled        │
+│ binary, for any purpose, commercial or non-commercial, and by any            │
+│ means.                                                                       │
+│                                                                              │
+│ In jurisdictions that recognize copyright laws, the author or authors        │
+│ of this software dedicate any and all copyright interest in the              │
+│ software to the public domain. We make this dedication for the benefit       │
+│ of the public at large and to the detriment of our heirs and                 │
+│ successors. We intend this dedication to be an overt act of                  │
+│ relinquishment in perpetuity of all present and future rights to this        │
+│ software under copyright law.                                                │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,              │
+│ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF           │
+│ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.       │
+│ IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR            │
+│ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,        │
+│ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR        │
+│ OTHER DEALINGS IN THE SOFTWARE.                                              │
+│                                                                              │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "libc/dns/ent.h"
+
+struct protoent *getprotoent(void) {
+  return NULL;
+}
+
+struct protoent *getprotobyname(const char *name) {
+  return NULL;
+}
+
+struct protoent *getprotobynumber(int proto) {
+  return NULL;
+}
+
+void setprotoent(int stayopen) {
+}
+
+void endprotoent(void) {
+}

--- a/libc/dns/prototxt.c
+++ b/libc/dns/prototxt.c
@@ -57,11 +57,10 @@ static textwindows noinline char *GetNtProtocolsTxtPath(char *pathbuf,
  *
  * format of /etc/protocols is like this:
  *
- *      # comment
- *      # NAME      PROTOCOL    ALIASES
- *
- *      ip	        0	        IP
- *      icmp	    1	        ICMP
+ * # comment
+ * # NAME           PROTOCOL        ALIASES
+ * ip               0               IP
+ * icmp             1               ICMP
  *
  * @param protonum is the protocol number
  * @param buf is a buffer to store the official name of the protocol
@@ -102,7 +101,10 @@ int LookupProtoByNumber(const int protonum, char *buf, size_t bufsize,
     name = strtok_r(line, " \t\r\n\v", &tok);
     number = strtok_r(NULL, " \t\r\n\v", &tok);
     if (name && number && protonum == atoi(number)) {
-      strncpy(buf, name, bufsize);
+      if (!memccpy(buf, name, '\0', bufsize)) {
+        strcpy(buf, "");
+        break;
+      }
       found = 1;
     }
   }
@@ -170,8 +172,11 @@ int LookupProtoByName(const char *protoname, char *buf, size_t bufsize,
 
       if (alias) /* alias matched with protoname */
       {
+        if (!memccpy(buf, name, '\0', bufsize)) {
+          strcpy(buf, "");
+          break;
+        }
         result = atoi(number);
-        strncpy(buf, name, bufsize);
         found = 1;
       }
     }

--- a/libc/dns/prototxt.c
+++ b/libc/dns/prototxt.c
@@ -67,7 +67,7 @@ static textwindows noinline char *GetNtProtocolsTxtPath(char *pathbuf,
  * @param bufsize is the size of buf
  * @param filepath is the location of the protocols file
  *          (if NULL, uses /etc/protocols)
- * @returns 0 on success, -1 on error
+ * @return 0 on success, -1 on error
  *
  * @note aliases are not read from the file.
  */
@@ -129,7 +129,7 @@ int LookupProtoByNumber(const int protonum, char *buf, size_t bufsize,
  * @param bufsize is the size of buf
  * @param filepath is the location of protocols file
  *          (if NULL, uses /etc/protocols)
- * @returns -1 on error, or
+ * @return -1 on error, or
  *          positive protocol number
  *
  * @note aliases are read from file for comparison, but not returned.

--- a/libc/dns/prototxt.c
+++ b/libc/dns/prototxt.c
@@ -1,0 +1,190 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│vi: set net ft=c ts=2 sts=2 sw=2 fenc=utf-8                                :vi│
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ This is free and unencumbered software released into the public domain.      │
+│                                                                              │
+│ Anyone is free to copy, modify, publish, use, compile, sell, or              │
+│ distribute this software, either in source code form or as a compiled        │
+│ binary, for any purpose, commercial or non-commercial, and by any            │
+│ means.                                                                       │
+│                                                                              │
+│ In jurisdictions that recognize copyright laws, the author or authors        │
+│ of this software dedicate any and all copyright interest in the              │
+│ software to the public domain. We make this dedication for the benefit       │
+│ of the public at large and to the detriment of our heirs and                 │
+│ successors. We intend this dedication to be an overt act of                  │
+│ relinquishment in perpetuity of all present and future rights to this        │
+│ software under copyright law.                                                │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,              │
+│ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF           │
+│ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.       │
+│ IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR            │
+│ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,        │
+│ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR        │
+│ OTHER DEALINGS IN THE SOFTWARE.                                              │
+│                                                                              │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "libc/dns/prototxt.h"
+
+#include "libc/bits/safemacros.internal.h"
+#include "libc/dce.h"
+#include "libc/errno.h"
+#include "libc/fmt/conv.h"
+#include "libc/fmt/fmt.h"
+#include "libc/macros.internal.h"
+#include "libc/mem/mem.h"
+#include "libc/nt/systeminfo.h"
+#include "libc/runtime/runtime.h"
+#include "libc/str/str.h"
+
+static textwindows noinline char *GetNtProtocolsTxtPath(char *pathbuf,
+                                                        uint32_t size) {
+  /* protocol, not plural */
+  const char *const kWinHostsPath = "\\drivers\\etc\\protocol";
+  uint32_t len = GetSystemDirectoryA(&pathbuf[0], size);
+  if (len && len + strlen(kWinHostsPath) + 1 < size) {
+    if (pathbuf[len] == '\\') pathbuf[len--] = '\0';
+    memcpy(&pathbuf[len], kWinHostsPath, strlen(kWinHostsPath) + 1);
+    return &pathbuf[0];
+  } else {
+    return NULL;
+  }
+}
+
+/**
+ * Opens and searches /etc/protocols to find name for a given number.
+ *
+ * format of /etc/protocols is like this:
+ *
+ *      # comment
+ *      # NAME      PROTOCOL    ALIASES
+ *
+ *      ip	        0	        IP
+ *      icmp	    1	        ICMP
+ *
+ * @param protonum is the protocol number
+ * @param buf is a buffer to store the official name of the protocol
+ * @param bufsize is the size of buf
+ * @param filepath is the location of the protocols file
+ *          (if NULL, uses /etc/protocols)
+ * @returns 0 on success, -1 on error
+ *
+ * @note aliases are not read from the file.
+ */
+int LookupProtoByNumber(const int protonum, char *buf, size_t bufsize,
+                        const char *filepath) {
+  FILE *f;
+  char *line;
+  char pathbuf[PATH_MAX];
+  const char *path;
+  size_t linesize;
+  int found;
+  char *name, *number, *comment, *tok;
+
+  if (!(path = filepath)) {
+    path = "/etc/protocols";
+    if (IsWindows()) {
+      path =
+          firstnonnull(GetNtProtocolsTxtPath(pathbuf, ARRAYLEN(pathbuf)), path);
+    }
+  }
+
+  if (bufsize == 0 || !(f = fopen(path, "r"))) {
+    return -1;
+  }
+  line = NULL;
+  linesize = 0;
+  found = 0;
+
+  while (found == 0 && (getline(&line, &linesize, f)) != -1) {
+    if ((comment = strchr(line, '#'))) *comment = '\0';
+    name = strtok_r(line, " \t\r\n\v", &tok);
+    number = strtok_r(NULL, " \t\r\n\v", &tok);
+    if (name && number && protonum == atoi(number)) {
+      strncpy(buf, name, bufsize);
+      found = 1;
+    }
+  }
+  free(line);
+
+  if (ferror(f)) {
+    errno = ferror(f);
+    return -1;
+  }
+  fclose(f);
+
+  if (!found) return -1;
+
+  return 0;
+}
+
+/**
+ * Opens and searches /etc/protocols to find number for a given name.
+ *
+ * @param protoname is a NULL-terminated string
+ * @param buf is a buffer to store the official name of the protocol
+ * @param bufsize is the size of buf
+ * @param filepath is the location of protocols file
+ *          (if NULL, uses /etc/protocols)
+ * @returns -1 on error, or
+ *          positive protocol number
+ *
+ * @note aliases are read from file for comparison, but not returned.
+ * @see LookupProtoByNumber
+ */
+int LookupProtoByName(const char *protoname, char *buf, size_t bufsize,
+                      const char *filepath) {
+  FILE *f;
+  char *line;
+  char pathbuf[PATH_MAX];
+  const char *path;
+  size_t linesize;
+  int found, result;
+  char *name, *number, *alias, *comment, *tok;
+
+  if (!(path = filepath)) {
+    path = "/etc/protocols";
+    if (IsWindows()) {
+      path =
+          firstnonnull(GetNtProtocolsTxtPath(pathbuf, ARRAYLEN(pathbuf)), path);
+    }
+  }
+
+  if (bufsize == 0 || !(f = fopen(path, "r"))) {
+    return -1;
+  }
+  line = NULL;
+  linesize = 0;
+  found = 0;
+  result = -1;
+
+  while (found == 0 && (getline(&line, &linesize, f)) != -1) {
+    if ((comment = strchr(line, '#'))) *comment = '\0';
+    name = strtok_r(line, " \t\r\n\v", &tok);
+    number = strtok_r(NULL, "/ \t\r\n\v", &tok);
+    if (name && number) {
+      alias = name;
+      while (alias && strcasecmp(alias, protoname) != 0)
+        alias = strtok_r(NULL, " \t\r\n\v", &tok);
+
+      if (alias) /* alias matched with protoname */
+      {
+        result = atoi(number);
+        strncpy(buf, name, bufsize);
+        found = 1;
+      }
+    }
+  }
+  free(line);
+
+  if (ferror(f)) {
+    errno = ferror(f);
+    return -1;
+  }
+  fclose(f);
+
+  if (!found) return -1;
+
+  return result;
+}

--- a/libc/dns/prototxt.h
+++ b/libc/dns/prototxt.h
@@ -1,0 +1,18 @@
+#ifndef COSMOPOLITAN_LIBC_DNS_PROTOTXT_H_
+#define COSMOPOLITAN_LIBC_DNS_PROTOTXT_H_
+#include "libc/sock/sock.h"
+#include "libc/stdio/stdio.h"
+
+#if !(__ASSEMBLER__ + __LINKER__ + 0)
+COSMOPOLITAN_C_START_
+
+int LookupProtoByNumber(const int, char *, size_t, const char *)
+    paramsnonnull((2));
+int LookupProtoByName(const char *, char *, size_t, const char *)
+    paramsnonnull((1, 2));
+
+/* TODO: implement like struct HostsTxt? */
+
+COSMOPOLITAN_C_END_
+#endif /* !(__ASSEMBLER__ + __LINKER__ + 0) */
+#endif /* COSMOPOLITAN_LIBC_DNS_PROTOTXT_H_ */

--- a/libc/dns/servicestxt.c
+++ b/libc/dns/servicestxt.c
@@ -63,7 +63,7 @@ static textwindows noinline char *GetNtServicesTxtPath(char *pathbuf,
  *      fsp		    21/udp		    fspd
  *      ssh		    22/tcp
  *
- * @param servport is the port number (in network byte order)
+ * @param servport is the port number
  * @param servproto is a pointer to a string (*servproto can be NULL)
  * @param buf is a buffer to store the official name of the service
  * @param bufsize is the size of buf
@@ -103,7 +103,7 @@ int LookupServicesByPort(const int servport, char **servproto, char *buf,
     name = strtok_r(line, " \t\r\n\v", &tok);
     port = strtok_r(NULL, "/ \t\r\n\v", &tok);
     proto = strtok_r(NULL, " \t\r\n\v", &tok);
-    if (name && port && proto && servport == htons(atoi(port))) {
+    if (name && port && proto && servport == atoi(port)) {
       if (!servproto[0]) {
         servproto[0] = strdup(proto);
         strncpy(buf, name, bufsize);
@@ -137,7 +137,7 @@ int LookupServicesByPort(const int servport, char **servproto, char *buf,
  * @param filepath is the location of services file
  *          (if NULL, uses /etc/services)
  * @returns -1 on error, or
- *          positive port number (in network byte order)
+ *          positive port number
  *
  * @note aliases are read from file for comparison, but not returned.
  * @see LookupServicesByPort
@@ -182,11 +182,11 @@ int LookupServicesByName(const char *servname, char **servproto, char *buf,
       {
         if (!servproto[0]) {
           servproto[0] = strdup(proto);
-          result = htons(atoi(port));
+          result = atoi(port);
           strncpy(buf, name, bufsize);
           found = 1;
         } else if (strcasecmp(proto, servproto[0]) == 0) {
-          result = htons(atoi(port));
+          result = atoi(port);
           strncpy(buf, name, bufsize);
           found = 1;
         }

--- a/libc/dns/servicestxt.c
+++ b/libc/dns/servicestxt.c
@@ -72,7 +72,7 @@ static textwindows noinline char *GetNtServicesTxtPath(char *pathbuf,
  * @param bufsize is the size of buf
  * @param filepath is the location of the services file
  *          (if NULL, uses /etc/services)
- * @returns 0 on success, -1 on error
+ * @return 0 on success, -1 on error
  *
  * @note aliases are not read from the file.
  */
@@ -149,7 +149,7 @@ int LookupServicesByPort(const int servport, char *servproto,
  * @param bufsize is the size of buf
  * @param filepath is the location of services file
  *          (if NULL, uses /etc/services)
- * @returns -1 on error, or
+ * @return -1 on error, or
  *          positive port number
  *
  * @note aliases are read from file for comparison, but not returned.

--- a/libc/dns/servicestxt.h
+++ b/libc/dns/servicestxt.h
@@ -6,10 +6,10 @@
 #if !(__ASSEMBLER__ + __LINKER__ + 0)
 COSMOPOLITAN_C_START_
 
-int LookupServicesByPort(const int, char **, char *, size_t, const char *)
-    paramsnonnull((2, 3));
-int LookupServicesByName(const char *, char **, char *, size_t, const char *)
-    paramsnonnull((1, 2, 3));
+int LookupServicesByPort(const int, char *, size_t, char *, size_t,
+                         const char *) paramsnonnull((2, 4));
+int LookupServicesByName(const char *, char *, size_t, char *, size_t,
+                         const char *) paramsnonnull((1, 2));
 
 /* TODO: implement like struct HostsTxt? */
 

--- a/libc/sock/parseport.c
+++ b/libc/sock/parseport.c
@@ -20,7 +20,17 @@
 #include "libc/sock/sock.h"
 #include "libc/sysv/errfuns.h"
 
-int parseport(const char *service) {
-  int port = atoi(service);
-  return (0 <= port && port <= 65535) ? port : einval();
+/* parses string to port number.
+ *
+ * @param service is a NULL-terminated string
+ * @return valid port number or einval()
+ *
+ * @see strtoimax
+ */
+int parseport(const char* service) {
+  char* end;
+  int port = strtoimax(service, &end, 0);
+  if (!service || end == service || *end != '\0' || port < 0 || port > 65535)
+    return einval();
+  return port;
 }

--- a/test/libc/dns/prototxt_test.c
+++ b/test/libc/dns/prototxt_test.c
@@ -1,0 +1,73 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│vi: set net ft=c ts=2 sts=2 sw=2 fenc=utf-8                                :vi│
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ This is free and unencumbered software released into the public domain.      │
+│                                                                              │
+│ Anyone is free to copy, modify, publish, use, compile, sell, or              │
+│ distribute this software, either in source code form or as a compiled        │
+│ binary, for any purpose, commercial or non-commercial, and by any            │
+│ means.                                                                       │
+│                                                                              │
+│ In jurisdictions that recognize copyright laws, the author or authors        │
+│ of this software dedicate any and all copyright interest in the              │
+│ software to the public domain. We make this dedication for the benefit       │
+│ of the public at large and to the detriment of our heirs and                 │
+│ successors. We intend this dedication to be an overt act of                  │
+│ relinquishment in perpetuity of all present and future rights to this        │
+│ software under copyright law.                                                │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,              │
+│ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF           │
+│ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.       │
+│ IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR            │
+│ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,        │
+│ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR        │
+│ OTHER DEALINGS IN THE SOFTWARE.                                              │
+│                                                                              │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "libc/dns/prototxt.h"
+
+#include "libc/calls/calls.h"
+#include "libc/dns/dns.h"
+#include "libc/dns/ent.h"
+#include "libc/testlib/testlib.h"
+
+char testlib_enable_tmp_setup_teardown;
+
+void SetUp() {
+  int fd;
+  const char* sample = "\
+# skip comment string\n\
+rspf	73	RSPF CPHB	\n\
+ggp	    3	GGP		    ";
+
+  ASSERT_NE(-1, (fd = creat("protocols", 0755)));
+  ASSERT_NE(-1, write(fd, sample, strlen(sample)));
+  ASSERT_NE(-1, close(fd));
+}
+
+TEST(LookupProtoByNumber, GetNameWhenNumberCorrect) {
+  char name[16]; /* sample has only names of length 3-4 */
+
+  ASSERT_EQ(-1, /*non-existent number */
+            LookupProtoByNumber(24, name, sizeof(name), "protocols"));
+
+  ASSERT_EQ(0, /* works with valid number */
+            LookupProtoByNumber(73, name, sizeof(name), "protocols"));
+  ASSERT_STREQ(name, "rspf"); /* official name written */
+}
+
+TEST(LookupProtoByName, GetNumberWhenNameOrAlias) {
+  char name[16]; /* sample has only names of length 3-4 */
+
+  ASSERT_EQ(-1, /* non-existent name or alias */
+            LookupProtoByName("tcp", name, sizeof(name), "protocols"));
+
+  ASSERT_EQ(3, /* works with valid name */
+            LookupProtoByName("ggp", name, sizeof(name), "protocols"));
+  ASSERT_STREQ(name, "ggp");
+
+  ASSERT_EQ(73, /* works with valid alias */
+            LookupProtoByName("CPHB", name, sizeof(name), "protocols"));
+  ASSERT_STREQ(name, "rspf"); /* official name written */
+}

--- a/test/libc/dns/prototxt_test.c
+++ b/test/libc/dns/prototxt_test.c
@@ -48,9 +48,14 @@ ggp	    3	GGP		    ";
 
 TEST(LookupProtoByNumber, GetNameWhenNumberCorrect) {
   char name[16]; /* sample has only names of length 3-4 */
+  strcpy(name, "");
 
   ASSERT_EQ(-1, /*non-existent number */
             LookupProtoByNumber(24, name, sizeof(name), "protocols"));
+
+  ASSERT_EQ(-1, /* sizeof(name) insufficient, memccpy failure */
+            LookupProtoByNumber(73, name, 1, "protocols"));
+  ASSERT_STREQ(name, ""); /* cleaned up after memccpy failed */
 
   ASSERT_EQ(0, /* works with valid number */
             LookupProtoByNumber(73, name, sizeof(name), "protocols"));
@@ -59,9 +64,14 @@ TEST(LookupProtoByNumber, GetNameWhenNumberCorrect) {
 
 TEST(LookupProtoByName, GetNumberWhenNameOrAlias) {
   char name[16]; /* sample has only names of length 3-4 */
+  strcpy(name, "");
 
   ASSERT_EQ(-1, /* non-existent name or alias */
             LookupProtoByName("tcp", name, sizeof(name), "protocols"));
+
+  ASSERT_EQ(-1, /* sizeof(name) insufficient, memccpy failure */
+            LookupProtoByName("ggp", name, 1, "protocols"));
+  ASSERT_STREQ(name, ""); /* cleaned up after memccpy failed */
 
   ASSERT_EQ(3, /* works with valid name */
             LookupProtoByName("ggp", name, sizeof(name), "protocols"));

--- a/test/libc/dns/servicestxt_test.c
+++ b/test/libc/dns/servicestxt_test.c
@@ -48,87 +48,107 @@ ssh		    22/tcp		# SSH Remote Login Protocol";
 }
 
 TEST(LookupServicesByPort, GetNameWhenPortCorrect) {
-  char name[16]; /* sample has only names of length 3 */
+  char name[8];        /* service names are of length 3 */
+  char eitherproto[8]; /* protocol names are of length 3 */
   char proto1[] = "tcp";
   char proto2[] = "udp";
-  char* localproto[1];
+  char* localproto;
 
-  localproto[0] = NULL;
-  ASSERT_EQ(
-      -1, /* non existent port */
-      LookupServicesByPort(965, localproto, name, sizeof(name), "services"));
-  ASSERT_EQ(NULL, localproto[0]);
+  eitherproto[0] = '\0';
 
+  localproto = eitherproto;
+  ASSERT_EQ(-1, /* non existent port */
+            LookupServicesByPort(965, localproto, sizeof(eitherproto), name,
+                                 sizeof(name), "services"));
+  ASSERT_EQ('\0', localproto[0]);
+
+  localproto = eitherproto;
   ASSERT_EQ(-1, /* port in network byte order */
-            LookupServicesByPort(htons(22), localproto, name, sizeof(name),
-                                 "services"));
-  ASSERT_EQ(NULL, localproto[0]);
+            LookupServicesByPort(htons(22), localproto, sizeof(eitherproto),
+                                 name, sizeof(name), "services"));
+  ASSERT_EQ('\0', localproto[0]);
 
-  localproto[0] = proto2;
-  ASSERT_EQ(
-      -1, /* port ok but wrong protocol */
-      LookupServicesByPort(22, localproto, name, sizeof(name), "services"));
-  ASSERT_EQ(localproto[0], proto2);
+  localproto = proto2;
+  ASSERT_EQ(-1, /* port ok but wrong protocol */
+            LookupServicesByPort(22, localproto, sizeof(proto2), name,
+                                 sizeof(name), "services"));
+  ASSERT_STREQ(proto2, "udp");
 
-  localproto[0] = proto1;
+  localproto = proto1;
   ASSERT_EQ(
-      0, LookupServicesByPort(22, localproto, name, sizeof(name), "services"));
+      -1, /* protocol is non-NULL/length must be nonzero */
+      LookupServicesByPort(22, localproto, 0, name, sizeof(name), "services"));
+  ASSERT_STREQ(proto1, "tcp");
+
+  localproto = proto1;
+  ASSERT_EQ(0, LookupServicesByPort(22, localproto, sizeof(proto1), name,
+                                    sizeof(name), "services"));
   ASSERT_STREQ(name, "ssh");
-  ASSERT_EQ(localproto[0], proto1);
+  ASSERT_STREQ(proto1, "tcp");
 
-  localproto[0] = proto2;
-  ASSERT_EQ(
-      0, LookupServicesByPort(19, localproto, name, sizeof(name), "services"));
+  localproto = proto2;
+  ASSERT_EQ(0, LookupServicesByPort(19, localproto, sizeof(proto2), name,
+                                    sizeof(name), "services"));
   ASSERT_STREQ(name, "chargen");
-  ASSERT_EQ(localproto[0], proto2);
+  ASSERT_STREQ(proto2, "udp");
 
-  localproto[0] = NULL;
-  ASSERT_EQ(
-      0, /* pick first matching protocol */
-      LookupServicesByPort(19, localproto, name, sizeof(name), "services"));
+  localproto = eitherproto;
+  ASSERT_EQ(0, /* pick first matching protocol */
+            LookupServicesByPort(19, localproto, sizeof(eitherproto), name,
+                                 sizeof(name), "services"));
   ASSERT_STREQ(name, "chargen");
-  ASSERT_NE(NULL, localproto[0]); /* got alloc'd during the call */
-  ASSERT_STREQ(localproto[0], "tcp");
-  free(localproto[0]);
+  ASSERT_NE('\0', localproto[0]); /* buffer filled during the call */
+  ASSERT_STREQ(eitherproto, "tcp");
 }
 
 TEST(LookupServicesByName, GetPortWhenNameOrAlias) {
-  char name[16]; /* sample has only names of length 3 */
+  char name[8];        /* service names are of length 3 */
+  char eitherproto[8]; /* protocol names are of length 3 */
   char proto1[] = "tcp";
   char proto2[] = "udp";
-  char* localproto[1];
+  char* localproto;
+  eitherproto[0] = '\0';
 
-  localproto[0] = NULL;
-  ASSERT_EQ(
-      -1, /* non-existent name */
-      LookupServicesByName("http", localproto, name, sizeof(name), "services"));
-  ASSERT_EQ(NULL, localproto[0]);
+  localproto = eitherproto;
+  ASSERT_EQ(-1, /* non-existent name */
+            LookupServicesByName("http", localproto, sizeof(eitherproto), name,
+                                 sizeof(name), "services"));
+  ASSERT_EQ('\0', localproto[0]);
 
-  localproto[0] = proto2;
-  ASSERT_EQ(
-      -1, /* name exists but wrong protocol */
-      LookupServicesByName("ssh", localproto, name, sizeof(name), "services"));
-  ASSERT_EQ(localproto[0], proto2);
+  localproto = proto2;
+  ASSERT_EQ(-1, /* name exists but wrong protocol */
+            LookupServicesByName("ssh", localproto, sizeof(proto2), name,
+                                 sizeof(name), "services"));
+  ASSERT_STREQ(proto2, "udp");
 
-  localproto[0] = proto1;
-  ASSERT_EQ(22, LookupServicesByName("ssh", localproto, name, sizeof(name),
-                                     "services"));
+  localproto = proto2;
+  ASSERT_EQ(-1, /* protocol is non-NULL/length must be nonzero */
+            LookupServicesByName("ssh", localproto, 0, name, sizeof(name),
+                                 "services"));
+  ASSERT_STREQ(proto2, "udp");
+
+  localproto = proto1;
+  ASSERT_EQ(22, LookupServicesByName("ssh", localproto, sizeof(proto1), name,
+                                     sizeof(name), "services"));
   ASSERT_STREQ(name, "ssh"); /* official name written to buffer */
-  ASSERT_EQ(localproto[0], proto1);
+  ASSERT_STREQ(proto1, "tcp");
 
-  localproto[0] = proto2;
+  localproto = proto2;
   ASSERT_EQ(19, /* works if alias provided */
-            LookupServicesByName("ttytst", localproto, name, sizeof(name),
-                                 "services"));
+            LookupServicesByName("ttytst", localproto, sizeof(proto2), name,
+                                 sizeof(name), "services"));
   ASSERT_STREQ(name, "chargen"); /* official name written to buffer */
-  ASSERT_EQ(localproto[0], proto2);
 
-  localproto[0] = NULL;
-  ASSERT_EQ(19, /* pick first matching protocol */
-            LookupServicesByName("source", localproto, name, sizeof(name),
+  localproto = proto2;
+  ASSERT_EQ(19, /* can get port returned without official name */
+            LookupServicesByName("ttytst", localproto, sizeof(proto2), NULL, 0,
                                  "services"));
+
+  name[0] = '\0';
+  localproto = eitherproto;
+  ASSERT_EQ(19, /* pick first matching protocol */
+            LookupServicesByName("source", localproto, sizeof(eitherproto),
+                                 name, sizeof(name), "services"));
   ASSERT_STREQ(name, "chargen");
-  ASSERT_NE(NULL, localproto[0]); /* got alloc'd during the call */
-  ASSERT_STREQ(localproto[0], "tcp");
-  free(localproto[0]);
+  ASSERT_STREQ(localproto, "tcp");
 }


### PR DESCRIPTION
`struct netent` related functions are stubs in the `musl` source code (see [here](https://github.com/ifduyue/musl/blob/master/src/network/netname.c) and [here](https://github.com/ifduyue/musl/blob/master/src/network/ent.c)), so left them as stubs here.

`struct protoent` related functions follow from `struct servent`: the function names, calls, returns, errors, and tests are very similar.  Of course, `/etc/protocols` is read instead of `/etc/services`.

The protocols file on my Windows 10 system is called `<location>\\etc\\protocol`, not `protocols`, so I assumed that must be the case for Windows in general.

The [`man` page entry for `getprotobyname`](https://linux.die.net/man/3/getprotobyname)  does not specify case-sensitive comparisons, so the implementation uses `strcasecmp` for comparing names/aliases.

`getprotobyname`/`getprotobynumber` calls output matches glibc, except for the `protoent.p_aliases`.

Surprisingly the [`musl` implementations of `getprotoby*`](https://github.com/ifduyue/musl/blob/master/src/network/proto.c) do not read `/etc/protocols`, there's just a hardcoded list of protocols in the source code.
