### PR TITLE
Add zipimport hook at the end just in case

### DIFF
--- a/third_party/python/Python/import.c
+++ b/third_party/python/Python/import.c
@@ -152,8 +152,9 @@ _PyImportZip_Init(void)
                     "# can't import zipimport.zipimporter\n");
         }
         else {
-            /* sys.path_hooks.insert(0, zipimporter) */
-            err = PyList_Insert(path_hooks, 0, zipimporter);
+            /* sys.path_hooks.append(zipimporter) */
+            /* add this hook in case of import from external zip */
+            err = PyList_Append(path_hooks, zipimporter);
             Py_DECREF(zipimporter);
             if (err < 0) {
                 goto error;

--- a/third_party/python/Python/pylifecycle.c
+++ b/third_party/python/Python/pylifecycle.c
@@ -295,6 +295,8 @@ _Py_InitializeEx_Private(int install_sigs, int install_importlib)
         Py_XDECREF(warnings_module);
     }
 
+    _PyImportZip_Init();
+
     if (!Py_NoSiteFlag)
         _Py_InitSite(); /* Module site */
 }


### PR DESCRIPTION
```
In Python, the zipimport path hook is usually the first entry in
sys.path_hooks, so that any zip files in sys.path can be handled
correctly. In the APE, the zipimport hook was removed because it was
relatively slow compared to Cosmopolitan when it came to handling
imports from the APE's internal zip store.

However, some python scripts (for example when pip installs some
packages) modify sys.path to consider a local zip file, and then attempt
to import from it. This change prevents potential "unable to import"
errors in such cases, so that Actually Portable Python can be more of a
drop-in improved replacement.
```

You can check `python.com -v` (or use `ftrace` if unsure) to confirm that the zipimport hook does not interfere during any imports from the APE ZIP store during startup. (If zipimport did interfere, it would say something like `# zipimport: found <n> name(s) in <location>` or `imported via zipimport`, which it did earlier in #235).

Submitted this because some old script I had lying around didn't work with the APE until I made this change. I don't think it affects the APE startup time substantially.