### PR TITLE
Add error reporting to redbean Slurp

### DIFF
--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -4639,12 +4639,18 @@ static int LuaEncodeLatin1(lua_State *L) {
 }
 
 static int LuaSlurp(lua_State *L) {
-  char *p;
+  char *p, *f;
   size_t n;
-  p = xslurp(luaL_checkstring(L, 1), &n);
-  lua_pushlstring(L, p, n);
-  free(p);
-  return 1;
+  f = luaL_checkstring(L, 1);
+  if ((p = xslurp(f, &n))) {
+    lua_pushlstring(L, p, n);
+    free(p);
+    return 1;
+  } else {
+    lua_pushnil(L);
+    lua_pushstring(L, gc(xasprintf("Can't slurp file %`'s: %m", f)));
+    return 2;
+  }
 }
 
 static int LuaIndentLines(lua_State *L) {


### PR DESCRIPTION
This should allow `content = assert(Slurp(filename))` to work as
expected and report an error if file doesn't exist or can't be read.

@jart, I'm wondering if we can parse the Commentary field in `sysv/consts.sh` (or add a column) to get better error descriptions to use in `strerror/%m` instead of errno names (and keep errno names as the fallback)?. It'll slightly increase the exe size (maybe skip it for TINY), but should be quite manageable and make the error reports more user friendly.