### PR TITLE
Add clock polyfill on Windows

### DIFF
--- a/libc/calls/clock.c
+++ b/libc/calls/clock.c
@@ -19,6 +19,11 @@
 #include "libc/calls/struct/timespec.h"
 #include "libc/sysv/consts/clock.h"
 #include "libc/time/time.h"
+#include "libc/dce.h"
+#include "libc/nt/synchronization.h"
+#include "libc/nt/runtime.h"
+#include "libc/nt/accounting.h"
+#include "libc/fmt/conv.h"
 
 /**
  * Returns how much CPU program has consumed on time-sharing system.
@@ -28,7 +33,17 @@
  */
 int64_t clock(void) {
   struct timespec ts;
-  if (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts) == -1) return -1;
+  struct NtFileTime creation_time, exit_time, kernel_time, user_time;
+  int64_t proc, total;
+  // polyfill on Windows where CLOCK_PROCESS_CPUTIME_ID may be not available
+  if (IsWindows() && CLOCK_PROCESS_CPUTIME_ID == -1) {
+     proc = GetCurrentProcess();
+     if (!GetProcessTimes(proc, &creation_time,
+                          &exit_time, &kernel_time, &user_time)) return -1;
+     total = ReadFileTime(kernel_time) + ReadFileTime(user_time);
+     ts = WindowsDurationToTimeSpec(total);
+  }
+  else if (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts) == -1) return -1;
   return ts.tv_sec * CLOCKS_PER_SEC +
          ts.tv_nsec / (1000000000 / CLOCKS_PER_SEC);
 }


### PR DESCRIPTION
This helps if there is no LOCK_PROCESS_CPUTIME_ID on Windows.

This patch works, but it works too well, as it shows kernel+user time, but `clock()` on windows actually shows the wall time ("The clock function tells how much wall-clock time has passed since the CRT initialization during process start." from https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/clock) and that's why I suggested `CLOCK_MONOTONIC_RAW` minus the same value saved during the process initialization. Should I update the implementation?