### PR TITLE
Update GetHeaders and GetParams descriptions in redbean help.

### DIFF
--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -570,7 +570,7 @@ FUNCTIONS
            message, then this function will fold those multiple entries into
            a single string.
 
-   GetHeaders() → table[name:str,value:str]
+   GetHeaders() → {name:str = value:str, ...}
            Returns HTTP headers as dictionary mapping header key strings to
            their UTF-8 decoded values. The ordering of headers from the
            request message is not preserved. Whether or not the same key can
@@ -604,7 +604,7 @@ FUNCTIONS
            Anything else that the RFC classifies as a "token" string is
            accepted too, which might contain characters like &".
 
-   GetParams() → array[array[str]]
+   GetParams() → {{name:str[, value:str]}, ...}
            Returns name=value parameters from Request-URL and
            application/x-www-form-urlencoded message body in the order they
            were received. This may contain duplicates. The inner array will


### PR DESCRIPTION
It's a minor change, but here is the rationale:

1. I find the distinction between table and array confusing here (since the same structure is used in Lua); this may also conflict with the array structure if/when it's introduced
2. The usage of square brackets doesn't allow for its use to mark optional elements; for example, the second description would need to be changed for something like `array[array[name:str[,value:str]]]`, which is ambiguous and confusing to read.
3. Using `=` shows that it's a hash and not an array (while it's actually an array in the second case)

I hope this syntax reads better and is easier to understand.
