### PR TITLE
Redbean log improv

### DIFF
--- a/libc/log/log.h
+++ b/libc/log/log.h
@@ -72,6 +72,15 @@ extern unsigned __log_level; /* log level for runtime check */
   ((!__builtin_constant_p(LEVEL) || (LEVEL) <= LOGGABLELEVEL) && \
    (LEVEL) <= __log_level)
 
+// die with an error message without backtrace and debugger invocation
+#define DIEF(FMT, ...)                                              \
+  do {                                                              \
+    ++ftrace;                                                       \
+    flogf(kLogError, __FILE__, __LINE__, NULL, FMT, ##__VA_ARGS__); \
+    exit(1);                                                        \
+    unreachable;                                                    \
+  } while (0)
+
 #define FATALF(FMT, ...)                                              \
   do {                                                                \
     ++ftrace;                                                         \

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -2291,7 +2291,7 @@ static char *ServeErrorImpl(unsigned code, const char *reason,
 
 static char *ServeErrorWithDetail(unsigned code, const char *reason,
                                   const char *details) {
-  ERRORF("(rsp) server error: %d %s", code, reason);
+  ERRORF("(srvr) server error: %d %s", code, reason);
   return ServeErrorImpl(code, reason, details);
 }
 
@@ -2300,12 +2300,12 @@ static char *ServeError(unsigned code, const char *reason) {
 }
 
 static char *ServeFailure(unsigned code, const char *reason) {
-  ERRORF("(rsp) failure: %d %s %s HTTP%02d %.*s %`'.*s %`'.*s %`'.*s %`'.*s", code,
-       reason, DescribeClient(), msg.version, msg.xmethod.b - msg.xmethod.a,
-       inbuf.p + msg.xmethod.a, HeaderLength(kHttpHost), HeaderData(kHttpHost),
-       msg.uri.b - msg.uri.a, inbuf.p + msg.uri.a, HeaderLength(kHttpReferer),
-       HeaderData(kHttpReferer), HeaderLength(kHttpUserAgent),
-       HeaderData(kHttpUserAgent));
+  ERRORF("(srvr) failure: %d %s %s HTTP%02d %.*s %`'.*s %`'.*s %`'.*s %`'.*s", code,
+         reason, DescribeClient(), msg.version, msg.xmethod.b - msg.xmethod.a,
+         inbuf.p + msg.xmethod.a, HeaderLength(kHttpHost), HeaderData(kHttpHost),
+         msg.uri.b - msg.uri.a, inbuf.p + msg.uri.a, HeaderLength(kHttpReferer),
+         HeaderData(kHttpReferer), HeaderLength(kHttpUserAgent),
+         HeaderData(kHttpUserAgent));
   return ServeErrorImpl(code, reason, NULL);
 }
 
@@ -5983,7 +5983,7 @@ static char *SetStatus(unsigned code, const char *reason) {
   hdrbuf.p[9] += code / 100;
   hdrbuf.p[10] += code / 10 % 10;
   hdrbuf.p[11] += code % 10;
-  VERBOSEF("(rsp) %s%s", hdrbuf.p, reason);
+  VERBOSEF("(rsp) %d %s", code, reason);
   return AppendCrlf(stpcpy(hdrbuf.p + 13, reason));
 }
 

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -6465,8 +6465,7 @@ static void Listen(void) {
       servers.p[n].addr.sin_addr.s_addr = htonl(ips.p[i]);
       if ((servers.p[n].fd = GoodSocket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC,
                                         IPPROTO_TCP, true, &timeout)) == -1) {
-        perror("socket");
-        exit(1);
+        FATALF("socket: %m");
       }
       if (bind(servers.p[n].fd, &servers.p[n].addr,
                sizeof(servers.p[n].addr)) == -1) {
@@ -6476,13 +6475,11 @@ static void Listen(void) {
         exit(1);
       }
       if (listen(servers.p[n].fd, 10) == -1) {
-        perror("listen");
-        exit(1);
+        FATALF("listen: %m");
       }
       addrsize = sizeof(servers.p[n].addr);
       if (getsockname(servers.p[n].fd, &servers.p[n].addr, &addrsize) == -1) {
-        perror("getsockname");
-        exit(1);
+        FATALF("getsockname: %m");
       }
       port = ntohs(servers.p[n].addr.sin_port);
       ip = ntohl(servers.p[n].addr.sin_addr.s_addr);


### PR DESCRIPTION
This implements several changes:

- Updated log level for redbean messages to better work with verbose/silent logging
- Moved `FATALF` call to the end of `HandleForkFailure`
- Added categories for each log message
- Replaced `perror` with an appropriate log message using `%m`
- Replaced `flogf(); exit();` with (added) `DIEF`
- Slightly reorganized Lua error messages for consistency and reduced number of messages