### PR TITLE
Log reorg

### DIFF
--- a/dsp/mpeg/mpeg1.c
+++ b/dsp/mpeg/mpeg1.c
@@ -591,24 +591,24 @@ void plm_video_decode_sequence_header(plm_video_t *self) {
 
   self->has_sequence_header = true;
 
-  LOGF("%s:\n"
-       "\t%-20s = %15d;\n"
-       "\t%-20s = %15d;\n"
-       "\t%-20s = %15f;\n"
-       "\t%-20s = %15f;\n"
-       "\t%-20s = %15d;\n"
-       "\t%-20s = %15d;\n"
-       "\t%-20s = %15d;\n"
-       "\t%-20s = %15d;\n"
-       "\t%-20s = %15d;\n"
-       "\t%-20s = %15d;\n"
-       "\t%-20s = %15d;",
-       "New MPEG Sequence", "width", self->width, "height", self->height,
-       "framerate", self->framerate, "pixel_aspect_ratio",
-       self->pixel_aspect_ratio, "mb_size", self->mb_size, "mb_width",
-       self->mb_width, "mb_height", self->mb_height, "luma_width",
-       self->luma_width, "luma_height", self->luma_height, "chroma_width",
-       self->chroma_width, "chroma_height", self->chroma_height);
+  INFOF("%s:\n"
+        "\t%-20s = %15d;\n"
+        "\t%-20s = %15d;\n"
+        "\t%-20s = %15f;\n"
+        "\t%-20s = %15f;\n"
+        "\t%-20s = %15d;\n"
+        "\t%-20s = %15d;\n"
+        "\t%-20s = %15d;\n"
+        "\t%-20s = %15d;\n"
+        "\t%-20s = %15d;\n"
+        "\t%-20s = %15d;\n"
+        "\t%-20s = %15d;",
+        "New MPEG Sequence", "width", self->width, "height", self->height,
+        "framerate", self->framerate, "pixel_aspect_ratio",
+        self->pixel_aspect_ratio, "mb_size", self->mb_size, "mb_width",
+        self->mb_width, "mb_height", self->mb_height, "luma_width",
+        self->luma_width, "luma_height", self->luma_height, "chroma_width",
+        self->chroma_width, "chroma_height", self->chroma_height);
 }
 
 static void plm_video_copy_macroblock(plm_video_t *self, int motion_h,
@@ -1082,7 +1082,7 @@ static plm_frame_t *plm_video_decode_impl(plm_video_t *self) {
 plm_frame_t *plm_video_decode(plm_video_t *self) {
   long double tsc;
   plm_frame_t *res;
-  LOGF("plm_video_decode");
+  INFOF("plm_video_decode");
   tsc = nowl();
   res = plm_video_decode_impl(self);
   plmpegdecode_latency_ = lroundl((nowl() - tsc) * 1e6l);

--- a/libc/log/log.h
+++ b/libc/log/log.h
@@ -73,7 +73,7 @@ extern unsigned __log_level; /* log level for runtime check */
    (LEVEL) <= __log_level)
 
 // log a message with the specified log level (not checking if LOGGABLE)
-#define ANYF(LEVEL, FMT, ...)                                   \
+#define LOGF(LEVEL, FMT, ...)                                   \
   do {                                                          \
     ++ftrace;                                                   \
     flogf(LEVEL, __FILE__, __LINE__, NULL, FMT, ##__VA_ARGS__); \
@@ -114,7 +114,7 @@ extern unsigned __log_level; /* log level for runtime check */
     }                                                                \
   } while (0)
 
-#define LOGF(FMT, ...)                                               \
+#define INFOF(FMT, ...)                                              \
   do {                                                               \
     if (LOGGABLE(kLogInfo)) {                                        \
       ++ftrace;                                                      \

--- a/libc/log/log.h
+++ b/libc/log/log.h
@@ -150,15 +150,6 @@ extern unsigned __log_level; /* log level for runtime check */
     }                                                                   \
   } while (0)
 
-#define VFLOG(FMT, VA)                                     \
-  do {                                                     \
-    if (LOGGABLE(kLogInfo)) {                              \
-      ++ftrace;                                            \
-      vflogf(kLogInfo, __FILE__, __LINE__, NULL, FMT, VA); \
-      --ftrace;                                            \
-    }                                                      \
-  } while (0)
-
 #define FLOGF(F, FMT, ...)                                        \
   do {                                                            \
     if (LOGGABLE(kLogInfo)) {                                     \
@@ -166,24 +157,6 @@ extern unsigned __log_level; /* log level for runtime check */
       flogf(kLogInfo, __FILE__, __LINE__, F, FMT, ##__VA_ARGS__); \
       --ftrace;                                                   \
     }                                                             \
-  } while (0)
-
-#define VFLOGF(F, FMT, VA)                              \
-  do {                                                  \
-    if (LOGGABLE(kLogInfo)) {                           \
-      ++ftrace;                                         \
-      vflogf(kLogInfo, __FILE__, __LINE__, F, FMT, VA); \
-      --ftrace;                                         \
-    }                                                   \
-  } while (0)
-
-#define VWARNF(FMT, VA)                                    \
-  do {                                                     \
-    if (LOGGABLE(kLogWarn)) {                              \
-      ++ftrace;                                            \
-      vflogf(kLogWarn, __FILE__, __LINE__, NULL, FMT, VA); \
-      --ftrace;                                            \
-    }                                                      \
   } while (0)
 
 #define FWARNF(F, FMT, ...)                                       \
@@ -195,43 +168,11 @@ extern unsigned __log_level; /* log level for runtime check */
     }                                                             \
   } while (0)
 
-#define VFWARNF(F, FMT, VA)                             \
-  do {                                                  \
-    if (LOGGABLE(kLogWarn)) {                           \
-      ++ftrace;                                         \
-      vflogf(kLogWarn, __FILE__, __LINE__, F, FMT, VA); \
-      --ftrace;                                         \
-    }                                                   \
-  } while (0)
-
-#define VFATALF(FMT, VA)                                    \
-  do {                                                      \
-    ++ftrace;                                               \
-    vffatalf(kLogFatal, __FILE__, __LINE__, NULL, FMT, VA); \
-    unreachable;                                            \
-  } while (0)
-
 #define FFATALF(F, FMT, ...)                                       \
   do {                                                             \
     ++ftrace;                                                      \
     ffatalf(kLogFatal, __FILE__, __LINE__, F, FMT, ##__VA_ARGS__); \
     unreachable;                                                   \
-  } while (0)
-
-#define VFFATALF(F, FMT, VA)                             \
-  do {                                                   \
-    ++ftrace;                                            \
-    vffatalf(kLogFatal, __FILE__, __LINE__, F, FMT, VA); \
-    unreachable;                                         \
-  } while (0)
-
-#define VDEBUGF(FMT, VA)                                      \
-  do {                                                        \
-    if (UNLIKELY(LOGGABLE(kLogDebug))) {                      \
-      ++ftrace;                                               \
-      vfdebugf(kLogDebug, __FILE__, __LINE__, NULL, FMT, VA); \
-      --ftrace;                                               \
-    }                                                         \
   } while (0)
 
 #define FDEBUGF(F, FMT, ...)                                         \
@@ -241,33 +182,6 @@ extern unsigned __log_level; /* log level for runtime check */
       fdebugf(kLogDebug, __FILE__, __LINE__, F, FMT, ##__VA_ARGS__); \
       --ftrace;                                                      \
     }                                                                \
-  } while (0)
-
-#define VFVERBOSEF(F, FMT, VA)                                 \
-  do {                                                         \
-    if (LOGGABLE(kLogVerbose)) {                               \
-      ++ftrace;                                                \
-      vfverbosef(kLogVerbose, __FILE__, __LINE__, F, FMT, VA); \
-      --ftrace;                                                \
-    }                                                          \
-  } while (0)
-
-#define VFDEBUGF(F, FMT, VA)                               \
-  do {                                                     \
-    if (LOGGABLE(kLogDebug)) {                             \
-      ++ftrace;                                            \
-      vfdebugf(kLogDebug, __FILE__, __LINE__, F, FMT, VA); \
-      --ftrace;                                            \
-    }                                                      \
-  } while (0)
-
-#define VNOISEF(FMT, VA)                                      \
-  do {                                                        \
-    if (UNLIKELY(LOGGABLE(kLogNoise))) {                      \
-      ++ftrace;                                               \
-      vfnoisef(kLogNoise, __FILE__, __LINE__, NULL, FMT, VA); \
-      --ftrace;                                               \
-    }                                                         \
   } while (0)
 
 #define FNOISEF(F, FMT, ...)                                         \

--- a/libc/log/vflogf.c
+++ b/libc/log/vflogf.c
@@ -65,9 +65,9 @@ void vflogf_onfail(FILE *f) {
  * will display microseconsd as a delta elapsed time. This is useful if
  * you do something like:
  *
- *     LOGF("connecting to foo");
+ *     INFOF("connecting to foo");
  *     connect(...)
- *     LOGF("connected to foo");
+ *     INFOF("connected to foo");
  *
  * In that case, the second log entry will always display the amount of
  * time that it took to connect. This is great in forking applications.

--- a/libc/log/vflogf.c
+++ b/libc/log/vflogf.c
@@ -101,7 +101,6 @@ void(vflogf)(unsigned level, const char *file, int line, FILE *f,
     vflogf_onfail(f);
   }
   (vfprintf)(f, fmt, va);
-  va_end(va);
   fputs("\n", f);
   if (bufmode == _IOLBF) {
     f->bufmode = _IOLBF;

--- a/net/https/sslcache.c
+++ b/net/https/sslcache.c
@@ -109,7 +109,7 @@ int UncacheSslSession(void *data, mbedtls_ssl_session *session) {
   mbedtls_x509_crt *cert;
   struct SslCacheEntry *e;
   uint32_t i, hash, ticketlen;
-  LOGF("uncache");
+  INFOF("uncache");
   cache = data;
   hash = HashSslSession(session);
   i = hash & cache->mask;

--- a/third_party/mbedtls/ssl_srv.c
+++ b/third_party/mbedtls/ssl_srv.c
@@ -4473,7 +4473,7 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
             return( ret );
     }
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
-    /* LOGF("handshake step %s", GetSslStateName(ssl->state)); */
+    /* INFOF("handshake step %s", GetSslStateName(ssl->state)); */
     switch( ssl->state )
     {
         case MBEDTLS_SSL_HELLO_REQUEST:

--- a/tool/build/lib/op101.c
+++ b/tool/build/lib/op101.c
@@ -79,7 +79,7 @@ static void SgdtMs(struct Machine *m, uint32_t rde) {
 
 static void LgdtMs(struct Machine *m, uint32_t rde) {
   LoadDescriptorTable(m, rde, &m->gdt_limit, &m->gdt_base);
-  LOGF("set gdt %p lim %,d", m->gdt_base, m->gdt_limit);
+  INFOF("set gdt %p lim %,d", m->gdt_base, m->gdt_limit);
 }
 
 static void SidtMs(struct Machine *m, uint32_t rde) {
@@ -88,7 +88,7 @@ static void SidtMs(struct Machine *m, uint32_t rde) {
 
 static void LidtMs(struct Machine *m, uint32_t rde) {
   LoadDescriptorTable(m, rde, &m->idt_limit, &m->idt_base);
-  LOGF("set idt %p lim %,d", m->idt_base, m->idt_limit);
+  INFOF("set idt %p lim %,d", m->idt_base, m->idt_limit);
 }
 
 static void Monitor(struct Machine *m, uint32_t rde) {

--- a/tool/build/package.c
+++ b/tool/build/package.c
@@ -622,10 +622,10 @@ void CompressLowEntropyReadOnlyDataSections(struct Package *pkg,
                    ".rodata") &&
         rlencode(&rle, p, shdr->sh_size) != -1) {
       isprofitable = rle.i * sizeof(rle.p[0]) <= shdr->sh_size / 2;
-      LOGF("%s(%s): rlencode()%s on %s is%s profitable (%,zu → %,zu bytes)",
-           &pkg->strings.p[pkg->path], &pkg->strings.p[obj->path],
-           haverldecode ? "" : " [NOT LINKED]", name,
-           isprofitable ? "" : " NOT", shdr->sh_size, rle.i * sizeof(rle.p[0]));
+      INFOF("%s(%s): rlencode()%s on %s is%s profitable (%,zu → %,zu bytes)",
+            &pkg->strings.p[pkg->path], &pkg->strings.p[obj->path],
+            haverldecode ? "" : " [NOT LINKED]", name,
+            isprofitable ? "" : " NOT", shdr->sh_size, rle.i * sizeof(rle.p[0]));
     }
   }
   free(rle.p);

--- a/tool/build/runitd.c
+++ b/tool/build/runitd.c
@@ -204,7 +204,7 @@ void StartTcpServer(void) {
   CHECK_NE(-1, listen(g_servfd, 10));
   asize = sizeof(g_servaddr);
   CHECK_NE(-1, getsockname(g_servfd, &g_servaddr, &asize));
-  LOGF("%s:%s", "listening on tcp", gc(DescribeAddress(&g_servaddr)));
+  INFOF("%s:%s", "listening on tcp", gc(DescribeAddress(&g_servaddr)));
   if (g_sendready) {
     printf("ready %hu\n", ntohs(g_servaddr.sin_port));
     fflush(stdout);
@@ -306,8 +306,8 @@ void HandleClient(void) {
   exename = gc(calloc(1, namesize + 1));
   Recv(exename, namesize);
   g_exepath = gc(xasprintf("o/%d.%s", getpid(), basename(exename)));
-  LOGF("%s asked we run %`'s (%,u bytes @ %`'s)", addrstr, exename, filesize,
-       g_exepath);
+  INFOF("%s asked we run %`'s (%,u bytes @ %`'s)", addrstr, exename, filesize,
+        g_exepath);
 
   exe = malloc(filesize);
   Recv(exe, filesize);
@@ -428,9 +428,9 @@ int Serve(void) {
   }
   close(g_servfd);
   if (!g_timeout) {
-    LOGF("timeout expired, shutting down");
+    INFOF("timeout expired, shutting down");
   } else {
-    LOGF("got ctrl-c, shutting down");
+    INFOF("got ctrl-c, shutting down");
   }
   return 0;
 }

--- a/tool/net/echoserver.c
+++ b/tool/net/echoserver.c
@@ -130,7 +130,7 @@ void AddSocket(const struct Socket *s) {
 
 void RemoveSocket(size_t i) {
   DCHECK_LT(i, g_sockets.i);
-  LOGF("removing: %s", gc(DescribeSocket(&g_sockets.p[i])));
+  INFOF("removing: %s", gc(DescribeSocket(&g_sockets.p[i])));
   CHECK_NE(-1, close(g_sockets.p[i].fd));
   while (g_sockets.p[i].egress.i) {
     free(g_sockets.p[i].egress.p[g_sockets.p[i].egress.i - 1].data.iov_base);
@@ -189,7 +189,7 @@ void BeginListeningForIncomingTraffic(void) {
     }
     uint32_t addrsize = sizeof(s->addr);
     CHECK_NE(-1, getsockname(s->fd, &s->addr, &addrsize));
-    LOGF("listening on %s", gc(DescribeSocket(s)));
+    INFOF("listening on %s", gc(DescribeSocket(s)));
   }
 }
 
@@ -202,8 +202,8 @@ void AcceptConnection(size_t i) {
   client.protocol = server->protocol;
   uint32_t addrsize = sizeof(client.addr);
   CHECK_NE(-1L, (client.fd = accept(server->fd, &client.addr, &addrsize)));
-  LOGF("%s accepted %s", gc(DescribeSocket(server)),
-       gc(DescribeSocket(&client)));
+  INFOF("%s accepted %s", gc(DescribeSocket(server)),
+        gc(DescribeSocket(&client)));
   AddSocket(&client);
 }
 
@@ -219,8 +219,8 @@ bool ReceiveData(size_t i) {
                                 msg.data.iov_len, 0, isudp ? &msg.dest : NULL,
                                 isudp ? &msg.destsize : NULL)));
   if (0 < got && got <= msg.data.iov_len) {
-    LOGF("%s received %lu bytes from %s", gc(DescribeSocket(&g_sockets.p[i])),
-         got, gc(DescribeAddress(&msg.dest)));
+    INFOF("%s received %lu bytes from %s", gc(DescribeSocket(&g_sockets.p[i])),
+          got, gc(DescribeAddress(&msg.dest)));
     msg.data.iov_base = xrealloc(msg.data.iov_base, (msg.data.iov_len = got));
     append(&g_sockets.p[i].egress, &msg);
     g_polls.p[i].events |= POLLOUT;
@@ -241,8 +241,8 @@ void SendData(size_t i) {
   CHECK_NE(-1L, (sent = sendto(s->fd, msg->data.iov_base, msg->data.iov_len, 0,
                                isudp ? &msg->dest : NULL,
                                isudp ? msg->destsize : 0)));
-  LOGF("%s sent %lu bytes to %s", gc(DescribeSocket(s)), msg->data.iov_len,
-       gc(DescribeAddress(&msg->dest)));
+  INFOF("%s sent %lu bytes to %s", gc(DescribeSocket(s)), msg->data.iov_len,
+        gc(DescribeAddress(&msg->dest)));
   if (!(msg->data.iov_len -= min((size_t)sent, (size_t)msg->data.iov_len))) {
     free_s(&msg->data.iov_base);
     if (!--s->egress.i) {
@@ -290,7 +290,7 @@ int main(int argc, char *argv[]) {
   memset(&icall, 0, sizeof(icall));
   interruptiblecall(&icall, (void *)EchoServer, 0, 0, 0, 0);
   fputc('\r', stderr);
-  LOGF("%s", "shutting down...");
+  INFOF("%s", "shutting down...");
   size_t i;
   for (i = g_sockets.i; i; --i) RemoveSocket(i - 1);
   return 0;

--- a/tool/viz/lib/ycbcr2rgb3.c
+++ b/tool/viz/lib/ycbcr2rgb3.c
@@ -192,7 +192,7 @@ void YCbCrComputeSamplingSolution(struct YCbCrSamplingSolution *scale, long dyn,
       fabs(scale->rx - rx) > .001 || fabs(scale->oy - oy) > .001 ||
       fabs(scale->ox - ox) > .001 || fabs(scale->py - py) > .001 ||
       fabs(scale->px - px) > .001) {
-    LOGF("recomputing sampling solution");
+    INFOF("recomputing sampling solution");
     FreeSamplingSolution(scale->cy), scale->cy = NULL;
     FreeSamplingSolution(scale->cx), scale->cx = NULL;
     scale->cy = ComputeSamplingSolution(dyn, syn, ry, oy, py);
@@ -297,13 +297,13 @@ void YCbCr2RgbScaler(struct YCbCr *me, long dyn, long dxn,
     yox = sxn / scxn / 2 - prx * .5;
     coy = syn / scyn / 2 - pry * .5;
     cox = sxn / scxn / 2 - prx * .5;
-    LOGF("gyarados pry=%.3f prx=%.3f syn=%.3f sxn=%.3f dyn=%ld dxn=%ld "
-         "yyn=%ld "
-         "yxn=%ld cyn=%ld cxn=%ld yry=%.3f yrx=%.3f cry=%.3f crx=%.3f "
-         "yoy=%.3f "
-         "yox=%.3f coy=%.3f cox=%.3f",
-         pry, prx, syn, sxn, dyn, dxn, yyn, yxn, cyn, cxn, yry, yrx, cry, crx,
-         yoy, yox, coy, cox);
+    INFOF("gyarados pry=%.3f prx=%.3f syn=%.3f sxn=%.3f dyn=%ld dxn=%ld "
+          "yyn=%ld "
+          "yxn=%ld cyn=%ld cxn=%ld yry=%.3f yrx=%.3f cry=%.3f crx=%.3f "
+          "yoy=%.3f "
+          "yox=%.3f coy=%.3f cox=%.3f",
+          pry, prx, syn, sxn, dyn, dxn, yyn, yxn, cyn, cxn, yry, yrx, cry, crx,
+          yoy, yox, coy, cox);
     YCbCrComputeSamplingSolution(&me->luma, dyn, dxn, syn, sxn, yry, yrx, yoy,
                                  yox, pry, prx);
     YCbCrComputeSamplingSolution(&me->chroma, dyn, dxn, scyn, scxn, cry, crx,
@@ -318,7 +318,7 @@ void YCbCr2RgbScaler(struct YCbCr *me, long dyn, long dxn,
                   me->chroma.cy, me->chroma.cx, false);
     gyarados_latency_ = lround((nowl() - ts) * 1e6l);
     YCbCrConvert(me, dyn, dxn, RGB, yys, yxs, Y, cys, cxs, Cb, Cr);
-    LOGF("done");
+    INFOF("done");
   }
 }
 
@@ -370,7 +370,7 @@ void *YCbCr2RgbScale(long dyn, long dxn,
   CHECK_LE(yxn, yxs);
   CHECK_LE(cyn, cys);
   CHECK_LE(cxn, cxs);
-  LOGF("magikarp2x");
+  INFOF("magikarp2x");
   magikarp_start_ = nowl();
   minyys = MAX(ceil(syn), MAX(yyn, ceil(dyn * pry)));
   minyxs = MAX(ceil(sxn), MAX(yxn, ceil(dxn * prx)));

--- a/tool/viz/printvideo.c
+++ b/tool/viz/printvideo.c
@@ -171,7 +171,7 @@ mode.\n\
 
 #define BALLOC(B, A, N, NAME)              \
   ({                                       \
-    LOGF("balloc/%s %,zu bytes", NAME, N); \
+    INFOF("balloc/%s %,zu bytes", NAME, N); \
     balloc(B, A, N);                       \
   })
 
@@ -347,7 +347,7 @@ static bool CloseSpeaker(void) {
   int rc, wstatus;
   rc = 0;
   sched_yield();
-  LOGF("CloseSpeaker");
+  INFOF("CloseSpeaker");
   if (playfd_) {
     rc |= close(playfd_);
     playfd_ = -1;
@@ -443,7 +443,7 @@ static void DimensionDisplay(void) {
     yn = ROUNDDOWN(yn, 2);
     xn = ROUNDDOWN(xn, 2);
     g2_ = resizegraphic(&graphic_[1], yn, xn);
-    LOGF("%s 𝑑(%hu×%hu)×(%d,%d): 𝑔₁(%zu×%zu,r=%f) → 𝑔₂(%zu×%zu)",
+    INFOF("%s 𝑑(%hu×%hu)×(%d,%d): 𝑔₁(%zu×%zu,r=%f) → 𝑔₂(%zu×%zu)",
          "DimensionDisplay", wsize_.ws_row, wsize_.ws_col, g1_->yn, g1_->xn,
          ratio, yn, xn);
     BALLOC(&xtcodes_, 64, ((g2_->yn) * g2_->xn + 8) * sizeof(struct TtyRgb),
@@ -818,15 +818,15 @@ static void TranscodeVideo(plm_frame_t *pf) {
     TIMEIT(t4, RenderIt());
   }
 
-  LOGF("𝑓%zu(%u×%u) %,zub (%f BPP) "
-       "ycbcr=%,zuns "
-       "scale=%,zuns "
-       "lace=%,zuns "
-       "fx=%,zuns "
-       "quantize=%,zuns "
-       "render=%,zuns",
-       framecount_++, g2_->yn, g2_->xn, f2_->n,
-       (f1_->n / (double)(g2_->yn * g2_->xn)), t1, t2, t8, t6, t3, t4);
+  INFOF("𝑓%zu(%u×%u) %,zub (%f BPP) "
+        "ycbcr=%,zuns "
+        "scale=%,zuns "
+        "lace=%,zuns "
+        "fx=%,zuns "
+        "quantize=%,zuns "
+        "render=%,zuns",
+        framecount_++, g2_->yn, g2_->xn, f2_->n,
+        (f1_->n / (double)(g2_->yn * g2_->xn)), t1, t2, t8, t6, t3, t4);
 }
 
 static void OnVideo(plm_t *mpeg, plm_frame_t *pf, void *user) {
@@ -847,7 +847,7 @@ static void OnVideo(plm_t *mpeg, plm_frame_t *pf, void *user) {
 static void OpenVideo(void) {
   size_t yn, xn;
   playfd_ = -1;
-  LOGF("%s(%`'s)", "OpenVideo", patharg_);
+  INFOF("%s(%`'s)", "OpenVideo", patharg_);
   CHECK_NOTNULL((plm_ = plm_create_with_filename(patharg_)));
   swing_ = 219;
   xn = plm_get_width(plm_);
@@ -1304,7 +1304,7 @@ static void HandleSignals(void) {
 static void PrintVideo(void) {
   long double decode_last, decode_end, next_tick, lag;
   dura_ = MIN(MAX_FRAMERATE, 1 / plm_get_framerate(plm_));
-  LOGF("framerate=%f dura=%f", plm_get_framerate(plm_), dura_);
+  INFOF("framerate=%f dura=%f", plm_get_framerate(plm_), dura_);
   next_tick = deadline_ = decode_last = nowl();
   next_tick += dura_;
   deadline_ += dura_;
@@ -1319,8 +1319,8 @@ static void PrintVideo(void) {
     deadline_ = next_tick - lag;
     if (gotvideo_ || !plm_get_video_enabled(plm_)) {
       gotvideo_ = false;
-      LOGF("entering printvideo event loop (lag=%,ldns, grace=%,ldns)",
-           AsNanoseconds(lag), AsNanoseconds(GetGraceTime()));
+      INFOF("entering printvideo event loop (lag=%,ldns, grace=%,ldns)",
+            AsNanoseconds(lag), AsNanoseconds(GetGraceTime()));
     }
     do {
       if (!setjmp(jbi_)) {
@@ -1452,68 +1452,68 @@ static void TryToOpenFrameBuffer(void) {
   }
   if ((fb0_.fd = open(fb0_.path, O_RDWR)) != -1) {
     CHECK_NE(-1, (rc = ioctl(fb0_.fd, FBIOGET_FSCREENINFO, &fb0_.fscreen)));
-    LOGF("ioctl(%s) → %d", "FBIOGET_FSCREENINFO", rc);
-    LOGF("%s.%s=%.*s", "fb0_.fscreen", "id", sizeof(fb0_.fscreen.id),
-         fb0_.fscreen.id);
-    LOGF("%s.%s=%p", "fb0_.fscreen", "smem_start", fb0_.fscreen.smem_start);
-    LOGF("%s.%s=%u", "fb0_.fscreen", "smem_len", fb0_.fscreen.smem_len);
-    LOGF("%s.%s=%u", "fb0_.fscreen", "type", fb0_.fscreen.type);
-    LOGF("%s.%s=%u", "fb0_.fscreen", "type_aux", fb0_.fscreen.type_aux);
-    LOGF("%s.%s=%u", "fb0_.fscreen", "visual", fb0_.fscreen.visual);
-    LOGF("%s.%s=%hu", "fb0_.fscreen", "xpanstep", fb0_.fscreen.xpanstep);
-    LOGF("%s.%s=%hu", "fb0_.fscreen", "ypanstep", fb0_.fscreen.ypanstep);
-    LOGF("%s.%s=%hu", "fb0_.fscreen", "ywrapstep", fb0_.fscreen.ywrapstep);
-    LOGF("%s.%s=%u", "fb0_.fscreen", "line_length", fb0_.fscreen.line_length);
-    LOGF("%s.%s=%p", "fb0_.fscreen", "mmio_start", fb0_.fscreen.mmio_start);
-    LOGF("%s.%s=%u", "fb0_.fscreen", "mmio_len", fb0_.fscreen.mmio_len);
-    LOGF("%s.%s=%u", "fb0_.fscreen", "accel", fb0_.fscreen.accel);
-    LOGF("%s.%s=%#b", "fb0_.fscreen", "capabilities",
-         fb0_.fscreen.capabilities);
+    INFOF("ioctl(%s) → %d", "FBIOGET_FSCREENINFO", rc);
+    INFOF("%s.%s=%.*s", "fb0_.fscreen", "id", sizeof(fb0_.fscreen.id),
+          fb0_.fscreen.id);
+    INFOF("%s.%s=%p", "fb0_.fscreen", "smem_start", fb0_.fscreen.smem_start);
+    INFOF("%s.%s=%u", "fb0_.fscreen", "smem_len", fb0_.fscreen.smem_len);
+    INFOF("%s.%s=%u", "fb0_.fscreen", "type", fb0_.fscreen.type);
+    INFOF("%s.%s=%u", "fb0_.fscreen", "type_aux", fb0_.fscreen.type_aux);
+    INFOF("%s.%s=%u", "fb0_.fscreen", "visual", fb0_.fscreen.visual);
+    INFOF("%s.%s=%hu", "fb0_.fscreen", "xpanstep", fb0_.fscreen.xpanstep);
+    INFOF("%s.%s=%hu", "fb0_.fscreen", "ypanstep", fb0_.fscreen.ypanstep);
+    INFOF("%s.%s=%hu", "fb0_.fscreen", "ywrapstep", fb0_.fscreen.ywrapstep);
+    INFOF("%s.%s=%u", "fb0_.fscreen", "line_length", fb0_.fscreen.line_length);
+    INFOF("%s.%s=%p", "fb0_.fscreen", "mmio_start", fb0_.fscreen.mmio_start);
+    INFOF("%s.%s=%u", "fb0_.fscreen", "mmio_len", fb0_.fscreen.mmio_len);
+    INFOF("%s.%s=%u", "fb0_.fscreen", "accel", fb0_.fscreen.accel);
+    INFOF("%s.%s=%#b", "fb0_.fscreen", "capabilities",
+          fb0_.fscreen.capabilities);
     CHECK_NE(-1, (rc = ioctl(fb0_.fd, FBIOGET_VSCREENINFO, &fb0_.vscreen)));
-    LOGF("ioctl(%s) → %d", "FBIOGET_VSCREENINFO", rc);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "xres", fb0_.vscreen.xres);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "yres", fb0_.vscreen.yres);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "xres_virtual", fb0_.vscreen.xres_virtual);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "yres_virtual", fb0_.vscreen.yres_virtual);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "xoffset", fb0_.vscreen.xoffset);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "yoffset", fb0_.vscreen.yoffset);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "bits_per_pixel",
-         fb0_.vscreen.bits_per_pixel);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "grayscale", fb0_.vscreen.grayscale);
-    LOGF("%s.%s=%u", "fb0_.vscreen.red", "offset", fb0_.vscreen.red.offset);
-    LOGF("%s.%s=%u", "fb0_.vscreen.red", "length", fb0_.vscreen.red.length);
-    LOGF("%s.%s=%u", "fb0_.vscreen.red", "msb_right",
-         fb0_.vscreen.red.msb_right);
-    LOGF("%s.%s=%u", "fb0_.vscreen.green", "offset", fb0_.vscreen.green.offset);
-    LOGF("%s.%s=%u", "fb0_.vscreen.green", "length", fb0_.vscreen.green.length);
-    LOGF("%s.%s=%u", "fb0_.vscreen.green", "msb_right",
-         fb0_.vscreen.green.msb_right);
-    LOGF("%s.%s=%u", "fb0_.vscreen.blue", "offset", fb0_.vscreen.blue.offset);
-    LOGF("%s.%s=%u", "fb0_.vscreen.blue", "length", fb0_.vscreen.blue.length);
-    LOGF("%s.%s=%u", "fb0_.vscreen.blue", "msb_right",
-         fb0_.vscreen.blue.msb_right);
-    LOGF("%s.%s=%u", "fb0_.vscreen.transp", "offset",
-         fb0_.vscreen.transp.offset);
-    LOGF("%s.%s=%u", "fb0_.vscreen.transp", "length",
-         fb0_.vscreen.transp.length);
-    LOGF("%s.%s=%u", "fb0_.vscreen.transp", "msb_right",
-         fb0_.vscreen.transp.msb_right);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "nonstd", fb0_.vscreen.nonstd);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "activate", fb0_.vscreen.activate);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "height", fb0_.vscreen.height);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "width", fb0_.vscreen.width);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "accel_flags", fb0_.vscreen.accel_flags);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "pixclock", fb0_.vscreen.pixclock);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "left_margin", fb0_.vscreen.left_margin);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "right_margin", fb0_.vscreen.right_margin);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "upper_margin", fb0_.vscreen.upper_margin);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "lower_margin", fb0_.vscreen.lower_margin);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "hsync_len", fb0_.vscreen.hsync_len);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "vsync_len", fb0_.vscreen.vsync_len);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "sync", fb0_.vscreen.sync);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "vmode", fb0_.vscreen.vmode);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "rotate", fb0_.vscreen.rotate);
-    LOGF("%s.%s=%u", "fb0_.vscreen", "colorspace", fb0_.vscreen.colorspace);
+    INFOF("ioctl(%s) → %d", "FBIOGET_VSCREENINFO", rc);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "xres", fb0_.vscreen.xres);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "yres", fb0_.vscreen.yres);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "xres_virtual", fb0_.vscreen.xres_virtual);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "yres_virtual", fb0_.vscreen.yres_virtual);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "xoffset", fb0_.vscreen.xoffset);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "yoffset", fb0_.vscreen.yoffset);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "bits_per_pixel",
+          fb0_.vscreen.bits_per_pixel);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "grayscale", fb0_.vscreen.grayscale);
+    INFOF("%s.%s=%u", "fb0_.vscreen.red", "offset", fb0_.vscreen.red.offset);
+    INFOF("%s.%s=%u", "fb0_.vscreen.red", "length", fb0_.vscreen.red.length);
+    INFOF("%s.%s=%u", "fb0_.vscreen.red", "msb_right",
+          fb0_.vscreen.red.msb_right);
+    INFOF("%s.%s=%u", "fb0_.vscreen.green", "offset", fb0_.vscreen.green.offset);
+    INFOF("%s.%s=%u", "fb0_.vscreen.green", "length", fb0_.vscreen.green.length);
+    INFOF("%s.%s=%u", "fb0_.vscreen.green", "msb_right",
+          fb0_.vscreen.green.msb_right);
+    INFOF("%s.%s=%u", "fb0_.vscreen.blue", "offset", fb0_.vscreen.blue.offset);
+    INFOF("%s.%s=%u", "fb0_.vscreen.blue", "length", fb0_.vscreen.blue.length);
+    INFOF("%s.%s=%u", "fb0_.vscreen.blue", "msb_right",
+          fb0_.vscreen.blue.msb_right);
+    INFOF("%s.%s=%u", "fb0_.vscreen.transp", "offset",
+          fb0_.vscreen.transp.offset);
+    INFOF("%s.%s=%u", "fb0_.vscreen.transp", "length",
+          fb0_.vscreen.transp.length);
+    INFOF("%s.%s=%u", "fb0_.vscreen.transp", "msb_right",
+          fb0_.vscreen.transp.msb_right);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "nonstd", fb0_.vscreen.nonstd);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "activate", fb0_.vscreen.activate);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "height", fb0_.vscreen.height);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "width", fb0_.vscreen.width);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "accel_flags", fb0_.vscreen.accel_flags);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "pixclock", fb0_.vscreen.pixclock);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "left_margin", fb0_.vscreen.left_margin);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "right_margin", fb0_.vscreen.right_margin);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "upper_margin", fb0_.vscreen.upper_margin);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "lower_margin", fb0_.vscreen.lower_margin);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "hsync_len", fb0_.vscreen.hsync_len);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "vsync_len", fb0_.vscreen.vsync_len);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "sync", fb0_.vscreen.sync);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "vmode", fb0_.vscreen.vmode);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "rotate", fb0_.vscreen.rotate);
+    INFOF("%s.%s=%u", "fb0_.vscreen", "colorspace", fb0_.vscreen.colorspace);
     fb0_.size = fb0_.fscreen.smem_len;
     CHECK_NE(MAP_FAILED,
              (fb0_.map = mmap(NULL, fb0_.size, PROT_READ | PROT_WRITE,
@@ -1565,6 +1565,6 @@ int main(int argc, char *argv[]) {
     starttime_ = nowl();
     PrintVideo();
   }
-  LOGF("jb_ triggered");
+  INFOF("jb_ triggered");
   return 0;
 }


### PR DESCRIPTION
This PR renames `LOGF` to `INFOF` and `ANYF` to `LOGF`; `LOGF` now accepts log level, so it's a breaking change. I think I caught all the placed that need to be updated (including comments), but if there is a command to build all affected executables, I'll use it.

Along the same lines, should `LOGIFNEG1` and `LOGIFNULL` be named `WARNIFNEG1` and `WARNIFNULL`?
