### PR TITLE
Fix redbean's Lua-function Log, so it can be used in the global scope.

### DIFF
--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -4911,7 +4911,7 @@ static int LuaLog(lua_State *L) {
   level = luaL_checkinteger(L, 1);
   if (LOGGABLE(level)) {
     msg = luaL_checkstring(L, 2);
-    lua_getstack(L, 1, &ar);
+    lua_getstack(L, 0, &ar);
     lua_getinfo(L, "nSl", &ar);
     if (!strcmp(ar.name, "main")) {
       module = strndup(effectivepath.p, effectivepath.n);


### PR DESCRIPTION
Before this fix Log crashed the redbean when Log was used in the global scope.
The demo versions of redbean has a Log in a main function, therefore it didn't crash.
Lua doesn't need a main function and every other redbean Lua-function can also be used in the most outer scope.