### PR TITLE
Redbean add fetch with table

### DIFF
--- a/net/http/gethttpmethod.c
+++ b/net/http/gethttpmethod.c
@@ -20,10 +20,14 @@
 #include "net/http/http.h"
 
 /**
- * Returns small number for HTTP method, or 0 if not found.
+ * Converts HTTP method string into internal index
+ *
+ * @param len if -1 implies strlen
+ * @return small number for HTTP method, or 0 if not found.
  */
 int GetHttpMethod(const char *str, size_t len) {
   const struct HttpMethodSlot *slot;
+  if (len == -1) len = str ? strlen(str) : 0;
   if ((slot = LookupHttpMethod(str, len))) {
     return slot->code;
   } else {

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -3702,15 +3702,21 @@ static int LuaFetch(lua_State *L) {
                            .ai_flags = AI_NUMERICSERV};
 
   /*
-   * Get args.
+   * Get args: url [, body | {method = "PUT", body = "..."}]
    */
   urlarg = luaL_checklstring(L, 1, &urlarglen);
-  if (lua_isnoneornil(L, 2)) {
+  if (lua_istable(L, 2)) {
+    lua_settop(L, 2); // discard any extra arguments
+    lua_getfield(L, 2, "body");
+    body = luaL_optstring(L, -1, "");
+    lua_getfield(L, 2, "method");
+    method = GetHttpMethod(luaL_optstring(L, -1, ""), lua_rawlen(L, -1));
+    lua_settop(L, 2); // drop all added elements to keep the stack balanced
+  } else if (lua_isnoneornil(L, 2)) {
     body = "";
     method = kHttpGet;
   } else {
-    size_t bodylen;
-    body = luaL_checklstring(L, 2, &bodylen);
+    body = luaL_checkstring(L, 2);
     method = kHttpPost;
   }
 


### PR DESCRIPTION
This adds three changes (all in separate commits):

- Adds ability to supply a table with options as a second parameter (instead of the body). So far only "method" and "body" are recognized, but I plan to add at least "headers" in the future. If the second parameter is a string, then POST request is sent as before.
- Fixes providing Content-Length leader where appropriate. It's skipped for some requests (GET/HEAD/DELETE and few others) when 0
- Accepts arbitrary methods. Non-standard methods are needed for some of the use cases I've been working on. All method names are upper-cased to stay consistent with the standard ones.
