### PR TITLE
Don't pass unused args to printf in brailledump

### DIFF
--- a/tool/viz/bd.c
+++ b/tool/viz/bd.c
@@ -77,6 +77,6 @@ int main(int argc, char *argv[]) {
     }
     o += n;
   }
-  if (o) printf("%08x\n", o, A, B);
+  if (o) printf("%08x\n", o);
   return !feof(f);
 }


### PR DESCRIPTION
Justine,

I ported bd.c (as an exercise) and found a printf with too many arguments. I'm not sure if it would ever cause problems, or if it is gracefully handled in cosmopolitan (glibc didn't seem to give me any issues at least, but to be fair I didn't try to poke at it much).

--

The final print does not print any content, only the byte-offset of the
end-block, which makes the A, B params unused. From gcc:

    bd.c:77:17: warning: too many arguments for format [-Wformat-extra-args]
        if (o) printf("%08x\n", o, A, B);