### PR TITLE
contextmanager for ftrace

### DIFF
--- a/libc/runtime/ftracer.c
+++ b/libc/runtime/ftracer.c
@@ -43,6 +43,7 @@
 
 void ftrace_hook(void);
 
+bool ftrace_enabled;
 static int g_skew;
 static int g_lastsymbol;
 static uint64_t laststamp;
@@ -80,7 +81,7 @@ privileged noinstrument noasan void ftracer(void) {
   static bool noreentry;
   struct StackFrame *frame;
   if (!cmpxchg(&noreentry, 0, 1)) return;
-  if (g_symbols) {
+  if (ftrace_enabled && g_symbols) {
     stamp = rdtsc();
     frame = __builtin_frame_address(0);
     frame = frame->next;
@@ -103,6 +104,7 @@ textstartup void ftrace_install(void) {
       laststamp = kStartTsc;
       g_lastsymbol = -1;
       g_skew = GetNestingLevelImpl(__builtin_frame_address(0));
+      ftrace_enabled = 1;
       __hook(ftrace_hook, g_symbols);
     } else {
       __printf("error: --ftrace failed to open symbol table\r\n");

--- a/libc/runtime/runtime.h
+++ b/libc/runtime/runtime.h
@@ -34,6 +34,7 @@ extern unsigned char *__relo_start[];               /* αpε */
 extern unsigned char *__relo_end[];                 /* αpε */
 extern uint8_t __zip_start[];                       /* αpε */
 extern uint8_t __zip_end[];                         /* αpε */
+extern bool ftrace_enabled;
 
 void mcount(void);
 unsigned long getauxval(unsigned long);


### PR DESCRIPTION
Python likes to make a bunch of function calls for anything, so `ftrace`-ing a Python script from start to end produces a TON of info. `cosmo.ftrace()` + `cosmo.exit1()` are nice, but I have to still structure my Python script to exit right after a particular line.

As mentioned [here](https://github.com/jart/cosmopolitan/pull/264#issuecomment-912873761), This commit adds a simple contextmanager wrapper to `cosmo.ftrace()` so instead I can do things like this:

```python
import cosmo

with cosmo.ftrace(): # everything inside this will be logged to stderr
    a = 2 + 3

# logging disabled, do other things without having to terminate
print("a =", a)
```

the above snippet produces 32 lines of `ftrace` in stderr, which is much easier to examine:

```
+       sigprocmask 15481145
+ meth_dealloc 11490
+ PyFrame_BlockSetup 29
+ object_dealloc 389
+ PyObject_Free 61
+ _PyObject_Free.isra.0 14
+ PyDict_SetItem 372
+ insertdict 72
+   lookdict_unicode_nodummy 141
+   dictresize 133
+     new_keys_object 198
+       PyObject_Malloc 99
+       PyMem_Malloc 14
+       _PyObject_Alloc.isra.0 14
+         dlmalloc 54
+           dlmalloc_impl 14
+             tmalloc_large 78
+       memset 372
+       memset_avx 44
+       bzero 43
+       bzero_avx 38
+     PyObject_Free 197
+     _PyObject_Free.isra.0 10
+   find_empty_slot.isra.0 448
+ PyFrame_BlockPop 96
+ PyObject_CallFunctionObjArgs 252
+   objargs_mkstack.constprop.0 31
+   _PyObject_FastCallDict 55
+     _PyCFunction_FastCallDict 40
+       PyTuple_New 116
+       TracerObject_exit 150
a =  5
```