### PR TITLE
Fix SSE scalar ops

### DIFF
--- a/libc/bits/xmmintrin.internal.h
+++ b/libc/bits/xmmintrin.internal.h
@@ -100,7 +100,7 @@ typedef float __m128_u _Vector_size(16) forcealign(1) mayalias;
 #define _mm_add_ss(m128_0, m128_1) \
   ({                               \
     __m128 a = m128_0;             \
-    __m128 b = m128_0;             \
+    __m128 b = m128_1;             \
     a[0] += b[0];                  \
     a;                             \
   })
@@ -108,7 +108,7 @@ typedef float __m128_u _Vector_size(16) forcealign(1) mayalias;
 #define _mm_sub_ss(m128_0, m128_1) \
   ({                               \
     __m128 a = m128_0;             \
-    __m128 b = m128_0;             \
+    __m128 b = m128_1;             \
     a[0] -= b[0];                  \
     a;                             \
   })
@@ -116,7 +116,7 @@ typedef float __m128_u _Vector_size(16) forcealign(1) mayalias;
 #define _mm_mul_ss(m128_0, m128_1) \
   ({                               \
     __m128 a = m128_0;             \
-    __m128 b = m128_0;             \
+    __m128 b = m128_1;             \
     a[0] *= b[0];                  \
     a;                             \
   })
@@ -124,7 +124,7 @@ typedef float __m128_u _Vector_size(16) forcealign(1) mayalias;
 #define _mm_div_ss(m128_0, m128_1) \
   ({                               \
     __m128 a = m128_0;             \
-    __m128 b = m128_0;             \
+    __m128 b = m128_1;             \
     a[0] /= b[0];                  \
     a;                             \
   })


### PR DESCRIPTION
I'm not 100% sure, but I think the patch is correct according to my reading of the [Intel Intrinsics Guide](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#expand=3,4882,4891,4944,193,7003&text=_mm_sub_ss).