### PR TITLE
Backporting METH_FASTCALL from Python 3.7

### DIFF
--- a/third_party/python/Include/abstract.h
+++ b/third_party/python/Include/abstract.h
@@ -19,11 +19,12 @@ PyObject *_PyStack_AsTupleSlice(PyObject **stack, Py_ssize_t nargs,
 
 PyObject *_PyStack_AsDict(PyObject **values, PyObject *kwnames);
 
-PyObject ** _PyStack_UnpackDict(
+int _PyStack_UnpackDict(
     PyObject **args,
     Py_ssize_t nargs,
     PyObject *kwargs,
-    PyObject **kwnames,
+    PyObject ***p_stack,
+    PyObject **p_kwnames,
     PyObject *func);
 
 PyObject *_PyObject_FastCallDict(PyObject *func, PyObject **args,

--- a/third_party/python/Include/abstract.h
+++ b/third_party/python/Include/abstract.h
@@ -14,6 +14,9 @@ PyObject *PyObject_Call(PyObject *callable_object, PyObject *args,
 
 #ifndef Py_LIMITED_API
 PyObject *_PyStack_AsTuple(PyObject **stack, Py_ssize_t nargs);
+PyObject *_PyStack_AsTupleSlice(PyObject **stack, Py_ssize_t nargs,
+                                Py_ssize_t start, Py_ssize_t end);
+
 PyObject *_PyStack_AsDict(PyObject **values, PyObject *kwnames);
 
 PyObject ** _PyStack_UnpackDict(

--- a/third_party/python/Include/abstract.h
+++ b/third_party/python/Include/abstract.h
@@ -42,6 +42,14 @@ PyObject *_PyObject_FastCallKeywords(PyObject *func, PyObject **args,
 PyObject *_PyObject_Call_Prepend(PyObject *func, PyObject *obj, PyObject *args,
                                  PyObject *kwargs);
 
+#define _PY_FASTCALL_SMALL_STACK 5
+
+PyObject *_PyObject_FastCall_Prepend(
+    PyObject *callable,
+    PyObject *obj,
+    PyObject **args,
+    Py_ssize_t nargs);
+
 #if IsModeDbg()
 PyObject *_Py_CheckFunctionResult(PyObject *func, PyObject *result,
                                   const char *where);

--- a/third_party/python/Include/abstract.h
+++ b/third_party/python/Include/abstract.h
@@ -24,8 +24,7 @@ int _PyStack_UnpackDict(
     Py_ssize_t nargs,
     PyObject *kwargs,
     PyObject ***p_stack,
-    PyObject **p_kwnames,
-    PyObject *func);
+    PyObject **p_kwnames);
 
 PyObject *_PyObject_FastCallDict(PyObject *func, PyObject **args,
                                  Py_ssize_t nargs, PyObject *kwargs);

--- a/third_party/python/Include/methodobject.h
+++ b/third_party/python/Include/methodobject.h
@@ -93,6 +93,12 @@ typedef struct {
     PyObject    *m_module; /* The __module__ attribute, can be anything */
     PyObject    *m_weakreflist; /* List of weak references */
 } PyCFunctionObject;
+PyObject * _PyMethodDef_RawFastCallDict(
+    PyMethodDef *method,
+    PyObject *self,
+    PyObject **args,
+    Py_ssize_t nargs,
+    PyObject *kwargs);
 #endif
 
 int PyCFunction_ClearFreeList(void);

--- a/third_party/python/Include/modsupport.h
+++ b/third_party/python/Include/modsupport.h
@@ -47,7 +47,8 @@ PyObject * Py_BuildValue(const char *, ...);
 PyObject * _Py_BuildValue_SizeT(const char *, ...);
 
 #ifndef Py_LIMITED_API
-int _PyArg_NoKeywords(const char *funcname, PyObject *kw);
+int _PyArg_NoKeywords(const char *funcname, PyObject *kwargs);
+int _PyArg_NoStackKeywords(const char *funcname, PyObject *kwnames);
 int _PyArg_NoPositional(const char *funcname, PyObject *args);
 #endif
 PyObject * Py_VaBuildValue(const char *, va_list);

--- a/third_party/python/Include/modsupport.h
+++ b/third_party/python/Include/modsupport.h
@@ -57,6 +57,12 @@ int _PyArg_UnpackStack(
 int _PyArg_NoKeywords(const char *funcname, PyObject *kwargs);
 int _PyArg_NoStackKeywords(const char *funcname, PyObject *kwnames);
 int _PyArg_NoPositional(const char *funcname, PyObject *args);
+#define _PyArg_NoKeywords(funcname, kwargs) \
+    ((kwargs) == NULL || _PyArg_NoKeywords((funcname), (kwargs)))
+#define _PyArg_NoStackKeywords(funcname, kwnames) \
+    ((kwnames) == NULL || _PyArg_NoStackKeywords((funcname), (kwnames)))
+#define _PyArg_NoPositional(funcname, args) \
+    ((args) == NULL || _PyArg_NoPositional((funcname), (args)))
 #endif
 PyObject * Py_VaBuildValue(const char *, va_list);
 

--- a/third_party/python/Include/modsupport.h
+++ b/third_party/python/Include/modsupport.h
@@ -66,12 +66,15 @@ typedef struct _PyArg_Parser {
 } _PyArg_Parser;
 #ifdef PY_SSIZE_T_CLEAN
 #define _PyArg_ParseTupleAndKeywordsFast  _PyArg_ParseTupleAndKeywordsFast_SizeT
-#define _PyArg_ParseStack  _PyArg_ParseStack_SizeT
+#define _PyArg_ParseStack _PyArg_ParseStack_SizeT
+#define _PyArg_ParseStackAndKeywords  _PyArg_ParseStackAndKeywords_SizeT
 #define _PyArg_VaParseTupleAndKeywordsFast  _PyArg_VaParseTupleAndKeywordsFast_SizeT
 #endif
 int _PyArg_ParseTupleAndKeywordsFast(PyObject *, PyObject *,
                                                  struct _PyArg_Parser *, ...);
-int _PyArg_ParseStack(PyObject **args, Py_ssize_t nargs, PyObject *kwnames,
+int _PyArg_ParseStack(PyObject **args, Py_ssize_t nargs,
+                    const char *format, ...);
+int _PyArg_ParseStackAndKeywords(PyObject **args, Py_ssize_t nargs, PyObject *kwnames,
                                   struct _PyArg_Parser *, ...);
 int _PyArg_VaParseTupleAndKeywordsFast(PyObject *, PyObject *,
                                                    struct _PyArg_Parser *, va_list);

--- a/third_party/python/Include/modsupport.h
+++ b/third_party/python/Include/modsupport.h
@@ -47,6 +47,13 @@ PyObject * Py_BuildValue(const char *, ...);
 PyObject * _Py_BuildValue_SizeT(const char *, ...);
 
 #ifndef Py_LIMITED_API
+int _PyArg_UnpackStack(
+    PyObject **args,
+    Py_ssize_t nargs,
+    const char *name,
+    Py_ssize_t min,
+    Py_ssize_t max,
+    ...);
 int _PyArg_NoKeywords(const char *funcname, PyObject *kwargs);
 int _PyArg_NoStackKeywords(const char *funcname, PyObject *kwnames);
 int _PyArg_NoPositional(const char *funcname, PyObject *args);

--- a/third_party/python/Lib/pickle.py
+++ b/third_party/python/Lib/pickle.py
@@ -1465,12 +1465,16 @@ class _Unpickler:
     def load_appends(self):
         items = self.pop_mark()
         list_obj = self.stack[-1]
-        if isinstance(list_obj, list):
-            list_obj.extend(items)
+        try:
+            extend = list_obj.extend
+        except AttributeError:
+            pass
         else:
-            append = list_obj.append
-            for item in items:
-                append(item)
+            extend(items)
+            return
+        append = list_obj.append
+        for item in items:
+            append(item)
     dispatch[APPENDS[0]] = load_appends
 
     def load_setitem(self):

--- a/third_party/python/Lib/test/test_dict.py
+++ b/third_party/python/Lib/test/test_dict.py
@@ -272,10 +272,56 @@ class DictTest(unittest.TestCase):
         self.assertEqual(baddict3.fromkeys({"a", "b", "c"}), res)
 
     def test_copy(self):
-        d = {1:1, 2:2, 3:3}
-        self.assertEqual(d.copy(), {1:1, 2:2, 3:3})
+        d = {1: 1, 2: 2, 3: 3}
+        self.assertIsNot(d.copy(), d)
+        self.assertEqual(d.copy(), d)
+        self.assertEqual(d.copy(), {1: 1, 2: 2, 3: 3})
+
+        copy = d.copy()
+        d[4] = 4
+        self.assertNotEqual(copy, d)
+
         self.assertEqual({}.copy(), {})
         self.assertRaises(TypeError, d.copy, None)
+
+    def test_copy_fuzz(self):
+        for dict_size in [10, 100, 1000, 10000, 100000]:
+            dict_size = random.randrange(
+                dict_size // 2, dict_size + dict_size // 2)
+            with self.subTest(dict_size=dict_size):
+                d = {}
+                for i in range(dict_size):
+                    d[i] = i
+
+                d2 = d.copy()
+                self.assertIsNot(d2, d)
+                self.assertEqual(d, d2)
+                d2['key'] = 'value'
+                self.assertNotEqual(d, d2)
+                self.assertEqual(len(d2), len(d) + 1)
+
+    def test_copy_maintains_tracking(self):
+        class A:
+            pass
+
+        key = A()
+
+        for d in ({}, {'a': 1}, {key: 'val'}):
+            d2 = d.copy()
+            self.assertEqual(gc.is_tracked(d), gc.is_tracked(d2))
+
+    def test_copy_noncompact(self):
+        # Dicts don't compact themselves on del/pop operations.
+        # Copy will use a slow merging strategy that produces
+        # a compacted copy when roughly 33% of dict is a non-used
+        # keys-space (to optimize memory footprint).
+        # In this test we want to hit the slow/compacting
+        # branch of dict.copy() and make sure it works OK.
+        d = {k: k for k in range(1000)}
+        for k in range(950):
+            del d[k]
+        d2 = d.copy()
+        self.assertEqual(d2, d)
 
     def test_get(self):
         d = {}

--- a/third_party/python/Lib/test/test_exceptions.py
+++ b/third_party/python/Lib/test/test_exceptions.py
@@ -1162,27 +1162,20 @@ class ExceptionTests(unittest.TestCase):
                 # The following line is included in the traceback report:
                 raise exc
 
-        class BrokenRepr(BrokenDel):
-            def __repr__(self):
-                raise AttributeError("repr() is broken")
-
         class BrokenExceptionDel:
             def __del__(self):
                 exc = BrokenStrException()
                 # The following line is included in the traceback report:
                 raise exc
 
-        for test_class in (BrokenDel, BrokenRepr, BrokenExceptionDel):
+        for test_class in (BrokenDel, BrokenExceptionDel):
             with self.subTest(test_class):
                 obj = test_class()
                 with captured_stderr() as stderr:
                     del obj
                 report = stderr.getvalue()
                 self.assertIn("Exception ignored", report)
-                if test_class is BrokenRepr:
-                    self.assertIn("<object repr() failed>", report)
-                else:
-                    self.assertIn(test_class.__del__.__qualname__, report)
+                self.assertIn(test_class.__del__.__qualname__, report)
                 self.assertIn("test_exceptions.py", report)
                 self.assertIn("raise exc", report)
                 if test_class is BrokenExceptionDel:

--- a/third_party/python/Modules/_collectionsmodule.c
+++ b/third_party/python/Modules/_collectionsmodule.c
@@ -936,12 +936,18 @@ done:
 }
 
 static PyObject *
-deque_rotate(dequeobject *deque, PyObject *args)
+deque_rotate(dequeobject *deque, PyObject **args, Py_ssize_t nargs,
+             PyObject *kwnames)
 {
     Py_ssize_t n=1;
 
-    if (!PyArg_ParseTuple(args, "|n:rotate", &n))
+    if (!_PyArg_NoStackKeywords("rotate", kwnames)) {
         return NULL;
+    }
+    if (!_PyArg_ParseStack(args, nargs, "|n:rotate", &n)) {
+        return NULL;
+    }
+
     if (!_deque_rotate(deque, n))
         Py_RETURN_NONE;
     return NULL;
@@ -1070,7 +1076,8 @@ deque_len(dequeobject *deque)
 }
 
 static PyObject *
-deque_index(dequeobject *deque, PyObject *args)
+deque_index(dequeobject *deque, PyObject **args, Py_ssize_t nargs,
+            PyObject *kwnames)
 {
     Py_ssize_t i, n, start=0, stop=Py_SIZE(deque);
     PyObject *v, *item;
@@ -1079,10 +1086,15 @@ deque_index(dequeobject *deque, PyObject *args)
     size_t start_state = deque->state;
     int cmp;
 
-    if (!PyArg_ParseTuple(args, "O|O&O&:index", &v,
-                                _PyEval_SliceIndexNotNone, &start,
-                                _PyEval_SliceIndexNotNone, &stop))
+    if (!_PyArg_NoStackKeywords("index", kwnames)) {
         return NULL;
+    }
+    if (!_PyArg_ParseStack(args, nargs, "O|O&O&:index", &v,
+                           _PyEval_SliceIndex, &start,
+                           _PyEval_SliceIndex, &stop)) {
+        return NULL;
+    }
+
     if (start < 0) {
         start += Py_SIZE(deque);
         if (start < 0)
@@ -1145,15 +1157,21 @@ PyDoc_STRVAR(index_doc,
 */
 
 static PyObject *
-deque_insert(dequeobject *deque, PyObject *args)
+deque_insert(dequeobject *deque, PyObject **args, Py_ssize_t nargs,
+             PyObject *kwnames)
 {
     Py_ssize_t index;
     Py_ssize_t n = Py_SIZE(deque);
     PyObject *value;
     PyObject *rv;
 
-    if (!PyArg_ParseTuple(args, "nO:insert", &index, &value))
+    if (!_PyArg_NoStackKeywords("insert", kwnames)) {
         return NULL;
+    }
+    if (!_PyArg_ParseStack(args, nargs, "nO:insert", &index, &value)) {
+        return NULL;
+    }
+
     if (deque->maxlen == Py_SIZE(deque)) {
         PyErr_SetString(PyExc_IndexError, "deque already at its maximum size");
         return NULL;
@@ -1623,9 +1641,9 @@ static PyMethodDef deque_methods[] = {
     {"extendleft",              (PyCFunction)deque_extendleft,
         METH_O,                  extendleft_doc},
     {"index",                   (PyCFunction)deque_index,
-        METH_VARARGS,            index_doc},
+        METH_FASTCALL,            index_doc},
     {"insert",                  (PyCFunction)deque_insert,
-        METH_VARARGS,            insert_doc},
+        METH_FASTCALL,            insert_doc},
     {"pop",                     (PyCFunction)deque_pop,
         METH_NOARGS,             pop_doc},
     {"popleft",                 (PyCFunction)deque_popleft,
@@ -1639,7 +1657,7 @@ static PyMethodDef deque_methods[] = {
     {"reverse",                 (PyCFunction)deque_reverse,
         METH_NOARGS,             reverse_doc},
     {"rotate",                  (PyCFunction)deque_rotate,
-        METH_VARARGS,            rotate_doc},
+        METH_FASTCALL,            rotate_doc},
     {"__sizeof__",              (PyCFunction)deque_sizeof,
         METH_NOARGS,             sizeof_doc},
     {NULL,              NULL}   /* sentinel */

--- a/third_party/python/Modules/_elementtree.c
+++ b/third_party/python/Modules/_elementtree.c
@@ -2807,7 +2807,8 @@ typedef struct {
 } XMLParserObject;
 
 static PyObject*
-_elementtree_XMLParser_doctype(XMLParserObject* self, PyObject* args);
+_elementtree_XMLParser_doctype(XMLParserObject* self, PyObject** args,
+                                Py_ssize_t nargs, PyObject* kwnames);
 static PyObject *
 _elementtree_XMLParser_doctype_impl(XMLParserObject *self, PyObject *name,
                                     PyObject *pubid, PyObject *system);

--- a/third_party/python/Modules/_io/clinic/_iomodule.inc
+++ b/third_party/python/Modules/_io/clinic/_iomodule.inc
@@ -131,6 +131,11 @@ PyDoc_STRVAR(_io_open__doc__,
     {"open", (PyCFunction)_io_open, METH_FASTCALL, _io_open__doc__},
 
 static PyObject *
+_io_open_impl(PyObject *module, PyObject *file, const char *mode,
+              int buffering, const char *encoding, const char *errors,
+              const char *newline, int closefd, PyObject *opener);
+
+static PyObject *
 _io_open(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
@@ -154,4 +159,4 @@ _io_open(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=c5b8fc8b83102bbf input=a9049054013a1b77]*/
+/*[clinic end generated code: output=79fd04d9c9d8f28f input=a9049054013a1b77]*/

--- a/third_party/python/Modules/_io/clinic/_iomodule.inc
+++ b/third_party/python/Modules/_io/clinic/_iomodule.inc
@@ -145,7 +145,7 @@ _io_open(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     int closefd = 1;
     PyObject *opener = Py_None;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &file, &mode, &buffering, &encoding, &errors, &newline, &closefd, &opener)) {
         goto exit;
     }

--- a/third_party/python/Modules/_io/clinic/bufferedio.inc
+++ b/third_party/python/Modules/_io/clinic/bufferedio.inc
@@ -11,6 +11,8 @@ PyDoc_STRVAR(_io__BufferedIOBase_readinto__doc__,
 #define _IO__BUFFEREDIOBASE_READINTO_METHODDEF    \
     {"readinto", (PyCFunction)_io__BufferedIOBase_readinto, METH_O, _io__BufferedIOBase_readinto__doc__},
 
+static PyObject *
+_io__BufferedIOBase_readinto_impl(PyObject *self, Py_buffer *buffer);
 
 static PyObject *
 _io__BufferedIOBase_readinto(PyObject *self, PyObject *arg)
@@ -90,19 +92,23 @@ PyDoc_STRVAR(_io__Buffered_peek__doc__,
 "\n");
 
 #define _IO__BUFFERED_PEEK_METHODDEF    \
-    {"peek", (PyCFunction)_io__Buffered_peek, METH_VARARGS, _io__Buffered_peek__doc__},
+    {"peek", (PyCFunction)_io__Buffered_peek, METH_FASTCALL, _io__Buffered_peek__doc__},
 
 static PyObject *
 _io__Buffered_peek_impl(buffered *self, Py_ssize_t size);
 
 static PyObject *
-_io__Buffered_peek(buffered *self, PyObject *args)
+_io__Buffered_peek(buffered *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_ssize_t size = 0;
 
-    if (!PyArg_ParseTuple(args, "|n:peek",
+    if (!_PyArg_ParseStack(args, nargs, "|n:peek",
         &size)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("peek", kwnames)) {
         goto exit;
     }
     return_value = _io__Buffered_peek_impl(self, size);
@@ -117,19 +123,23 @@ PyDoc_STRVAR(_io__Buffered_read__doc__,
 "\n");
 
 #define _IO__BUFFERED_READ_METHODDEF    \
-    {"read", (PyCFunction)_io__Buffered_read, METH_VARARGS, _io__Buffered_read__doc__},
+    {"read", (PyCFunction)_io__Buffered_read, METH_FASTCALL, _io__Buffered_read__doc__},
 
 static PyObject *
 _io__Buffered_read_impl(buffered *self, Py_ssize_t n);
 
 static PyObject *
-_io__Buffered_read(buffered *self, PyObject *args)
+_io__Buffered_read(buffered *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_ssize_t n = -1;
 
-    if (!PyArg_ParseTuple(args, "|O&:read",
+    if (!_PyArg_ParseStack(args, nargs, "|O&:read",
         _PyIO_ConvertSsize_t, &n)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("read", kwnames)) {
         goto exit;
     }
     return_value = _io__Buffered_read_impl(self, n);
@@ -232,19 +242,23 @@ PyDoc_STRVAR(_io__Buffered_readline__doc__,
 "\n");
 
 #define _IO__BUFFERED_READLINE_METHODDEF    \
-    {"readline", (PyCFunction)_io__Buffered_readline, METH_VARARGS, _io__Buffered_readline__doc__},
+    {"readline", (PyCFunction)_io__Buffered_readline, METH_FASTCALL, _io__Buffered_readline__doc__},
 
 static PyObject *
 _io__Buffered_readline_impl(buffered *self, Py_ssize_t size);
 
 static PyObject *
-_io__Buffered_readline(buffered *self, PyObject *args)
+_io__Buffered_readline(buffered *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!PyArg_ParseTuple(args, "|O&:readline",
+    if (!_PyArg_ParseStack(args, nargs, "|O&:readline",
         _PyIO_ConvertSsize_t, &size)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
         goto exit;
     }
     return_value = _io__Buffered_readline_impl(self, size);
@@ -259,20 +273,24 @@ PyDoc_STRVAR(_io__Buffered_seek__doc__,
 "\n");
 
 #define _IO__BUFFERED_SEEK_METHODDEF    \
-    {"seek", (PyCFunction)_io__Buffered_seek, METH_VARARGS, _io__Buffered_seek__doc__},
+    {"seek", (PyCFunction)_io__Buffered_seek, METH_FASTCALL, _io__Buffered_seek__doc__},
 
 static PyObject *
 _io__Buffered_seek_impl(buffered *self, PyObject *targetobj, int whence);
 
 static PyObject *
-_io__Buffered_seek(buffered *self, PyObject *args)
+_io__Buffered_seek(buffered *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *targetobj;
     int whence = 0;
 
-    if (!PyArg_ParseTuple(args, "O|i:seek",
+    if (!_PyArg_ParseStack(args, nargs, "O|i:seek",
         &targetobj, &whence)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
         goto exit;
     }
     return_value = _io__Buffered_seek_impl(self, targetobj, whence);
@@ -474,4 +492,4 @@ _io_BufferedRandom___init__(PyObject *self, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=a956f394ecde4cf9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c1127ca3a3f57d06 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/_io/clinic/bufferedio.inc
+++ b/third_party/python/Modules/_io/clinic/bufferedio.inc
@@ -305,20 +305,24 @@ PyDoc_STRVAR(_io__Buffered_truncate__doc__,
 "\n");
 
 #define _IO__BUFFERED_TRUNCATE_METHODDEF    \
-    {"truncate", (PyCFunction)_io__Buffered_truncate, METH_VARARGS, _io__Buffered_truncate__doc__},
+    {"truncate", (PyCFunction)_io__Buffered_truncate, METH_FASTCALL, _io__Buffered_truncate__doc__},
 
 static PyObject *
 _io__Buffered_truncate_impl(buffered *self, PyObject *pos);
 
 static PyObject *
-_io__Buffered_truncate(buffered *self, PyObject *args)
+_io__Buffered_truncate(buffered *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *pos = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "truncate",
+    if (!_PyArg_UnpackStack(args, nargs, "truncate",
         0, 1,
         &pos)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
         goto exit;
     }
     return_value = _io__Buffered_truncate_impl(self, pos);
@@ -492,4 +496,4 @@ _io_BufferedRandom___init__(PyObject *self, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=c1127ca3a3f57d06 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c526190c51a616c8 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/_io/clinic/bytesio.inc
+++ b/third_party/python/Modules/_io/clinic/bytesio.inc
@@ -159,20 +159,24 @@ PyDoc_STRVAR(_io_BytesIO_read__doc__,
 "Return an empty bytes object at EOF.");
 
 #define _IO_BYTESIO_READ_METHODDEF    \
-    {"read", (PyCFunction)_io_BytesIO_read, METH_VARARGS, _io_BytesIO_read__doc__},
+    {"read", (PyCFunction)_io_BytesIO_read, METH_FASTCALL, _io_BytesIO_read__doc__},
 
 static PyObject *
 _io_BytesIO_read_impl(bytesio *self, PyObject *arg);
 
 static PyObject *
-_io_BytesIO_read(bytesio *self, PyObject *args)
+_io_BytesIO_read(bytesio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *arg = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "read",
+    if (!_PyArg_UnpackStack(args, nargs, "read",
         0, 1,
         &arg)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("read", kwnames)) {
         goto exit;
     }
     return_value = _io_BytesIO_read_impl(self, arg);
@@ -204,20 +208,24 @@ PyDoc_STRVAR(_io_BytesIO_readline__doc__,
 "Return an empty bytes object at EOF.");
 
 #define _IO_BYTESIO_READLINE_METHODDEF    \
-    {"readline", (PyCFunction)_io_BytesIO_readline, METH_VARARGS, _io_BytesIO_readline__doc__},
+    {"readline", (PyCFunction)_io_BytesIO_readline, METH_FASTCALL, _io_BytesIO_readline__doc__},
 
 static PyObject *
 _io_BytesIO_readline_impl(bytesio *self, PyObject *arg);
 
 static PyObject *
-_io_BytesIO_readline(bytesio *self, PyObject *args)
+_io_BytesIO_readline(bytesio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *arg = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "readline",
+    if (!_PyArg_UnpackStack(args, nargs, "readline",
         0, 1,
         &arg)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
         goto exit;
     }
     return_value = _io_BytesIO_readline_impl(self, arg);
@@ -237,20 +245,24 @@ PyDoc_STRVAR(_io_BytesIO_readlines__doc__,
 "total number of bytes in the lines returned.");
 
 #define _IO_BYTESIO_READLINES_METHODDEF    \
-    {"readlines", (PyCFunction)_io_BytesIO_readlines, METH_VARARGS, _io_BytesIO_readlines__doc__},
+    {"readlines", (PyCFunction)_io_BytesIO_readlines, METH_FASTCALL, _io_BytesIO_readlines__doc__},
 
 static PyObject *
 _io_BytesIO_readlines_impl(bytesio *self, PyObject *arg);
 
 static PyObject *
-_io_BytesIO_readlines(bytesio *self, PyObject *args)
+_io_BytesIO_readlines(bytesio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *arg = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "readlines",
+    if (!_PyArg_UnpackStack(args, nargs, "readlines",
         0, 1,
         &arg)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("readlines", kwnames)) {
         goto exit;
     }
     return_value = _io_BytesIO_readlines_impl(self, arg);
@@ -304,20 +316,24 @@ PyDoc_STRVAR(_io_BytesIO_truncate__doc__,
 "The current file position is unchanged.  Returns the new size.");
 
 #define _IO_BYTESIO_TRUNCATE_METHODDEF    \
-    {"truncate", (PyCFunction)_io_BytesIO_truncate, METH_VARARGS, _io_BytesIO_truncate__doc__},
+    {"truncate", (PyCFunction)_io_BytesIO_truncate, METH_FASTCALL, _io_BytesIO_truncate__doc__},
 
 static PyObject *
 _io_BytesIO_truncate_impl(bytesio *self, PyObject *arg);
 
 static PyObject *
-_io_BytesIO_truncate(bytesio *self, PyObject *args)
+_io_BytesIO_truncate(bytesio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *arg = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "truncate",
+    if (!_PyArg_UnpackStack(args, nargs, "truncate",
         0, 1,
         &arg)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
         goto exit;
     }
     return_value = _io_BytesIO_truncate_impl(self, arg);
@@ -433,4 +449,4 @@ _io_BytesIO___init__(PyObject *self, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=2b2b78d39cdf6846 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=08139186b009ec47 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/_io/clinic/bytesio.inc
+++ b/third_party/python/Modules/_io/clinic/bytesio.inc
@@ -339,20 +339,24 @@ PyDoc_STRVAR(_io_BytesIO_seek__doc__,
 "Returns the new absolute position.");
 
 #define _IO_BYTESIO_SEEK_METHODDEF    \
-    {"seek", (PyCFunction)_io_BytesIO_seek, METH_VARARGS, _io_BytesIO_seek__doc__},
+    {"seek", (PyCFunction)_io_BytesIO_seek, METH_FASTCALL, _io_BytesIO_seek__doc__},
 
 static PyObject *
 _io_BytesIO_seek_impl(bytesio *self, Py_ssize_t pos, int whence);
 
 static PyObject *
-_io_BytesIO_seek(bytesio *self, PyObject *args)
+_io_BytesIO_seek(bytesio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_ssize_t pos;
     int whence = 0;
 
-    if (!PyArg_ParseTuple(args, "n|i:seek",
+    if (!_PyArg_ParseStack(args, nargs, "n|i:seek",
         &pos, &whence)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
         goto exit;
     }
     return_value = _io_BytesIO_seek_impl(self, pos, whence);
@@ -429,4 +433,4 @@ _io_BytesIO___init__(PyObject *self, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=6382e8eb578eea64 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2b2b78d39cdf6846 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/_io/clinic/fileio.inc
+++ b/third_party/python/Modules/_io/clinic/fileio.inc
@@ -337,20 +337,24 @@ PyDoc_STRVAR(_io_FileIO_truncate__doc__,
 "The current file position is changed to the value of size.");
 
 #define _IO_FILEIO_TRUNCATE_METHODDEF    \
-    {"truncate", (PyCFunction)_io_FileIO_truncate, METH_VARARGS, _io_FileIO_truncate__doc__},
+    {"truncate", (PyCFunction)_io_FileIO_truncate, METH_FASTCALL, _io_FileIO_truncate__doc__},
 
 static PyObject *
 _io_FileIO_truncate_impl(fileio *self, PyObject *posobj);
 
 static PyObject *
-_io_FileIO_truncate(fileio *self, PyObject *args)
+_io_FileIO_truncate(fileio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *posobj = NULL;
 
-    if (!PyArg_UnpackTuple(args, "truncate",
+    if (!_PyArg_UnpackStack(args, nargs, "truncate",
         0, 1,
         &posobj)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
         goto exit;
     }
     return_value = _io_FileIO_truncate_impl(self, posobj);
@@ -382,4 +386,4 @@ _io_FileIO_isatty(fileio *self, PyObject *Py_UNUSED(ignored))
 #ifndef _IO_FILEIO_TRUNCATE_METHODDEF
     #define _IO_FILEIO_TRUNCATE_METHODDEF
 #endif /* !defined(_IO_FILEIO_TRUNCATE_METHODDEF) */
-/*[clinic end generated code: output=5c2a0b493c0af58b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=034d782a0daa82bd input=a9049054013a1b77]*/

--- a/third_party/python/Modules/_io/clinic/fileio.inc
+++ b/third_party/python/Modules/_io/clinic/fileio.inc
@@ -16,6 +16,9 @@ PyDoc_STRVAR(_io_FileIO_close__doc__,
     {"close", (PyCFunction)_io_FileIO_close, METH_NOARGS, _io_FileIO_close__doc__},
 
 static PyObject *
+_io_FileIO_close_impl(fileio *self);
+
+static PyObject *
 _io_FileIO_close(fileio *self, PyObject *Py_UNUSED(ignored))
 {
     return _io_FileIO_close_impl(self);
@@ -38,6 +41,10 @@ PyDoc_STRVAR(_io_FileIO___init____doc__,
 "object is then obtained by calling opener with (*name*, *flags*).\n"
 "*opener* must return an open file descriptor (passing os.open as *opener*\n"
 "results in functionality similar to passing None).");
+
+static int
+_io_FileIO___init___impl(fileio *self, PyObject *nameobj, const char *mode,
+                         int closefd, PyObject *opener);
 
 static int
 _io_FileIO___init__(PyObject *self, PyObject *args, PyObject *kwargs)
@@ -196,19 +203,23 @@ PyDoc_STRVAR(_io_FileIO_read__doc__,
 "Return an empty bytes object at EOF.");
 
 #define _IO_FILEIO_READ_METHODDEF    \
-    {"read", (PyCFunction)_io_FileIO_read, METH_VARARGS, _io_FileIO_read__doc__},
+    {"read", (PyCFunction)_io_FileIO_read, METH_FASTCALL, _io_FileIO_read__doc__},
 
 static PyObject *
 _io_FileIO_read_impl(fileio *self, Py_ssize_t size);
 
 static PyObject *
-_io_FileIO_read(fileio *self, PyObject *args)
+_io_FileIO_read(fileio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!PyArg_ParseTuple(args, "|O&:read",
+    if (!_PyArg_ParseStack(args, nargs, "|O&:read",
         _PyIO_ConvertSsize_t, &size)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("read", kwnames)) {
         goto exit;
     }
     return_value = _io_FileIO_read_impl(self, size);
@@ -268,20 +279,24 @@ PyDoc_STRVAR(_io_FileIO_seek__doc__,
 "Note that not all file objects are seekable.");
 
 #define _IO_FILEIO_SEEK_METHODDEF    \
-    {"seek", (PyCFunction)_io_FileIO_seek, METH_VARARGS, _io_FileIO_seek__doc__},
+    {"seek", (PyCFunction)_io_FileIO_seek, METH_FASTCALL, _io_FileIO_seek__doc__},
 
 static PyObject *
 _io_FileIO_seek_impl(fileio *self, PyObject *pos, int whence);
 
 static PyObject *
-_io_FileIO_seek(fileio *self, PyObject *args)
+_io_FileIO_seek(fileio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *pos;
     int whence = 0;
 
-    if (!PyArg_ParseTuple(args, "O|i:seek",
+    if (!_PyArg_ParseStack(args, nargs, "O|i:seek",
         &pos, &whence)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
         goto exit;
     }
     return_value = _io_FileIO_seek_impl(self, pos, whence);
@@ -367,4 +382,4 @@ _io_FileIO_isatty(fileio *self, PyObject *Py_UNUSED(ignored))
 #ifndef _IO_FILEIO_TRUNCATE_METHODDEF
     #define _IO_FILEIO_TRUNCATE_METHODDEF
 #endif /* !defined(_IO_FILEIO_TRUNCATE_METHODDEF) */
-/*[clinic end generated code: output=51924bc0ee11d58e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5c2a0b493c0af58b input=a9049054013a1b77]*/

--- a/third_party/python/Modules/_io/clinic/iobase.inc
+++ b/third_party/python/Modules/_io/clinic/iobase.inc
@@ -13,6 +13,9 @@ PyDoc_STRVAR(_io__IOBase_tell__doc__,
     {"tell", (PyCFunction)_io__IOBase_tell, METH_NOARGS, _io__IOBase_tell__doc__},
 
 static PyObject *
+_io__IOBase_tell_impl(PyObject *self);
+
+static PyObject *
 _io__IOBase_tell(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _io__IOBase_tell_impl(self);
@@ -30,6 +33,9 @@ PyDoc_STRVAR(_io__IOBase_flush__doc__,
     {"flush", (PyCFunction)_io__IOBase_flush, METH_NOARGS, _io__IOBase_flush__doc__},
 
 static PyObject *
+_io__IOBase_flush_impl(PyObject *self);
+
+static PyObject *
 _io__IOBase_flush(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _io__IOBase_flush_impl(self);
@@ -45,6 +51,9 @@ PyDoc_STRVAR(_io__IOBase_close__doc__,
 
 #define _IO__IOBASE_CLOSE_METHODDEF    \
     {"close", (PyCFunction)_io__IOBase_close, METH_NOARGS, _io__IOBase_close__doc__},
+
+static PyObject *
+_io__IOBase_close_impl(PyObject *self);
 
 static PyObject *
 _io__IOBase_close(PyObject *self, PyObject *Py_UNUSED(ignored))
@@ -65,6 +74,9 @@ PyDoc_STRVAR(_io__IOBase_seekable__doc__,
     {"seekable", (PyCFunction)_io__IOBase_seekable, METH_NOARGS, _io__IOBase_seekable__doc__},
 
 static PyObject *
+_io__IOBase_seekable_impl(PyObject *self);
+
+static PyObject *
 _io__IOBase_seekable(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _io__IOBase_seekable_impl(self);
@@ -80,6 +92,9 @@ PyDoc_STRVAR(_io__IOBase_readable__doc__,
 
 #define _IO__IOBASE_READABLE_METHODDEF    \
     {"readable", (PyCFunction)_io__IOBase_readable, METH_NOARGS, _io__IOBase_readable__doc__},
+
+static PyObject *
+_io__IOBase_readable_impl(PyObject *self);
 
 static PyObject *
 _io__IOBase_readable(PyObject *self, PyObject *Py_UNUSED(ignored))
@@ -99,6 +114,9 @@ PyDoc_STRVAR(_io__IOBase_writable__doc__,
     {"writable", (PyCFunction)_io__IOBase_writable, METH_NOARGS, _io__IOBase_writable__doc__},
 
 static PyObject *
+_io__IOBase_writable_impl(PyObject *self);
+
+static PyObject *
 _io__IOBase_writable(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _io__IOBase_writable_impl(self);
@@ -116,6 +134,9 @@ PyDoc_STRVAR(_io__IOBase_fileno__doc__,
     {"fileno", (PyCFunction)_io__IOBase_fileno, METH_NOARGS, _io__IOBase_fileno__doc__},
 
 static PyObject *
+_io__IOBase_fileno_impl(PyObject *self);
+
+static PyObject *
 _io__IOBase_fileno(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _io__IOBase_fileno_impl(self);
@@ -131,6 +152,9 @@ PyDoc_STRVAR(_io__IOBase_isatty__doc__,
 
 #define _IO__IOBASE_ISATTY_METHODDEF    \
     {"isatty", (PyCFunction)_io__IOBase_isatty, METH_NOARGS, _io__IOBase_isatty__doc__},
+
+static PyObject *
+_io__IOBase_isatty_impl(PyObject *self);
 
 static PyObject *
 _io__IOBase_isatty(PyObject *self, PyObject *Py_UNUSED(ignored))
@@ -151,16 +175,23 @@ PyDoc_STRVAR(_io__IOBase_readline__doc__,
 "terminator(s) recognized.");
 
 #define _IO__IOBASE_READLINE_METHODDEF    \
-    {"readline", (PyCFunction)_io__IOBase_readline, METH_VARARGS, _io__IOBase_readline__doc__},
+    {"readline", (PyCFunction)_io__IOBase_readline, METH_FASTCALL, _io__IOBase_readline__doc__},
 
 static PyObject *
-_io__IOBase_readline(PyObject *self, PyObject *args)
+_io__IOBase_readline_impl(PyObject *self, Py_ssize_t limit);
+
+static PyObject *
+_io__IOBase_readline(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_ssize_t limit = -1;
 
-    if (!PyArg_ParseTuple(args, "|O&:readline",
+    if (!_PyArg_ParseStack(args, nargs, "|O&:readline",
         _PyIO_ConvertSsize_t, &limit)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
         goto exit;
     }
     return_value = _io__IOBase_readline_impl(self, limit);
@@ -180,16 +211,23 @@ PyDoc_STRVAR(_io__IOBase_readlines__doc__,
 "lines so far exceeds hint.");
 
 #define _IO__IOBASE_READLINES_METHODDEF    \
-    {"readlines", (PyCFunction)_io__IOBase_readlines, METH_VARARGS, _io__IOBase_readlines__doc__},
+    {"readlines", (PyCFunction)_io__IOBase_readlines, METH_FASTCALL, _io__IOBase_readlines__doc__},
 
 static PyObject *
-_io__IOBase_readlines(PyObject *self, PyObject *args)
+_io__IOBase_readlines_impl(PyObject *self, Py_ssize_t hint);
+
+static PyObject *
+_io__IOBase_readlines(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_ssize_t hint = -1;
 
-    if (!PyArg_ParseTuple(args, "|O&:readlines",
+    if (!_PyArg_ParseStack(args, nargs, "|O&:readlines",
         _PyIO_ConvertSsize_t, &hint)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("readlines", kwnames)) {
         goto exit;
     }
     return_value = _io__IOBase_readlines_impl(self, hint);
@@ -212,19 +250,23 @@ PyDoc_STRVAR(_io__RawIOBase_read__doc__,
 "\n");
 
 #define _IO__RAWIOBASE_READ_METHODDEF    \
-    {"read", (PyCFunction)_io__RawIOBase_read, METH_VARARGS, _io__RawIOBase_read__doc__},
+    {"read", (PyCFunction)_io__RawIOBase_read, METH_FASTCALL, _io__RawIOBase_read__doc__},
 
 static PyObject *
 _io__RawIOBase_read_impl(PyObject *self, Py_ssize_t n);
 
 static PyObject *
-_io__RawIOBase_read(PyObject *self, PyObject *args)
+_io__RawIOBase_read(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_ssize_t n = -1;
 
-    if (!PyArg_ParseTuple(args, "|n:read",
+    if (!_PyArg_ParseStack(args, nargs, "|n:read",
         &n)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("read", kwnames)) {
         goto exit;
     }
     return_value = _io__RawIOBase_read_impl(self, n);
@@ -250,4 +292,4 @@ _io__RawIOBase_readall(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _io__RawIOBase_readall_impl(self);
 }
-/*[clinic end generated code: output=0f53fed928d8e02f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1bcece367fc7b0cd input=a9049054013a1b77]*/

--- a/third_party/python/Modules/_io/clinic/stringio.inc
+++ b/third_party/python/Modules/_io/clinic/stringio.inc
@@ -13,6 +13,9 @@ PyDoc_STRVAR(_io_StringIO_getvalue__doc__,
     {"getvalue", (PyCFunction)_io_StringIO_getvalue, METH_NOARGS, _io_StringIO_getvalue__doc__},
 
 static PyObject *
+_io_StringIO_getvalue_impl(stringio *self);
+
+static PyObject *
 _io_StringIO_getvalue(stringio *self, PyObject *Py_UNUSED(ignored))
 {
     return _io_StringIO_getvalue_impl(self);
@@ -145,20 +148,24 @@ PyDoc_STRVAR(_io_StringIO_seek__doc__,
 "Returns the new absolute position.");
 
 #define _IO_STRINGIO_SEEK_METHODDEF    \
-    {"seek", (PyCFunction)_io_StringIO_seek, METH_VARARGS, _io_StringIO_seek__doc__},
+    {"seek", (PyCFunction)_io_StringIO_seek, METH_FASTCALL, _io_StringIO_seek__doc__},
 
 static PyObject *
 _io_StringIO_seek_impl(stringio *self, Py_ssize_t pos, int whence);
 
 static PyObject *
-_io_StringIO_seek(stringio *self, PyObject *args)
+_io_StringIO_seek(stringio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_ssize_t pos;
     int whence = 0;
 
-    if (!PyArg_ParseTuple(args, "n|i:seek",
+    if (!_PyArg_ParseStack(args, nargs, "n|i:seek",
         &pos, &whence)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
         goto exit;
     }
     return_value = _io_StringIO_seek_impl(self, pos, whence);
@@ -287,4 +294,4 @@ _io_StringIO_seekable(stringio *self, PyObject *Py_UNUSED(ignored))
 {
     return _io_StringIO_seekable_impl(self);
 }
-/*[clinic end generated code: output=5dd5c2a213e75405 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=69bf262268745061 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/_io/clinic/stringio.inc
+++ b/third_party/python/Modules/_io/clinic/stringio.inc
@@ -49,20 +49,24 @@ PyDoc_STRVAR(_io_StringIO_read__doc__,
 "is reached. Return an empty string at EOF.");
 
 #define _IO_STRINGIO_READ_METHODDEF    \
-    {"read", (PyCFunction)_io_StringIO_read, METH_VARARGS, _io_StringIO_read__doc__},
+    {"read", (PyCFunction)_io_StringIO_read, METH_FASTCALL, _io_StringIO_read__doc__},
 
 static PyObject *
 _io_StringIO_read_impl(stringio *self, PyObject *arg);
 
 static PyObject *
-_io_StringIO_read(stringio *self, PyObject *args)
+_io_StringIO_read(stringio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *arg = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "read",
+    if (!_PyArg_UnpackStack(args, nargs, "read",
         0, 1,
         &arg)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("read", kwnames)) {
         goto exit;
     }
     return_value = _io_StringIO_read_impl(self, arg);
@@ -80,20 +84,24 @@ PyDoc_STRVAR(_io_StringIO_readline__doc__,
 "Returns an empty string if EOF is hit immediately.");
 
 #define _IO_STRINGIO_READLINE_METHODDEF    \
-    {"readline", (PyCFunction)_io_StringIO_readline, METH_VARARGS, _io_StringIO_readline__doc__},
+    {"readline", (PyCFunction)_io_StringIO_readline, METH_FASTCALL, _io_StringIO_readline__doc__},
 
 static PyObject *
 _io_StringIO_readline_impl(stringio *self, PyObject *arg);
 
 static PyObject *
-_io_StringIO_readline(stringio *self, PyObject *args)
+_io_StringIO_readline(stringio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *arg = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "readline",
+    if (!_PyArg_UnpackStack(args, nargs, "readline",
         0, 1,
         &arg)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
         goto exit;
     }
     return_value = _io_StringIO_readline_impl(self, arg);
@@ -113,20 +121,24 @@ PyDoc_STRVAR(_io_StringIO_truncate__doc__,
 "Returns the new absolute position.");
 
 #define _IO_STRINGIO_TRUNCATE_METHODDEF    \
-    {"truncate", (PyCFunction)_io_StringIO_truncate, METH_VARARGS, _io_StringIO_truncate__doc__},
+    {"truncate", (PyCFunction)_io_StringIO_truncate, METH_FASTCALL, _io_StringIO_truncate__doc__},
 
 static PyObject *
 _io_StringIO_truncate_impl(stringio *self, PyObject *arg);
 
 static PyObject *
-_io_StringIO_truncate(stringio *self, PyObject *args)
+_io_StringIO_truncate(stringio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *arg = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "truncate",
+    if (!_PyArg_UnpackStack(args, nargs, "truncate",
         0, 1,
         &arg)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
         goto exit;
     }
     return_value = _io_StringIO_truncate_impl(self, arg);
@@ -294,4 +306,4 @@ _io_StringIO_seekable(stringio *self, PyObject *Py_UNUSED(ignored))
 {
     return _io_StringIO_seekable_impl(self);
 }
-/*[clinic end generated code: output=69bf262268745061 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ce8018ec29def422 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/_io/clinic/textio.inc
+++ b/third_party/python/Modules/_io/clinic/textio.inc
@@ -1,9 +1,3 @@
-/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:4;tab-width:8;coding:utf-8 -*-│
-│vi: set net ft=c ts=4 sts=4 sw=4 fenc=utf-8                                :vi│
-╞══════════════════════════════════════════════════════════════════════════════╡
-│ Python 3                                                                     │
-│ https://docs.python.org/3/license.html                                       │
-╚─────────────────────────────────────────────────────────────────────────────*/
 /* clang-format off */
 /*[clinic input]
 preserve
@@ -232,19 +226,23 @@ PyDoc_STRVAR(_io_TextIOWrapper_read__doc__,
 "\n");
 
 #define _IO_TEXTIOWRAPPER_READ_METHODDEF    \
-    {"read", (PyCFunction)_io_TextIOWrapper_read, METH_VARARGS, _io_TextIOWrapper_read__doc__},
+    {"read", (PyCFunction)_io_TextIOWrapper_read, METH_FASTCALL, _io_TextIOWrapper_read__doc__},
 
 static PyObject *
 _io_TextIOWrapper_read_impl(textio *self, Py_ssize_t n);
 
 static PyObject *
-_io_TextIOWrapper_read(textio *self, PyObject *args)
+_io_TextIOWrapper_read(textio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_ssize_t n = -1;
 
-    if (!PyArg_ParseTuple(args, "|O&:read",
+    if (!_PyArg_ParseStack(args, nargs, "|O&:read",
         _PyIO_ConvertSsize_t, &n)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("read", kwnames)) {
         goto exit;
     }
     return_value = _io_TextIOWrapper_read_impl(self, n);
@@ -259,19 +257,23 @@ PyDoc_STRVAR(_io_TextIOWrapper_readline__doc__,
 "\n");
 
 #define _IO_TEXTIOWRAPPER_READLINE_METHODDEF    \
-    {"readline", (PyCFunction)_io_TextIOWrapper_readline, METH_VARARGS, _io_TextIOWrapper_readline__doc__},
+    {"readline", (PyCFunction)_io_TextIOWrapper_readline, METH_FASTCALL, _io_TextIOWrapper_readline__doc__},
 
 static PyObject *
 _io_TextIOWrapper_readline_impl(textio *self, Py_ssize_t size);
 
 static PyObject *
-_io_TextIOWrapper_readline(textio *self, PyObject *args)
+_io_TextIOWrapper_readline(textio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!PyArg_ParseTuple(args, "|n:readline",
+    if (!_PyArg_ParseStack(args, nargs, "|n:readline",
         &size)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
         goto exit;
     }
     return_value = _io_TextIOWrapper_readline_impl(self, size);
@@ -286,20 +288,24 @@ PyDoc_STRVAR(_io_TextIOWrapper_seek__doc__,
 "\n");
 
 #define _IO_TEXTIOWRAPPER_SEEK_METHODDEF    \
-    {"seek", (PyCFunction)_io_TextIOWrapper_seek, METH_VARARGS, _io_TextIOWrapper_seek__doc__},
+    {"seek", (PyCFunction)_io_TextIOWrapper_seek, METH_FASTCALL, _io_TextIOWrapper_seek__doc__},
 
 static PyObject *
 _io_TextIOWrapper_seek_impl(textio *self, PyObject *cookieObj, int whence);
 
 static PyObject *
-_io_TextIOWrapper_seek(textio *self, PyObject *args)
+_io_TextIOWrapper_seek(textio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *cookieObj;
     int whence = 0;
 
-    if (!PyArg_ParseTuple(args, "O|i:seek",
+    if (!_PyArg_ParseStack(args, nargs, "O|i:seek",
         &cookieObj, &whence)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
         goto exit;
     }
     return_value = _io_TextIOWrapper_seek_impl(self, cookieObj, whence);
@@ -471,4 +477,4 @@ _io_TextIOWrapper_close(textio *self, PyObject *Py_UNUSED(ignored))
 {
     return _io_TextIOWrapper_close_impl(self);
 }
-/*[clinic end generated code: output=78ad14eba1667254 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1f8367c7a3301670 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/_io/clinic/textio.inc
+++ b/third_party/python/Modules/_io/clinic/textio.inc
@@ -68,7 +68,7 @@ _io_IncrementalNewlineDecoder_decode(nldecoder_object *self, PyObject **args, Py
     PyObject *input;
     int final = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &input, &final)) {
         goto exit;
     }

--- a/third_party/python/Modules/_io/clinic/textio.inc
+++ b/third_party/python/Modules/_io/clinic/textio.inc
@@ -337,20 +337,24 @@ PyDoc_STRVAR(_io_TextIOWrapper_truncate__doc__,
 "\n");
 
 #define _IO_TEXTIOWRAPPER_TRUNCATE_METHODDEF    \
-    {"truncate", (PyCFunction)_io_TextIOWrapper_truncate, METH_VARARGS, _io_TextIOWrapper_truncate__doc__},
+    {"truncate", (PyCFunction)_io_TextIOWrapper_truncate, METH_FASTCALL, _io_TextIOWrapper_truncate__doc__},
 
 static PyObject *
 _io_TextIOWrapper_truncate_impl(textio *self, PyObject *pos);
 
 static PyObject *
-_io_TextIOWrapper_truncate(textio *self, PyObject *args)
+_io_TextIOWrapper_truncate(textio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *pos = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "truncate",
+    if (!_PyArg_UnpackStack(args, nargs, "truncate",
         0, 1,
         &pos)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
         goto exit;
     }
     return_value = _io_TextIOWrapper_truncate_impl(self, pos);
@@ -477,4 +481,4 @@ _io_TextIOWrapper_close(textio *self, PyObject *Py_UNUSED(ignored))
 {
     return _io_TextIOWrapper_close_impl(self);
 }
-/*[clinic end generated code: output=1f8367c7a3301670 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=67eba50449900a96 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/_io/clinic/winconsoleio.inc
+++ b/third_party/python/Modules/_io/clinic/winconsoleio.inc
@@ -3,8 +3,6 @@
 preserve
 [clinic start generated code]*/
 
-#if defined(MS_WINDOWS)
-
 PyDoc_STRVAR(_io__WindowsConsoleIO_close__doc__,
 "close($self, /)\n"
 "--\n"
@@ -25,10 +23,6 @@ _io__WindowsConsoleIO_close(winconsoleio *self, PyObject *Py_UNUSED(ignored))
 {
     return _io__WindowsConsoleIO_close_impl(self);
 }
-
-#endif /* defined(MS_WINDOWS) */
-
-#if defined(MS_WINDOWS)
 
 PyDoc_STRVAR(_io__WindowsConsoleIO___init____doc__,
 "_WindowsConsoleIO(file, mode=\'r\', closefd=True, opener=None)\n"
@@ -66,10 +60,6 @@ exit:
     return return_value;
 }
 
-#endif /* defined(MS_WINDOWS) */
-
-#if defined(MS_WINDOWS)
-
 PyDoc_STRVAR(_io__WindowsConsoleIO_fileno__doc__,
 "fileno($self, /)\n"
 "--\n"
@@ -91,10 +81,6 @@ _io__WindowsConsoleIO_fileno(winconsoleio *self, PyObject *Py_UNUSED(ignored))
     return _io__WindowsConsoleIO_fileno_impl(self);
 }
 
-#endif /* defined(MS_WINDOWS) */
-
-#if defined(MS_WINDOWS)
-
 PyDoc_STRVAR(_io__WindowsConsoleIO_readable__doc__,
 "readable($self, /)\n"
 "--\n"
@@ -113,10 +99,6 @@ _io__WindowsConsoleIO_readable(winconsoleio *self, PyObject *Py_UNUSED(ignored))
     return _io__WindowsConsoleIO_readable_impl(self);
 }
 
-#endif /* defined(MS_WINDOWS) */
-
-#if defined(MS_WINDOWS)
-
 PyDoc_STRVAR(_io__WindowsConsoleIO_writable__doc__,
 "writable($self, /)\n"
 "--\n"
@@ -134,10 +116,6 @@ _io__WindowsConsoleIO_writable(winconsoleio *self, PyObject *Py_UNUSED(ignored))
 {
     return _io__WindowsConsoleIO_writable_impl(self);
 }
-
-#endif /* defined(MS_WINDOWS) */
-
-#if defined(MS_WINDOWS)
 
 PyDoc_STRVAR(_io__WindowsConsoleIO_readinto__doc__,
 "readinto($self, buffer, /)\n"
@@ -171,10 +149,6 @@ exit:
     return return_value;
 }
 
-#endif /* defined(MS_WINDOWS) */
-
-#if defined(MS_WINDOWS)
-
 PyDoc_STRVAR(_io__WindowsConsoleIO_readall__doc__,
 "readall($self, /)\n"
 "--\n"
@@ -195,10 +169,6 @@ _io__WindowsConsoleIO_readall(winconsoleio *self, PyObject *Py_UNUSED(ignored))
     return _io__WindowsConsoleIO_readall_impl(self);
 }
 
-#endif /* defined(MS_WINDOWS) */
-
-#if defined(MS_WINDOWS)
-
 PyDoc_STRVAR(_io__WindowsConsoleIO_read__doc__,
 "read($self, size=-1, /)\n"
 "--\n"
@@ -210,19 +180,23 @@ PyDoc_STRVAR(_io__WindowsConsoleIO_read__doc__,
 "Return an empty bytes object at EOF.");
 
 #define _IO__WINDOWSCONSOLEIO_READ_METHODDEF    \
-    {"read", (PyCFunction)_io__WindowsConsoleIO_read, METH_VARARGS, _io__WindowsConsoleIO_read__doc__},
+    {"read", (PyCFunction)_io__WindowsConsoleIO_read, METH_FASTCALL, _io__WindowsConsoleIO_read__doc__},
 
 static PyObject *
 _io__WindowsConsoleIO_read_impl(winconsoleio *self, Py_ssize_t size);
 
 static PyObject *
-_io__WindowsConsoleIO_read(winconsoleio *self, PyObject *args)
+_io__WindowsConsoleIO_read(winconsoleio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!PyArg_ParseTuple(args, "|O&:read",
+    if (!_PyArg_ParseStack(args, nargs, "|O&:read",
         _PyIO_ConvertSsize_t, &size)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("read", kwnames)) {
         goto exit;
     }
     return_value = _io__WindowsConsoleIO_read_impl(self, size);
@@ -230,10 +204,6 @@ _io__WindowsConsoleIO_read(winconsoleio *self, PyObject *args)
 exit:
     return return_value;
 }
-
-#endif /* defined(MS_WINDOWS) */
-
-#if defined(MS_WINDOWS)
 
 PyDoc_STRVAR(_io__WindowsConsoleIO_write__doc__,
 "write($self, b, /)\n"
@@ -270,10 +240,6 @@ exit:
     return return_value;
 }
 
-#endif /* defined(MS_WINDOWS) */
-
-#if defined(MS_WINDOWS)
-
 PyDoc_STRVAR(_io__WindowsConsoleIO_isatty__doc__,
 "isatty($self, /)\n"
 "--\n"
@@ -291,42 +257,4 @@ _io__WindowsConsoleIO_isatty(winconsoleio *self, PyObject *Py_UNUSED(ignored))
 {
     return _io__WindowsConsoleIO_isatty_impl(self);
 }
-
-#endif /* defined(MS_WINDOWS) */
-
-#ifndef _IO__WINDOWSCONSOLEIO_CLOSE_METHODDEF
-    #define _IO__WINDOWSCONSOLEIO_CLOSE_METHODDEF
-#endif /* !defined(_IO__WINDOWSCONSOLEIO_CLOSE_METHODDEF) */
-
-#ifndef _IO__WINDOWSCONSOLEIO_FILENO_METHODDEF
-    #define _IO__WINDOWSCONSOLEIO_FILENO_METHODDEF
-#endif /* !defined(_IO__WINDOWSCONSOLEIO_FILENO_METHODDEF) */
-
-#ifndef _IO__WINDOWSCONSOLEIO_READABLE_METHODDEF
-    #define _IO__WINDOWSCONSOLEIO_READABLE_METHODDEF
-#endif /* !defined(_IO__WINDOWSCONSOLEIO_READABLE_METHODDEF) */
-
-#ifndef _IO__WINDOWSCONSOLEIO_WRITABLE_METHODDEF
-    #define _IO__WINDOWSCONSOLEIO_WRITABLE_METHODDEF
-#endif /* !defined(_IO__WINDOWSCONSOLEIO_WRITABLE_METHODDEF) */
-
-#ifndef _IO__WINDOWSCONSOLEIO_READINTO_METHODDEF
-    #define _IO__WINDOWSCONSOLEIO_READINTO_METHODDEF
-#endif /* !defined(_IO__WINDOWSCONSOLEIO_READINTO_METHODDEF) */
-
-#ifndef _IO__WINDOWSCONSOLEIO_READALL_METHODDEF
-    #define _IO__WINDOWSCONSOLEIO_READALL_METHODDEF
-#endif /* !defined(_IO__WINDOWSCONSOLEIO_READALL_METHODDEF) */
-
-#ifndef _IO__WINDOWSCONSOLEIO_READ_METHODDEF
-    #define _IO__WINDOWSCONSOLEIO_READ_METHODDEF
-#endif /* !defined(_IO__WINDOWSCONSOLEIO_READ_METHODDEF) */
-
-#ifndef _IO__WINDOWSCONSOLEIO_WRITE_METHODDEF
-    #define _IO__WINDOWSCONSOLEIO_WRITE_METHODDEF
-#endif /* !defined(_IO__WINDOWSCONSOLEIO_WRITE_METHODDEF) */
-
-#ifndef _IO__WINDOWSCONSOLEIO_ISATTY_METHODDEF
-    #define _IO__WINDOWSCONSOLEIO_ISATTY_METHODDEF
-#endif /* !defined(_IO__WINDOWSCONSOLEIO_ISATTY_METHODDEF) */
-/*[clinic end generated code: output=9eba916f8537fff7 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b097ceeb54d6e15e input=a9049054013a1b77]*/

--- a/third_party/python/Modules/_io/winconsoleio.c
+++ b/third_party/python/Modules/_io/winconsoleio.c
@@ -1179,5 +1179,3 @@ PyTypeObject PyWindowsConsoleIO_Type = {
 };
 
 PyAPI_DATA(PyObject *) _PyWindowsConsoleIO_Type = (PyObject*)&PyWindowsConsoleIO_Type;
-
-#endif /* MS_WINDOWS */

--- a/third_party/python/Modules/_pickle.c
+++ b/third_party/python/Modules/_pickle.c
@@ -5983,7 +5983,6 @@ do_append(UnpicklerObject *self, Py_ssize_t x)
                 return -1;
             }
             result = _Pickle_FastCall(extend_func, slice);
-            Py_DECREF(slice);
             Py_DECREF(extend_func);
             if (result == NULL)
                 return -1;

--- a/third_party/python/Modules/_pickle.c
+++ b/third_party/python/Modules/_pickle.c
@@ -5946,6 +5946,8 @@ static int
 do_append(UnpicklerObject *self, Py_ssize_t x)
 {
     PyObject *value;
+    PyObject *slice;
+    PyObject *result;
     PyObject *list;
     Py_ssize_t len, i;
 
@@ -5957,8 +5959,7 @@ do_append(UnpicklerObject *self, Py_ssize_t x)
 
     list = self->stack->data[x - 1];
 
-    if (PyList_Check(list)) {
-        PyObject *slice;
+    if (PyList_CheckExact(list)) {
         Py_ssize_t list_len;
         int ret;
 
@@ -5971,27 +5972,48 @@ do_append(UnpicklerObject *self, Py_ssize_t x)
         return ret;
     }
     else {
-        PyObject *append_func;
-        _Py_IDENTIFIER(append);
+        PyObject *extend_func;
+        _Py_IDENTIFIER(extend);
 
-        append_func = _PyObject_GetAttrId(list, &PyId_append);
-        if (append_func == NULL)
-            return -1;
-        for (i = x; i < len; i++) {
-            PyObject *result;
-
-            value = self->stack->data[i];
-            result = _Pickle_FastCall(append_func, value);
-            if (result == NULL) {
-                Pdata_clear(self->stack, i + 1);
-                Py_SIZE(self->stack) = x;
-                Py_DECREF(append_func);
+        extend_func = _PyObject_GetAttrId(list, &PyId_extend);
+        if (extend_func != NULL) {
+            slice = Pdata_poplist(self->stack, x);
+            if (!slice) {
+                Py_DECREF(extend_func);
                 return -1;
             }
+            result = _Pickle_FastCall(extend_func, slice);
+            Py_DECREF(slice);
+            Py_DECREF(extend_func);
+            if (result == NULL)
+                return -1;
             Py_DECREF(result);
         }
-        Py_SIZE(self->stack) = x;
-        Py_DECREF(append_func);
+        else {
+            PyObject *append_func;
+            _Py_IDENTIFIER(append);
+
+            /* Even if the PEP 307 requires extend() and append() methods,
+               fall back on append() if the object has no extend() method
+               for backward compatibility. */
+            PyErr_Clear();
+            append_func = _PyObject_GetAttrId(list, &PyId_append);
+            if (append_func == NULL)
+                return -1;
+            for (i = x; i < len; i++) {
+                value = self->stack->data[i];
+                result = _Pickle_FastCall(append_func, value);
+                if (result == NULL) {
+                    Pdata_clear(self->stack, i + 1);
+                    Py_SIZE(self->stack) = x;
+                    Py_DECREF(append_func);
+                    return -1;
+                }
+                Py_DECREF(result);
+            }
+            Py_SIZE(self->stack) = x;
+            Py_DECREF(append_func);
+        }
     }
 
     return 0;

--- a/third_party/python/Modules/_struct.c
+++ b/third_party/python/Modules/_struct.c
@@ -46,6 +46,12 @@ PYTHON_PROVIDE("_struct.unpack_from");
 /* New version supporting byte order, alignment and size options,
    character strings, and unsigned numbers */
 
+
+/*[clinic input]
+class Struct "PyStructObject *" "&PyStructType"
+[clinic start generated code]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=9b032058a83ed7c3]*/
+
 static PyTypeObject PyStructType;
 
 /* The translation function for each format character is table driven */
@@ -116,6 +122,8 @@ typedef struct { char c; long long x; } s_long_long;
 #ifdef __powerc
 #pragma options align=reset
 #endif
+
+#include "third_party/python/Modules/clinic/_struct.inc"
 
 /* Helper for integer format codes: converts an arbitrary Python object to a
    PyLongObject if possible, otherwise fails.  Caller should decref. */
@@ -576,7 +584,7 @@ np_ubyte(char *p, PyObject *v, const formatdef *f)
                         "ubyte format requires 0 <= number <= 255");
         return -1;
     }
-    *(unsigned char *)p = (unsigned char)x;
+    *p = (char)x;
     return 0;
 }
 
@@ -905,7 +913,6 @@ bp_int(char *p, PyObject *v, const formatdef *f)
 {
     long x;
     Py_ssize_t i;
-    unsigned char *q = (unsigned char *)p;
     if (get_long(v, &x) < 0)
         return -1;
     i = f->size;
@@ -918,7 +925,7 @@ bp_int(char *p, PyObject *v, const formatdef *f)
 #endif
     }
     do {
-        q[--i] = (unsigned char)(x & 0xffL);
+        p[--i] = (char)x;
         x >>= 8;
     } while (i > 0);
     return 0;
@@ -929,7 +936,6 @@ bp_uint(char *p, PyObject *v, const formatdef *f)
 {
     unsigned long x;
     Py_ssize_t i;
-    unsigned char *q = (unsigned char *)p;
     if (get_ulong(v, &x) < 0)
         return -1;
     i = f->size;
@@ -940,7 +946,7 @@ bp_uint(char *p, PyObject *v, const formatdef *f)
             RANGE_ERROR(x, f, 1, maxint - 1);
     }
     do {
-        q[--i] = (unsigned char)(x & 0xffUL);
+        p[--i] = (char)x;
         x >>= 8;
     } while (i > 0);
     return 0;
@@ -1126,7 +1132,6 @@ lp_int(char *p, PyObject *v, const formatdef *f)
 {
     long x;
     Py_ssize_t i;
-    unsigned char *q = (unsigned char *)p;
     if (get_long(v, &x) < 0)
         return -1;
     i = f->size;
@@ -1139,7 +1144,7 @@ lp_int(char *p, PyObject *v, const formatdef *f)
 #endif
     }
     do {
-        *q++ = (unsigned char)(x & 0xffL);
+        *p++ = (char)x;
         x >>= 8;
     } while (--i > 0);
     return 0;
@@ -1150,7 +1155,6 @@ lp_uint(char *p, PyObject *v, const formatdef *f)
 {
     unsigned long x;
     Py_ssize_t i;
-    unsigned char *q = (unsigned char *)p;
     if (get_ulong(v, &x) < 0)
         return -1;
     i = f->size;
@@ -1161,7 +1165,7 @@ lp_uint(char *p, PyObject *v, const formatdef *f)
             RANGE_ERROR(x, f, 1, maxint - 1);
     }
     do {
-        *q++ = (unsigned char)(x & 0xffUL);
+        *p++ = (char)x;
         x >>= 8;
     } while (--i > 0);
     return 0;
@@ -1340,7 +1344,7 @@ prepare_s(PyStructObject *self)
     len = 0;
     ncodes = 0;
     while ((c = *s++) != '\0') {
-        if (Py_ISSPACE(c))
+        if (Py_ISSPACE(Py_CHARMASK(c)))
             continue;
         if ('0' <= c && c <= '9') {
             num = c - '0';
@@ -1405,7 +1409,7 @@ prepare_s(PyStructObject *self)
     s = fmt;
     size = 0;
     while ((c = *s++) != '\0') {
-        if (Py_ISSPACE(c))
+        if (Py_ISSPACE(Py_CHARMASK(c)))
             continue;
         if ('0' <= c && c <= '9') {
             num = c - '0';
@@ -1470,42 +1474,46 @@ s_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     return self;
 }
 
+/*[clinic input]
+Struct.__init__
+
+    format: object
+
+Create a compiled struct object.
+
+Return a new Struct object which writes and reads binary data according to
+the format string.
+
+See help(struct) for more on format strings.
+[clinic start generated code]*/
+
 static int
-s_init(PyObject *self, PyObject *args, PyObject *kwds)
+Struct___init___impl(PyStructObject *self, PyObject *format)
+/*[clinic end generated code: output=b8e80862444e92d0 input=192a4575a3dde802]*/
 {
-    PyStructObject *soself = (PyStructObject *)self;
-    PyObject *o_format = NULL;
     int ret = 0;
-    static char *kwlist[] = {"format", 0};
 
-    assert(PyStruct_Check(self));
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O:Struct", kwlist,
-                                     &o_format))
-        return -1;
-
-    if (PyUnicode_Check(o_format)) {
-        o_format = PyUnicode_AsASCIIString(o_format);
-        if (o_format == NULL)
+    if (PyUnicode_Check(format)) {
+        format = PyUnicode_AsASCIIString(format);
+        if (format == NULL)
             return -1;
     }
     /* XXX support buffer interface, too */
     else {
-        Py_INCREF(o_format);
+        Py_INCREF(format);
     }
 
-    if (!PyBytes_Check(o_format)) {
-        Py_DECREF(o_format);
+    if (!PyBytes_Check(format)) {
+        Py_DECREF(format);
         PyErr_Format(PyExc_TypeError,
-                     "Struct() argument 1 must be a str or bytes object, "
-                     "not %.200s",
-                     Py_TYPE(o_format)->tp_name);
+                     "Struct() argument 1 must be a bytes object, not %.200s",
+                     Py_TYPE(format)->tp_name);
         return -1;
     }
 
-    Py_XSETREF(soself->s_format, o_format);
+    Py_XSETREF(self->s_format, format);
 
-    ret = prepare_s(soself);
+    ret = prepare_s(self);
     return ret;
 }
 
@@ -1559,76 +1567,67 @@ fail:
 }
 
 
-PyDoc_STRVAR(s_unpack__doc__,
-"S.unpack(buffer) -> (v1, v2, ...)\n\
-\n\
-Return a tuple containing values unpacked according to the format\n\
-string S.format.  The buffer's size in bytes must be S.size.  See\n\
-help(struct) for more on format strings.");
+/*[clinic input]
+Struct.unpack
+
+    buffer: Py_buffer
+    /
+
+Return a tuple containing unpacked values.
+
+Unpack according to the format string Struct.format. The buffer's size
+in bytes must be Struct.size.
+
+See help(struct) for more on format strings.
+[clinic start generated code]*/
 
 static PyObject *
-s_unpack(PyObject *self, PyObject *input)
+Struct_unpack_impl(PyStructObject *self, Py_buffer *buffer)
+/*[clinic end generated code: output=873a24faf02e848a input=3113f8e7038b2f6c]*/
 {
-    Py_buffer vbuf;
-    PyObject *result;
-    PyStructObject *soself = (PyStructObject *)self;
-
-    assert(PyStruct_Check(self));
-    assert(soself->s_codes != NULL);
-    if (PyObject_GetBuffer(input, &vbuf, PyBUF_SIMPLE) < 0)
-        return NULL;
-    if (vbuf.len != soself->s_size) {
+    assert(self->s_codes != NULL);
+    if (buffer->len != self->s_size) {
         PyErr_Format(StructError,
-                     "unpack requires a buffer of %zd bytes",
-                     soself->s_size);
-        PyBuffer_Release(&vbuf);
+                     "unpack requires a bytes object of length %zd",
+                     self->s_size);
         return NULL;
     }
-    result = s_unpack_internal(soself, vbuf.buf);
-    PyBuffer_Release(&vbuf);
-    return result;
+    return s_unpack_internal(self, buffer->buf);
 }
 
-PyDoc_STRVAR(s_unpack_from__doc__,
-"S.unpack_from(buffer, offset=0) -> (v1, v2, ...)\n\
-\n\
-Return a tuple containing values unpacked according to the format\n\
-string S.format.  The buffer's size in bytes, minus offset, must be at\n\
-least S.size.  See help(struct) for more on format strings.");
+/*[clinic input]
+Struct.unpack_from
+
+    buffer: Py_buffer
+    offset: Py_ssize_t = 0
+
+Return a tuple containing unpacked values.
+
+Values are unpacked according to the format string Struct.format.
+
+The buffer's size in bytes, minus offset, must be at least Struct.size.
+
+See help(struct) for more on format strings.
+[clinic start generated code]*/
 
 static PyObject *
-s_unpack_from(PyObject *self, PyObject *args, PyObject *kwds)
+Struct_unpack_from_impl(PyStructObject *self, Py_buffer *buffer,
+                        Py_ssize_t offset)
+/*[clinic end generated code: output=57fac875e0977316 input=97ade52422f8962f]*/
 {
-    static char *kwlist[] = {"buffer", "offset", 0};
+    assert(self->s_codes != NULL);
 
-    PyObject *input;
-    Py_ssize_t offset = 0;
-    Py_buffer vbuf;
-    PyObject *result;
-    PyStructObject *soself = (PyStructObject *)self;
-
-    assert(PyStruct_Check(self));
-    assert(soself->s_codes != NULL);
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwds,
-                                     "O|n:unpack_from", kwlist,
-                                     &input, &offset))
-        return NULL;
-    if (PyObject_GetBuffer(input, &vbuf, PyBUF_SIMPLE) < 0)
-        return NULL;
     if (offset < 0)
-        offset += vbuf.len;
-    if (offset < 0 || vbuf.len - offset < soself->s_size) {
+        offset += buffer->len;
+    if (offset < 0 || buffer->len - offset < self->s_size) {
         PyErr_Format(StructError,
             "unpack_from requires a buffer of at least %zd bytes",
-            soself->s_size);
-        PyBuffer_Release(&vbuf);
+            self->s_size);
         return NULL;
     }
-    result = s_unpack_internal(soself, (char*)vbuf.buf + offset);
-    PyBuffer_Release(&vbuf);
-    return result;
+    return s_unpack_internal(self, (char*)buffer->buf + offset);
 }
+
 
 
 /* Unpack iterator type */
@@ -1643,8 +1642,6 @@ typedef struct {
 static void
 unpackiter_dealloc(unpackiterobject *self)
 {
-    /* bpo-31095: UnTrack is needed before calling any callbacks */
-    PyObject_GC_UnTrack(self);
     Py_XDECREF(self->so);
     PyBuffer_Release(&self->buf);
     PyObject_GC_Del(self);
@@ -1694,7 +1691,7 @@ unpackiter_iternext(unpackiterobject *self)
 }
 
 static PyTypeObject unpackiter_type = {
-    PyVarObject_HEAD_INIT(&PyType_Type, 0)
+    PyVarObject_HEAD_INIT(NULL, 0)
     "unpack_iterator",                          /* tp_name */
     sizeof(unpackiterobject),                   /* tp_basicsize */
     0,                                          /* tp_itemsize */
@@ -1724,48 +1721,54 @@ static PyTypeObject unpackiter_type = {
     unpackiter_methods                          /* tp_methods */
 };
 
-PyDoc_STRVAR(s_iter_unpack__doc__,
-"S.iter_unpack(buffer) -> iterator(v1, v2, ...)\n\
-\n\
-Return an iterator yielding tuples unpacked from the given bytes\n\
-source, like a repeated invocation of unpack_from().  Requires\n\
-that the bytes length be a multiple of the struct size.");
+/*[clinic input]
+Struct.iter_unpack
+
+    buffer: object
+    /
+
+Return an iterator yielding tuples.
+
+Tuples are unpacked from the given bytes source, like a repeated
+invocation of unpack_from().
+
+Requires that the bytes length be a multiple of the struct size.
+[clinic start generated code]*/
 
 static PyObject *
-s_iter_unpack(PyObject *_so, PyObject *input)
+Struct_iter_unpack(PyStructObject *self, PyObject *buffer)
+/*[clinic end generated code: output=172d83d0cd15dbab input=6d65b3f3107dbc99]*/
 {
-    PyStructObject *so = (PyStructObject *) _so;
-    unpackiterobject *self;
+    unpackiterobject *iter;
 
-    assert(PyStruct_Check(_so));
-    assert(so->s_codes != NULL);
+    assert(self->s_codes != NULL);
 
-    if (so->s_size == 0) {
+    if (self->s_size == 0) {
         PyErr_Format(StructError,
                      "cannot iteratively unpack with a struct of length 0");
         return NULL;
     }
 
-    self = (unpackiterobject *) PyType_GenericAlloc(&unpackiter_type, 0);
-    if (self == NULL)
+    iter = (unpackiterobject *) PyType_GenericAlloc(&unpackiter_type, 0);
+    if (iter == NULL)
         return NULL;
 
-    if (PyObject_GetBuffer(input, &self->buf, PyBUF_SIMPLE) < 0) {
-        Py_DECREF(self);
+    if (PyObject_GetBuffer(buffer, &iter->buf, PyBUF_SIMPLE) < 0) {
+        Py_DECREF(iter);
         return NULL;
     }
-    if (self->buf.len % so->s_size != 0) {
+    if (iter->buf.len % self->s_size != 0) {
         PyErr_Format(StructError,
-                     "iterative unpacking requires a buffer of "
-                     "a multiple of %zd bytes",
-                     so->s_size);
-        Py_DECREF(self);
+                     "iterative unpacking requires a bytes length "
+                     "multiple of %zd",
+                     self->s_size);
+        Py_DECREF(iter);
         return NULL;
     }
-    Py_INCREF(so);
-    self->so = so;
-    self->index = 0;
-    return (PyObject *) self;
+    Py_INCREF(self);
+    iter->so = self;
+    iter->index = 0;
+    return (PyObject *)iter;
 }
 
 
@@ -1780,20 +1783,21 @@ s_iter_unpack(PyObject *_so, PyObject *input)
  *
  */
 static int
-s_pack_internal(PyStructObject *soself, PyObject *args, int offset, char* buf)
+s_pack_internal(PyStructObject *soself, PyObject **args, int offset, char* buf)
 {
     formatcode *code;
     /* XXX(nnorwitz): why does i need to be a local?  can we use
        the offset parameter or do we need the wider width? */
     Py_ssize_t i;
-    bzero(buf, soself->s_size);
+
+    memset(buf, '\0', soself->s_size);
     i = offset;
     for (code = soself->s_codes; code->fmtdef != NULL; code++) {
         const formatdef *e = code->fmtdef;
         char *res = buf + code->offset;
         Py_ssize_t j = code->repeat;
         while (j--) {
-            PyObject *v = PyTuple_GET_ITEM(args, i++);
+            PyObject *v = args[i++];
             if (e->format == 's') {
                 Py_ssize_t n;
                 int isstring;
@@ -1866,7 +1870,7 @@ to the format string S.format.  See help(struct) for more on format\n\
 strings.");
 
 static PyObject *
-s_pack(PyObject *self, PyObject *args)
+s_pack(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyStructObject *soself;
     PyObject *result;
@@ -1875,10 +1879,13 @@ s_pack(PyObject *self, PyObject *args)
     soself = (PyStructObject *)self;
     assert(PyStruct_Check(self));
     assert(soself->s_codes != NULL);
-    if (PyTuple_GET_SIZE(args) != soself->s_len)
+    if (nargs != soself->s_len)
     {
         PyErr_Format(StructError,
-            "pack expected %zd items for packing (got %zd)", soself->s_len, PyTuple_GET_SIZE(args));
+            "pack expected %zd items for packing (got %zd)", soself->s_len, nargs);
+        return NULL;
+    }
+    if (!_PyArg_NoStackKeywords("pack", kwnames)) {
         return NULL;
     }
 
@@ -1905,7 +1912,7 @@ offset.  Note that the offset is a required argument.  See\n\
 help(struct) for more on format strings.");
 
 static PyObject *
-s_pack_into(PyObject *self, PyObject *args)
+s_pack_into(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyStructObject *soself;
     Py_buffer buffer;
@@ -1915,31 +1922,34 @@ s_pack_into(PyObject *self, PyObject *args)
     soself = (PyStructObject *)self;
     assert(PyStruct_Check(self));
     assert(soself->s_codes != NULL);
-    if (PyTuple_GET_SIZE(args) != (soself->s_len + 2))
+    if (nargs != (soself->s_len + 2))
     {
-        if (PyTuple_GET_SIZE(args) == 0) {
+        if (nargs == 0) {
             PyErr_Format(StructError,
                         "pack_into expected buffer argument");
         }
-        else if (PyTuple_GET_SIZE(args) == 1) {
+        else if (nargs == 1) {
             PyErr_Format(StructError,
                         "pack_into expected offset argument");
         }
         else {
             PyErr_Format(StructError,
                         "pack_into expected %zd items for packing (got %zd)",
-                        soself->s_len, (PyTuple_GET_SIZE(args) - 2));
+                        soself->s_len, (nargs - 2));
         }
+        return NULL;
+    }
+    if (!_PyArg_NoStackKeywords("pack_into", kwnames)) {
         return NULL;
     }
 
     /* Extract a writable memory buffer from the first argument */
-    if (!PyArg_Parse(PyTuple_GET_ITEM(args, 0), "w*", &buffer))
+    if (!PyArg_Parse(args[0], "w*", &buffer))
         return NULL;
     assert(buffer.len >= 0);
 
     /* Extract the offset from the first argument */
-    offset = PyNumber_AsSsize_t(PyTuple_GET_ITEM(args, 1), PyExc_IndexError);
+    offset = PyNumber_AsSsize_t(args[1], PyExc_IndexError);
     if (offset == -1 && PyErr_Occurred()) {
         PyBuffer_Release(&buffer);
         return NULL;
@@ -1999,21 +2009,14 @@ s_sizeof(PyStructObject *self, void *unused)
 /* List of functions */
 
 static struct PyMethodDef s_methods[] = {
-    {"iter_unpack",     s_iter_unpack,  METH_O, s_iter_unpack__doc__},
-    {"pack",            s_pack,         METH_VARARGS, s_pack__doc__},
-    {"pack_into",       s_pack_into,    METH_VARARGS, s_pack_into__doc__},
-    {"unpack",          s_unpack,       METH_O, s_unpack__doc__},
-    {"unpack_from",     (PyCFunction)s_unpack_from, METH_VARARGS|METH_KEYWORDS,
-                    s_unpack_from__doc__},
+    STRUCT_ITER_UNPACK_METHODDEF
+    {"pack",            (PyCFunction)s_pack, METH_FASTCALL, s_pack__doc__},
+    {"pack_into",       (PyCFunction)s_pack_into, METH_FASTCALL, s_pack_into__doc__},
+    STRUCT_UNPACK_METHODDEF
+    STRUCT_UNPACK_FROM_METHODDEF
     {"__sizeof__",      (PyCFunction)s_sizeof, METH_NOARGS, s_sizeof__doc__},
     {NULL,       NULL}          /* sentinel */
 };
-
-PyDoc_STRVAR(s__doc__,
-"Struct(fmt) --> compiled struct object\n"
-"\n"
-"Return a new Struct object which writes and reads binary data according to\n"
-"the format string fmt.  See help(struct) for more on format strings.");
 
 #define OFF(x) offsetof(PyStructObject, x)
 
@@ -2041,29 +2044,29 @@ PyTypeObject PyStructType = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
-    PyObject_GenericSetAttr,            /* tp_setattro */
+    PyObject_GenericGetAttr,                    /* tp_getattro */
+    PyObject_GenericSetAttr,                    /* tp_setattro */
     0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-    s__doc__,                           /* tp_doc */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,   /* tp_flags */
+    Struct___init____doc__,                     /* tp_doc */
     0,                                          /* tp_traverse */
     0,                                          /* tp_clear */
     0,                                          /* tp_richcompare */
     offsetof(PyStructObject, weakreflist),      /* tp_weaklistoffset */
     0,                                          /* tp_iter */
     0,                                          /* tp_iternext */
-    s_methods,                          /* tp_methods */
-    NULL,                               /* tp_members */
-    s_getsetlist,               /* tp_getset */
+    s_methods,                                  /* tp_methods */
+    NULL,                                       /* tp_members */
+    s_getsetlist,                               /* tp_getset */
     0,                                          /* tp_base */
     0,                                          /* tp_dict */
     0,                                          /* tp_descr_get */
     0,                                          /* tp_descr_set */
     0,                                          /* tp_dictoffset */
-    s_init,                             /* tp_init */
-    PyType_GenericAlloc,/* tp_alloc */
-    s_new,                              /* tp_new */
-    PyObject_Del,               /* tp_free */
+    Struct___init__,                            /* tp_init */
+    PyType_GenericAlloc,                        /* tp_alloc */
+    s_new,                                      /* tp_new */
+    PyObject_Del,                               /* tp_free */
 };
 
 
@@ -2072,7 +2075,7 @@ PyTypeObject PyStructType = {
 #define MAXCACHE 100
 static PyObject *cache = NULL;
 
-static PyObject *
+static PyStructObject *
 cache_struct(PyObject *fmt)
 {
     PyObject * s_object;
@@ -2086,202 +2089,214 @@ cache_struct(PyObject *fmt)
     s_object = PyDict_GetItem(cache, fmt);
     if (s_object != NULL) {
         Py_INCREF(s_object);
-        return s_object;
+        return (PyStructObject *)s_object;
     }
 
     s_object = PyObject_CallFunctionObjArgs((PyObject *)(&PyStructType), fmt, NULL);
     if (s_object != NULL) {
-        if (PyDict_Size(cache) >= MAXCACHE)
+        if (PyDict_GET_SIZE(cache) >= MAXCACHE)
             PyDict_Clear(cache);
         /* Attempt to cache the result */
         if (PyDict_SetItem(cache, fmt, s_object) == -1)
             PyErr_Clear();
     }
-    return s_object;
+    return (PyStructObject *)s_object;
 }
 
-PyDoc_STRVAR(clearcache_doc,
-"Clear the internal cache.");
+/*[clinic input]
+_clearcache
+
+Clear the internal cache.
+[clinic start generated code]*/
 
 static PyObject *
-clearcache(PyObject *self)
+_clearcache_impl(PyObject *module)
+/*[clinic end generated code: output=ce4fb8a7bf7cb523 input=463eaae04bab3211]*/
 {
     Py_CLEAR(cache);
     Py_RETURN_NONE;
 }
 
-PyDoc_STRVAR(calcsize_doc,
-"calcsize(fmt) -> integer\n\
-\n\
-Return size in bytes of the struct described by the format string fmt.");
+
+/*[clinic input]
+calcsize
+
+    format: object
+    /
+
+Return size in bytes of the struct described by the format string.
+[clinic start generated code]*/
 
 static PyObject *
-calcsize(PyObject *self, PyObject *fmt)
+calcsize(PyObject *module, PyObject *format)
+/*[clinic end generated code: output=90fbcf191fe9470a input=55488303a06777fa]*/
 {
     Py_ssize_t n;
-    PyObject *s_object = cache_struct(fmt);
+    PyStructObject *s_object = cache_struct(format);
     if (s_object == NULL)
         return NULL;
-    n = ((PyStructObject *)s_object)->s_size;
+    n = s_object->s_size;
     Py_DECREF(s_object);
     return PyLong_FromSsize_t(n);
 }
 
 PyDoc_STRVAR(pack_doc,
-"pack(fmt, v1, v2, ...) -> bytes\n\
+"pack(format, v1, v2, ...) -> bytes\n\
 \n\
 Return a bytes object containing the values v1, v2, ... packed according\n\
-to the format string fmt.  See help(struct) for more on format strings.");
+to the format string.  See help(struct) for more on format strings.");
 
 static PyObject *
-pack(PyObject *self, PyObject *args)
+pack(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
-    PyObject *s_object, *fmt, *newargs, *result;
-    Py_ssize_t n = PyTuple_GET_SIZE(args);
+    PyStructObject *s_object;
+    PyObject *format, *result;
 
-    if (n == 0) {
+    if (nargs == 0) {
         PyErr_SetString(PyExc_TypeError, "missing format argument");
         return NULL;
     }
-    fmt = PyTuple_GET_ITEM(args, 0);
-    newargs = PyTuple_GetSlice(args, 1, n);
-    if (newargs == NULL)
-        return NULL;
+    format = args[0];
 
-    s_object = cache_struct(fmt);
+    s_object = cache_struct(format);
     if (s_object == NULL) {
-        Py_DECREF(newargs);
         return NULL;
     }
-    result = s_pack(s_object, newargs);
-    Py_DECREF(newargs);
+    result = s_pack((PyObject *)s_object, args + 1, nargs - 1, kwnames);
     Py_DECREF(s_object);
     return result;
 }
 
 PyDoc_STRVAR(pack_into_doc,
-"pack_into(fmt, buffer, offset, v1, v2, ...)\n\
+"pack_into(format, buffer, offset, v1, v2, ...)\n\
 \n\
-Pack the values v1, v2, ... according to the format string fmt and write\n\
+Pack the values v1, v2, ... according to the format string and write\n\
 the packed bytes into the writable buffer buf starting at offset.  Note\n\
 that the offset is a required argument.  See help(struct) for more\n\
 on format strings.");
 
 static PyObject *
-pack_into(PyObject *self, PyObject *args)
+pack_into(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
-    PyObject *s_object, *fmt, *newargs, *result;
-    Py_ssize_t n = PyTuple_GET_SIZE(args);
+    PyStructObject *s_object;
+    PyObject *format, *result;
 
-    if (n == 0) {
+    if (nargs == 0) {
         PyErr_SetString(PyExc_TypeError, "missing format argument");
         return NULL;
     }
-    fmt = PyTuple_GET_ITEM(args, 0);
-    newargs = PyTuple_GetSlice(args, 1, n);
-    if (newargs == NULL)
-        return NULL;
+    format = args[0];
 
-    s_object = cache_struct(fmt);
+    s_object = cache_struct(format);
     if (s_object == NULL) {
-        Py_DECREF(newargs);
         return NULL;
     }
-    result = s_pack_into(s_object, newargs);
-    Py_DECREF(newargs);
+    result = s_pack_into((PyObject *)s_object, args + 1, nargs - 1, kwnames);
     Py_DECREF(s_object);
     return result;
 }
 
-PyDoc_STRVAR(unpack_doc,
-"unpack(fmt, buffer) -> (v1, v2, ...)\n\
-\n\
-Return a tuple containing values unpacked according to the format string\n\
-fmt.  The buffer's size in bytes must be calcsize(fmt). See help(struct)\n\
-for more on format strings.");
+/*[clinic input]
+unpack
+
+    format: object
+    inputstr: object
+    /
+
+Return a tuple containing values unpacked according to the format string.
+
+The buffer's size in bytes must be calcsize(format).
+
+See help(struct) for more on format strings.
+[clinic start generated code]*/
 
 static PyObject *
-unpack(PyObject *self, PyObject *args)
+unpack_impl(PyObject *module, PyObject *format, PyObject *inputstr)
+/*[clinic end generated code: output=06951d66eae6d63b input=4b81d54988890f5e]*/
 {
-    PyObject *s_object, *fmt, *inputstr, *result;
+    PyStructObject *s_object;
+    PyObject *result;
 
-    if (!PyArg_UnpackTuple(args, "unpack", 2, 2, &fmt, &inputstr))
-        return NULL;
-
-    s_object = cache_struct(fmt);
+    s_object = cache_struct(format);
     if (s_object == NULL)
         return NULL;
-    result = s_unpack(s_object, inputstr);
+    result = Struct_unpack(s_object, inputstr);
     Py_DECREF(s_object);
     return result;
 }
 
-PyDoc_STRVAR(unpack_from_doc,
-"unpack_from(fmt, buffer, offset=0) -> (v1, v2, ...)\n\
-\n\
-Return a tuple containing values unpacked according to the format string\n\
-fmt.  The buffer's size, minus offset, must be at least calcsize(fmt).\n\
-See help(struct) for more on format strings.");
+/*[clinic input]
+unpack_from
+
+    format: object
+    /
+    buffer: Py_buffer
+    offset: Py_ssize_t = 0
+
+Return a tuple containing values unpacked according to the format string.
+
+The buffer's size, minus offset, must be at least calcsize(format).
+
+See help(struct) for more on format strings.
+[clinic start generated code]*/
 
 static PyObject *
-unpack_from(PyObject *self, PyObject *args, PyObject *kwds)
+unpack_from_impl(PyObject *module, PyObject *format, Py_buffer *buffer,
+                 Py_ssize_t offset)
+/*[clinic end generated code: output=2492f0c3a0b82577 input=9ead76c6ac7164f7]*/
 {
-    PyObject *s_object, *fmt, *newargs, *result;
-    Py_ssize_t n = PyTuple_GET_SIZE(args);
+    PyStructObject *s_object;
+    PyObject *result;
 
-    if (n == 0) {
-        PyErr_SetString(PyExc_TypeError, "missing format argument");
-        return NULL;
-    }
-    fmt = PyTuple_GET_ITEM(args, 0);
-    newargs = PyTuple_GetSlice(args, 1, n);
-    if (newargs == NULL)
-        return NULL;
-
-    s_object = cache_struct(fmt);
+    s_object = cache_struct(format);
     if (s_object == NULL) {
-        Py_DECREF(newargs);
         return NULL;
     }
-    result = s_unpack_from(s_object, newargs, kwds);
-    Py_DECREF(newargs);
+    result = Struct_unpack_from_impl(s_object, buffer, offset);
+
     Py_DECREF(s_object);
     return result;
 }
 
-PyDoc_STRVAR(iter_unpack_doc,
-"iter_unpack(fmt, buffer) -> iterator(v1, v2, ...)\n\
-\n\
-Return an iterator yielding tuples unpacked from the given bytes\n\
-source according to the format string, like a repeated invocation of\n\
-unpack_from().  Requires that the bytes length be a multiple of the\n\
-format struct size.");
+/*[clinic input]
+iter_unpack
+
+    format: object
+    buffer: object
+    /
+
+Return an iterator yielding tuples unpacked from the given bytes.
+
+The bytes are unpacked according to the format string, like
+a repeated invocation of unpack_from().
+
+Requires that the bytes length be a multiple of the format struct size.
+[clinic start generated code]*/
 
 static PyObject *
-iter_unpack(PyObject *self, PyObject *args)
+iter_unpack_impl(PyObject *module, PyObject *format, PyObject *buffer)
+/*[clinic end generated code: output=b1291e97a6d4cf3c input=8674dfd2f0dae416]*/
 {
-    PyObject *s_object, *fmt, *input, *result;
+    PyStructObject *s_object;
+    PyObject *result;
 
-    if (!PyArg_ParseTuple(args, "OO:iter_unpack", &fmt, &input))
-        return NULL;
-
-    s_object = cache_struct(fmt);
+    s_object = cache_struct(format);
     if (s_object == NULL)
         return NULL;
-    result = s_iter_unpack(s_object, input);
+
+    result = Struct_iter_unpack(s_object, buffer);
     Py_DECREF(s_object);
     return result;
 }
 
 static struct PyMethodDef module_functions[] = {
-    {"_clearcache",     (PyCFunction)clearcache,        METH_NOARGS,    clearcache_doc},
-    {"calcsize",        calcsize,       METH_O, calcsize_doc},
-    {"iter_unpack",     iter_unpack,    METH_VARARGS,   iter_unpack_doc},
-    {"pack",            pack,           METH_VARARGS,   pack_doc},
-    {"pack_into",       pack_into,      METH_VARARGS,   pack_into_doc},
-    {"unpack",          unpack, METH_VARARGS,   unpack_doc},
-    {"unpack_from",     (PyCFunction)unpack_from,
-                    METH_VARARGS|METH_KEYWORDS,         unpack_from_doc},
+    _CLEARCACHE_METHODDEF
+    CALCSIZE_METHODDEF
+    ITER_UNPACK_METHODDEF
+    {"pack",            (PyCFunction)pack, METH_FASTCALL,   pack_doc},
+    {"pack_into",       (PyCFunction)pack_into, METH_FASTCALL,   pack_into_doc},
+    UNPACK_METHODDEF
+    UNPACK_FROM_METHODDEF
     {NULL,       NULL}          /* sentinel */
 };
 
@@ -2342,6 +2357,9 @@ PyInit__struct(void)
 
     Py_TYPE(&PyStructType) = &PyType_Type;
     if (PyType_Ready(&PyStructType) < 0)
+        return NULL;
+
+    if (PyType_Ready(&unpackiter_type) < 0)
         return NULL;
 
     /* Check endian and swap in faster functions */

--- a/third_party/python/Modules/audioop.c
+++ b/third_party/python/Modules/audioop.c
@@ -7,6 +7,7 @@
 #define PY_SSIZE_T_CLEAN
 #include "dsp/core/core.h"
 #include "libc/math.h"
+#include "third_party/python/Include/abstract.h"
 #include "third_party/python/Include/dictobject.h"
 #include "third_party/python/Include/floatobject.h"
 #include "third_party/python/Include/import.h"

--- a/third_party/python/Modules/cjkcodecs/clinic/multibytecodec.inc
+++ b/third_party/python/Modules/cjkcodecs/clinic/multibytecodec.inc
@@ -31,7 +31,7 @@ _multibytecodec_MultibyteCodec_encode(MultibyteCodecObject *self, PyObject **arg
     PyObject *input;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &input, &errors)) {
         goto exit;
     }
@@ -69,7 +69,7 @@ _multibytecodec_MultibyteCodec_decode(MultibyteCodecObject *self, PyObject **arg
     Py_buffer input = {NULL, NULL};
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &input, &errors)) {
         goto exit;
     }
@@ -106,7 +106,7 @@ _multibytecodec_MultibyteIncrementalEncoder_encode(MultibyteIncrementalEncoderOb
     PyObject *input;
     int final = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &input, &final)) {
         goto exit;
     }
@@ -155,7 +155,7 @@ _multibytecodec_MultibyteIncrementalDecoder_decode(MultibyteIncrementalDecoderOb
     Py_buffer input = {NULL, NULL};
     int final = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &input, &final)) {
         goto exit;
     }

--- a/third_party/python/Modules/clinic/_asynciomodule.inc
+++ b/third_party/python/Modules/clinic/_asynciomodule.inc
@@ -281,7 +281,7 @@ _asyncio_Task_current_task(PyTypeObject *type, PyObject **args, Py_ssize_t nargs
     static _PyArg_Parser _parser = {"|O:current_task", _keywords, 0};
     PyObject *loop = Py_None;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &loop)) {
         goto exit;
     }
@@ -313,7 +313,7 @@ _asyncio_Task_all_tasks(PyTypeObject *type, PyObject **args, Py_ssize_t nargs, P
     static _PyArg_Parser _parser = {"|O:all_tasks", _keywords, 0};
     PyObject *loop = Py_None;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &loop)) {
         goto exit;
     }
@@ -413,7 +413,7 @@ _asyncio_Task_get_stack(TaskObj *self, PyObject **args, Py_ssize_t nargs, PyObje
     static _PyArg_Parser _parser = {"|$O:get_stack", _keywords, 0};
     PyObject *limit = Py_None;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &limit)) {
         goto exit;
     }
@@ -451,7 +451,7 @@ _asyncio_Task_print_stack(TaskObj *self, PyObject **args, Py_ssize_t nargs, PyOb
     PyObject *limit = Py_None;
     PyObject *file = Py_None;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &limit, &file)) {
         goto exit;
     }
@@ -480,7 +480,7 @@ _asyncio_Task__step(TaskObj *self, PyObject **args, Py_ssize_t nargs, PyObject *
     static _PyArg_Parser _parser = {"|O:_step", _keywords, 0};
     PyObject *exc = Py_None;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &exc)) {
         goto exit;
     }
@@ -509,7 +509,7 @@ _asyncio_Task__wakeup(TaskObj *self, PyObject **args, Py_ssize_t nargs, PyObject
     static _PyArg_Parser _parser = {"O:_wakeup", _keywords, 0};
     PyObject *fut;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &fut)) {
         goto exit;
     }

--- a/third_party/python/Modules/clinic/_asynciomodule.inc
+++ b/third_party/python/Modules/clinic/_asynciomodule.inc
@@ -518,4 +518,4 @@ _asyncio_Task__wakeup(TaskObj *self, PyObject **args, Py_ssize_t nargs, PyObject
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=7441872b13652085 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1f2f5bbc35bc3c4e input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/_bz2module.inc
+++ b/third_party/python/Modules/clinic/_bz2module.inc
@@ -175,4 +175,4 @@ _bz2_BZ2Decompressor___init__(PyObject *self, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=7e57af0b368d3e55 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=0e97a1d716b35a14 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/_bz2module.inc
+++ b/third_party/python/Modules/clinic/_bz2module.inc
@@ -131,7 +131,7 @@ _bz2_BZ2Decompressor_decompress(BZ2Decompressor *self, PyObject **args, Py_ssize
     Py_buffer data = {NULL, NULL};
     Py_ssize_t max_length = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &data, &max_length)) {
         goto exit;
     }

--- a/third_party/python/Modules/clinic/_codecsmodule.inc
+++ b/third_party/python/Modules/clinic/_codecsmodule.inc
@@ -72,7 +72,7 @@ _codecs_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     const char *encoding = NULL;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &obj, &encoding, &errors)) {
         goto exit;
     }
@@ -111,7 +111,7 @@ _codecs_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     const char *encoding = NULL;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &obj, &encoding, &errors)) {
         goto exit;
     }

--- a/third_party/python/Modules/clinic/_codecsmodule.inc
+++ b/third_party/python/Modules/clinic/_codecsmodule.inc
@@ -154,21 +154,25 @@ PyDoc_STRVAR(_codecs_escape_decode__doc__,
 "\n");
 
 #define _CODECS_ESCAPE_DECODE_METHODDEF    \
-    {"escape_decode", (PyCFunction)_codecs_escape_decode, METH_VARARGS, _codecs_escape_decode__doc__},
+    {"escape_decode", (PyCFunction)_codecs_escape_decode, METH_FASTCALL, _codecs_escape_decode__doc__},
 
 static PyObject *
 _codecs_escape_decode_impl(PyObject *module, Py_buffer *data,
                            const char *errors);
 
 static PyObject *
-_codecs_escape_decode(PyObject *module, PyObject *args)
+_codecs_escape_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "s*|z:escape_decode",
+    if (!_PyArg_ParseStack(args, nargs, "s*|z:escape_decode",
         &data, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("escape_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_escape_decode_impl(module, &data, errors);
@@ -188,21 +192,25 @@ PyDoc_STRVAR(_codecs_escape_encode__doc__,
 "\n");
 
 #define _CODECS_ESCAPE_ENCODE_METHODDEF    \
-    {"escape_encode", (PyCFunction)_codecs_escape_encode, METH_VARARGS, _codecs_escape_encode__doc__},
+    {"escape_encode", (PyCFunction)_codecs_escape_encode, METH_FASTCALL, _codecs_escape_encode__doc__},
 
 static PyObject *
 _codecs_escape_encode_impl(PyObject *module, PyObject *data,
                            const char *errors);
 
 static PyObject *
-_codecs_escape_encode(PyObject *module, PyObject *args)
+_codecs_escape_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *data;
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "O!|z:escape_encode",
+    if (!_PyArg_ParseStack(args, nargs, "O!|z:escape_encode",
         &PyBytes_Type, &data, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("escape_encode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_escape_encode_impl(module, data, errors);
@@ -217,21 +225,25 @@ PyDoc_STRVAR(_codecs_unicode_internal_decode__doc__,
 "\n");
 
 #define _CODECS_UNICODE_INTERNAL_DECODE_METHODDEF    \
-    {"unicode_internal_decode", (PyCFunction)_codecs_unicode_internal_decode, METH_VARARGS, _codecs_unicode_internal_decode__doc__},
+    {"unicode_internal_decode", (PyCFunction)_codecs_unicode_internal_decode, METH_FASTCALL, _codecs_unicode_internal_decode__doc__},
 
 static PyObject *
 _codecs_unicode_internal_decode_impl(PyObject *module, PyObject *obj,
                                      const char *errors);
 
 static PyObject *
-_codecs_unicode_internal_decode(PyObject *module, PyObject *args)
+_codecs_unicode_internal_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *obj;
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "O|z:unicode_internal_decode",
+    if (!_PyArg_ParseStack(args, nargs, "O|z:unicode_internal_decode",
         &obj, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("unicode_internal_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_unicode_internal_decode_impl(module, obj, errors);
@@ -246,22 +258,26 @@ PyDoc_STRVAR(_codecs_utf_7_decode__doc__,
 "\n");
 
 #define _CODECS_UTF_7_DECODE_METHODDEF    \
-    {"utf_7_decode", (PyCFunction)_codecs_utf_7_decode, METH_VARARGS, _codecs_utf_7_decode__doc__},
+    {"utf_7_decode", (PyCFunction)_codecs_utf_7_decode, METH_FASTCALL, _codecs_utf_7_decode__doc__},
 
 static PyObject *
 _codecs_utf_7_decode_impl(PyObject *module, Py_buffer *data,
                           const char *errors, int final);
 
 static PyObject *
-_codecs_utf_7_decode(PyObject *module, PyObject *args)
+_codecs_utf_7_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
 
-    if (!PyArg_ParseTuple(args, "y*|zi:utf_7_decode",
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_7_decode",
         &data, &errors, &final)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("utf_7_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_utf_7_decode_impl(module, &data, errors, final);
@@ -281,22 +297,26 @@ PyDoc_STRVAR(_codecs_utf_8_decode__doc__,
 "\n");
 
 #define _CODECS_UTF_8_DECODE_METHODDEF    \
-    {"utf_8_decode", (PyCFunction)_codecs_utf_8_decode, METH_VARARGS, _codecs_utf_8_decode__doc__},
+    {"utf_8_decode", (PyCFunction)_codecs_utf_8_decode, METH_FASTCALL, _codecs_utf_8_decode__doc__},
 
 static PyObject *
 _codecs_utf_8_decode_impl(PyObject *module, Py_buffer *data,
                           const char *errors, int final);
 
 static PyObject *
-_codecs_utf_8_decode(PyObject *module, PyObject *args)
+_codecs_utf_8_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
 
-    if (!PyArg_ParseTuple(args, "y*|zi:utf_8_decode",
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_8_decode",
         &data, &errors, &final)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("utf_8_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_utf_8_decode_impl(module, &data, errors, final);
@@ -316,22 +336,26 @@ PyDoc_STRVAR(_codecs_utf_16_decode__doc__,
 "\n");
 
 #define _CODECS_UTF_16_DECODE_METHODDEF    \
-    {"utf_16_decode", (PyCFunction)_codecs_utf_16_decode, METH_VARARGS, _codecs_utf_16_decode__doc__},
+    {"utf_16_decode", (PyCFunction)_codecs_utf_16_decode, METH_FASTCALL, _codecs_utf_16_decode__doc__},
 
 static PyObject *
 _codecs_utf_16_decode_impl(PyObject *module, Py_buffer *data,
                            const char *errors, int final);
 
 static PyObject *
-_codecs_utf_16_decode(PyObject *module, PyObject *args)
+_codecs_utf_16_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
 
-    if (!PyArg_ParseTuple(args, "y*|zi:utf_16_decode",
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_16_decode",
         &data, &errors, &final)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("utf_16_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_utf_16_decode_impl(module, &data, errors, final);
@@ -351,22 +375,26 @@ PyDoc_STRVAR(_codecs_utf_16_le_decode__doc__,
 "\n");
 
 #define _CODECS_UTF_16_LE_DECODE_METHODDEF    \
-    {"utf_16_le_decode", (PyCFunction)_codecs_utf_16_le_decode, METH_VARARGS, _codecs_utf_16_le_decode__doc__},
+    {"utf_16_le_decode", (PyCFunction)_codecs_utf_16_le_decode, METH_FASTCALL, _codecs_utf_16_le_decode__doc__},
 
 static PyObject *
 _codecs_utf_16_le_decode_impl(PyObject *module, Py_buffer *data,
                               const char *errors, int final);
 
 static PyObject *
-_codecs_utf_16_le_decode(PyObject *module, PyObject *args)
+_codecs_utf_16_le_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
 
-    if (!PyArg_ParseTuple(args, "y*|zi:utf_16_le_decode",
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_16_le_decode",
         &data, &errors, &final)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("utf_16_le_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_utf_16_le_decode_impl(module, &data, errors, final);
@@ -386,22 +414,26 @@ PyDoc_STRVAR(_codecs_utf_16_be_decode__doc__,
 "\n");
 
 #define _CODECS_UTF_16_BE_DECODE_METHODDEF    \
-    {"utf_16_be_decode", (PyCFunction)_codecs_utf_16_be_decode, METH_VARARGS, _codecs_utf_16_be_decode__doc__},
+    {"utf_16_be_decode", (PyCFunction)_codecs_utf_16_be_decode, METH_FASTCALL, _codecs_utf_16_be_decode__doc__},
 
 static PyObject *
 _codecs_utf_16_be_decode_impl(PyObject *module, Py_buffer *data,
                               const char *errors, int final);
 
 static PyObject *
-_codecs_utf_16_be_decode(PyObject *module, PyObject *args)
+_codecs_utf_16_be_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
 
-    if (!PyArg_ParseTuple(args, "y*|zi:utf_16_be_decode",
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_16_be_decode",
         &data, &errors, &final)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("utf_16_be_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_utf_16_be_decode_impl(module, &data, errors, final);
@@ -422,14 +454,14 @@ PyDoc_STRVAR(_codecs_utf_16_ex_decode__doc__,
 "\n");
 
 #define _CODECS_UTF_16_EX_DECODE_METHODDEF    \
-    {"utf_16_ex_decode", (PyCFunction)_codecs_utf_16_ex_decode, METH_VARARGS, _codecs_utf_16_ex_decode__doc__},
+    {"utf_16_ex_decode", (PyCFunction)_codecs_utf_16_ex_decode, METH_FASTCALL, _codecs_utf_16_ex_decode__doc__},
 
 static PyObject *
 _codecs_utf_16_ex_decode_impl(PyObject *module, Py_buffer *data,
                               const char *errors, int byteorder, int final);
 
 static PyObject *
-_codecs_utf_16_ex_decode(PyObject *module, PyObject *args)
+_codecs_utf_16_ex_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
@@ -437,8 +469,12 @@ _codecs_utf_16_ex_decode(PyObject *module, PyObject *args)
     int byteorder = 0;
     int final = 0;
 
-    if (!PyArg_ParseTuple(args, "y*|zii:utf_16_ex_decode",
+    if (!_PyArg_ParseStack(args, nargs, "y*|zii:utf_16_ex_decode",
         &data, &errors, &byteorder, &final)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("utf_16_ex_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_utf_16_ex_decode_impl(module, &data, errors, byteorder, final);
@@ -458,22 +494,26 @@ PyDoc_STRVAR(_codecs_utf_32_decode__doc__,
 "\n");
 
 #define _CODECS_UTF_32_DECODE_METHODDEF    \
-    {"utf_32_decode", (PyCFunction)_codecs_utf_32_decode, METH_VARARGS, _codecs_utf_32_decode__doc__},
+    {"utf_32_decode", (PyCFunction)_codecs_utf_32_decode, METH_FASTCALL, _codecs_utf_32_decode__doc__},
 
 static PyObject *
 _codecs_utf_32_decode_impl(PyObject *module, Py_buffer *data,
                            const char *errors, int final);
 
 static PyObject *
-_codecs_utf_32_decode(PyObject *module, PyObject *args)
+_codecs_utf_32_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
 
-    if (!PyArg_ParseTuple(args, "y*|zi:utf_32_decode",
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_32_decode",
         &data, &errors, &final)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("utf_32_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_utf_32_decode_impl(module, &data, errors, final);
@@ -493,22 +533,26 @@ PyDoc_STRVAR(_codecs_utf_32_le_decode__doc__,
 "\n");
 
 #define _CODECS_UTF_32_LE_DECODE_METHODDEF    \
-    {"utf_32_le_decode", (PyCFunction)_codecs_utf_32_le_decode, METH_VARARGS, _codecs_utf_32_le_decode__doc__},
+    {"utf_32_le_decode", (PyCFunction)_codecs_utf_32_le_decode, METH_FASTCALL, _codecs_utf_32_le_decode__doc__},
 
 static PyObject *
 _codecs_utf_32_le_decode_impl(PyObject *module, Py_buffer *data,
                               const char *errors, int final);
 
 static PyObject *
-_codecs_utf_32_le_decode(PyObject *module, PyObject *args)
+_codecs_utf_32_le_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
 
-    if (!PyArg_ParseTuple(args, "y*|zi:utf_32_le_decode",
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_32_le_decode",
         &data, &errors, &final)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("utf_32_le_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_utf_32_le_decode_impl(module, &data, errors, final);
@@ -528,22 +572,26 @@ PyDoc_STRVAR(_codecs_utf_32_be_decode__doc__,
 "\n");
 
 #define _CODECS_UTF_32_BE_DECODE_METHODDEF    \
-    {"utf_32_be_decode", (PyCFunction)_codecs_utf_32_be_decode, METH_VARARGS, _codecs_utf_32_be_decode__doc__},
+    {"utf_32_be_decode", (PyCFunction)_codecs_utf_32_be_decode, METH_FASTCALL, _codecs_utf_32_be_decode__doc__},
 
 static PyObject *
 _codecs_utf_32_be_decode_impl(PyObject *module, Py_buffer *data,
                               const char *errors, int final);
 
 static PyObject *
-_codecs_utf_32_be_decode(PyObject *module, PyObject *args)
+_codecs_utf_32_be_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
 
-    if (!PyArg_ParseTuple(args, "y*|zi:utf_32_be_decode",
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_32_be_decode",
         &data, &errors, &final)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("utf_32_be_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_utf_32_be_decode_impl(module, &data, errors, final);
@@ -564,14 +612,14 @@ PyDoc_STRVAR(_codecs_utf_32_ex_decode__doc__,
 "\n");
 
 #define _CODECS_UTF_32_EX_DECODE_METHODDEF    \
-    {"utf_32_ex_decode", (PyCFunction)_codecs_utf_32_ex_decode, METH_VARARGS, _codecs_utf_32_ex_decode__doc__},
+    {"utf_32_ex_decode", (PyCFunction)_codecs_utf_32_ex_decode, METH_FASTCALL, _codecs_utf_32_ex_decode__doc__},
 
 static PyObject *
 _codecs_utf_32_ex_decode_impl(PyObject *module, Py_buffer *data,
                               const char *errors, int byteorder, int final);
 
 static PyObject *
-_codecs_utf_32_ex_decode(PyObject *module, PyObject *args)
+_codecs_utf_32_ex_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
@@ -579,8 +627,12 @@ _codecs_utf_32_ex_decode(PyObject *module, PyObject *args)
     int byteorder = 0;
     int final = 0;
 
-    if (!PyArg_ParseTuple(args, "y*|zii:utf_32_ex_decode",
+    if (!_PyArg_ParseStack(args, nargs, "y*|zii:utf_32_ex_decode",
         &data, &errors, &byteorder, &final)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("utf_32_ex_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_utf_32_ex_decode_impl(module, &data, errors, byteorder, final);
@@ -600,21 +652,25 @@ PyDoc_STRVAR(_codecs_unicode_escape_decode__doc__,
 "\n");
 
 #define _CODECS_UNICODE_ESCAPE_DECODE_METHODDEF    \
-    {"unicode_escape_decode", (PyCFunction)_codecs_unicode_escape_decode, METH_VARARGS, _codecs_unicode_escape_decode__doc__},
+    {"unicode_escape_decode", (PyCFunction)_codecs_unicode_escape_decode, METH_FASTCALL, _codecs_unicode_escape_decode__doc__},
 
 static PyObject *
 _codecs_unicode_escape_decode_impl(PyObject *module, Py_buffer *data,
                                    const char *errors);
 
 static PyObject *
-_codecs_unicode_escape_decode(PyObject *module, PyObject *args)
+_codecs_unicode_escape_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "s*|z:unicode_escape_decode",
+    if (!_PyArg_ParseStack(args, nargs, "s*|z:unicode_escape_decode",
         &data, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("unicode_escape_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_unicode_escape_decode_impl(module, &data, errors);
@@ -634,21 +690,25 @@ PyDoc_STRVAR(_codecs_raw_unicode_escape_decode__doc__,
 "\n");
 
 #define _CODECS_RAW_UNICODE_ESCAPE_DECODE_METHODDEF    \
-    {"raw_unicode_escape_decode", (PyCFunction)_codecs_raw_unicode_escape_decode, METH_VARARGS, _codecs_raw_unicode_escape_decode__doc__},
+    {"raw_unicode_escape_decode", (PyCFunction)_codecs_raw_unicode_escape_decode, METH_FASTCALL, _codecs_raw_unicode_escape_decode__doc__},
 
 static PyObject *
 _codecs_raw_unicode_escape_decode_impl(PyObject *module, Py_buffer *data,
                                        const char *errors);
 
 static PyObject *
-_codecs_raw_unicode_escape_decode(PyObject *module, PyObject *args)
+_codecs_raw_unicode_escape_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "s*|z:raw_unicode_escape_decode",
+    if (!_PyArg_ParseStack(args, nargs, "s*|z:raw_unicode_escape_decode",
         &data, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("raw_unicode_escape_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_raw_unicode_escape_decode_impl(module, &data, errors);
@@ -668,21 +728,25 @@ PyDoc_STRVAR(_codecs_latin_1_decode__doc__,
 "\n");
 
 #define _CODECS_LATIN_1_DECODE_METHODDEF    \
-    {"latin_1_decode", (PyCFunction)_codecs_latin_1_decode, METH_VARARGS, _codecs_latin_1_decode__doc__},
+    {"latin_1_decode", (PyCFunction)_codecs_latin_1_decode, METH_FASTCALL, _codecs_latin_1_decode__doc__},
 
 static PyObject *
 _codecs_latin_1_decode_impl(PyObject *module, Py_buffer *data,
                             const char *errors);
 
 static PyObject *
-_codecs_latin_1_decode(PyObject *module, PyObject *args)
+_codecs_latin_1_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "y*|z:latin_1_decode",
+    if (!_PyArg_ParseStack(args, nargs, "y*|z:latin_1_decode",
         &data, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("latin_1_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_latin_1_decode_impl(module, &data, errors);
@@ -702,21 +766,25 @@ PyDoc_STRVAR(_codecs_ascii_decode__doc__,
 "\n");
 
 #define _CODECS_ASCII_DECODE_METHODDEF    \
-    {"ascii_decode", (PyCFunction)_codecs_ascii_decode, METH_VARARGS, _codecs_ascii_decode__doc__},
+    {"ascii_decode", (PyCFunction)_codecs_ascii_decode, METH_FASTCALL, _codecs_ascii_decode__doc__},
 
 static PyObject *
 _codecs_ascii_decode_impl(PyObject *module, Py_buffer *data,
                           const char *errors);
 
 static PyObject *
-_codecs_ascii_decode(PyObject *module, PyObject *args)
+_codecs_ascii_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "y*|z:ascii_decode",
+    if (!_PyArg_ParseStack(args, nargs, "y*|z:ascii_decode",
         &data, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("ascii_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_ascii_decode_impl(module, &data, errors);
@@ -736,22 +804,26 @@ PyDoc_STRVAR(_codecs_charmap_decode__doc__,
 "\n");
 
 #define _CODECS_CHARMAP_DECODE_METHODDEF    \
-    {"charmap_decode", (PyCFunction)_codecs_charmap_decode, METH_VARARGS, _codecs_charmap_decode__doc__},
+    {"charmap_decode", (PyCFunction)_codecs_charmap_decode, METH_FASTCALL, _codecs_charmap_decode__doc__},
 
 static PyObject *
 _codecs_charmap_decode_impl(PyObject *module, Py_buffer *data,
                             const char *errors, PyObject *mapping);
 
 static PyObject *
-_codecs_charmap_decode(PyObject *module, PyObject *args)
+_codecs_charmap_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     PyObject *mapping = NULL;
 
-    if (!PyArg_ParseTuple(args, "y*|zO:charmap_decode",
+    if (!_PyArg_ParseStack(args, nargs, "y*|zO:charmap_decode",
         &data, &errors, &mapping)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("charmap_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_charmap_decode_impl(module, &data, errors, mapping);
@@ -773,22 +845,26 @@ PyDoc_STRVAR(_codecs_mbcs_decode__doc__,
 "\n");
 
 #define _CODECS_MBCS_DECODE_METHODDEF    \
-    {"mbcs_decode", (PyCFunction)_codecs_mbcs_decode, METH_VARARGS, _codecs_mbcs_decode__doc__},
+    {"mbcs_decode", (PyCFunction)_codecs_mbcs_decode, METH_FASTCALL, _codecs_mbcs_decode__doc__},
 
 static PyObject *
 _codecs_mbcs_decode_impl(PyObject *module, Py_buffer *data,
                          const char *errors, int final);
 
 static PyObject *
-_codecs_mbcs_decode(PyObject *module, PyObject *args)
+_codecs_mbcs_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
 
-    if (!PyArg_ParseTuple(args, "y*|zi:mbcs_decode",
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:mbcs_decode",
         &data, &errors, &final)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("mbcs_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_mbcs_decode_impl(module, &data, errors, final);
@@ -812,22 +888,26 @@ PyDoc_STRVAR(_codecs_oem_decode__doc__,
 "\n");
 
 #define _CODECS_OEM_DECODE_METHODDEF    \
-    {"oem_decode", (PyCFunction)_codecs_oem_decode, METH_VARARGS, _codecs_oem_decode__doc__},
+    {"oem_decode", (PyCFunction)_codecs_oem_decode, METH_FASTCALL, _codecs_oem_decode__doc__},
 
 static PyObject *
 _codecs_oem_decode_impl(PyObject *module, Py_buffer *data,
                         const char *errors, int final);
 
 static PyObject *
-_codecs_oem_decode(PyObject *module, PyObject *args)
+_codecs_oem_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
 
-    if (!PyArg_ParseTuple(args, "y*|zi:oem_decode",
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:oem_decode",
         &data, &errors, &final)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("oem_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_oem_decode_impl(module, &data, errors, final);
@@ -851,14 +931,14 @@ PyDoc_STRVAR(_codecs_code_page_decode__doc__,
 "\n");
 
 #define _CODECS_CODE_PAGE_DECODE_METHODDEF    \
-    {"code_page_decode", (PyCFunction)_codecs_code_page_decode, METH_VARARGS, _codecs_code_page_decode__doc__},
+    {"code_page_decode", (PyCFunction)_codecs_code_page_decode, METH_FASTCALL, _codecs_code_page_decode__doc__},
 
 static PyObject *
 _codecs_code_page_decode_impl(PyObject *module, int codepage,
                               Py_buffer *data, const char *errors, int final);
 
 static PyObject *
-_codecs_code_page_decode(PyObject *module, PyObject *args)
+_codecs_code_page_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int codepage;
@@ -866,8 +946,12 @@ _codecs_code_page_decode(PyObject *module, PyObject *args)
     const char *errors = NULL;
     int final = 0;
 
-    if (!PyArg_ParseTuple(args, "iy*|zi:code_page_decode",
+    if (!_PyArg_ParseStack(args, nargs, "iy*|zi:code_page_decode",
         &codepage, &data, &errors, &final)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("code_page_decode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_code_page_decode_impl(module, codepage, &data, errors, final);
@@ -889,21 +973,25 @@ PyDoc_STRVAR(_codecs_readbuffer_encode__doc__,
 "\n");
 
 #define _CODECS_READBUFFER_ENCODE_METHODDEF    \
-    {"readbuffer_encode", (PyCFunction)_codecs_readbuffer_encode, METH_VARARGS, _codecs_readbuffer_encode__doc__},
+    {"readbuffer_encode", (PyCFunction)_codecs_readbuffer_encode, METH_FASTCALL, _codecs_readbuffer_encode__doc__},
 
 static PyObject *
 _codecs_readbuffer_encode_impl(PyObject *module, Py_buffer *data,
                                const char *errors);
 
 static PyObject *
-_codecs_readbuffer_encode(PyObject *module, PyObject *args)
+_codecs_readbuffer_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "s*|z:readbuffer_encode",
+    if (!_PyArg_ParseStack(args, nargs, "s*|z:readbuffer_encode",
         &data, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("readbuffer_encode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_readbuffer_encode_impl(module, &data, errors);
@@ -923,21 +1011,25 @@ PyDoc_STRVAR(_codecs_unicode_internal_encode__doc__,
 "\n");
 
 #define _CODECS_UNICODE_INTERNAL_ENCODE_METHODDEF    \
-    {"unicode_internal_encode", (PyCFunction)_codecs_unicode_internal_encode, METH_VARARGS, _codecs_unicode_internal_encode__doc__},
+    {"unicode_internal_encode", (PyCFunction)_codecs_unicode_internal_encode, METH_FASTCALL, _codecs_unicode_internal_encode__doc__},
 
 static PyObject *
 _codecs_unicode_internal_encode_impl(PyObject *module, PyObject *obj,
                                      const char *errors);
 
 static PyObject *
-_codecs_unicode_internal_encode(PyObject *module, PyObject *args)
+_codecs_unicode_internal_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *obj;
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "O|z:unicode_internal_encode",
+    if (!_PyArg_ParseStack(args, nargs, "O|z:unicode_internal_encode",
         &obj, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("unicode_internal_encode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_unicode_internal_encode_impl(module, obj, errors);
@@ -952,21 +1044,25 @@ PyDoc_STRVAR(_codecs_utf_7_encode__doc__,
 "\n");
 
 #define _CODECS_UTF_7_ENCODE_METHODDEF    \
-    {"utf_7_encode", (PyCFunction)_codecs_utf_7_encode, METH_VARARGS, _codecs_utf_7_encode__doc__},
+    {"utf_7_encode", (PyCFunction)_codecs_utf_7_encode, METH_FASTCALL, _codecs_utf_7_encode__doc__},
 
 static PyObject *
 _codecs_utf_7_encode_impl(PyObject *module, PyObject *str,
                           const char *errors);
 
 static PyObject *
-_codecs_utf_7_encode(PyObject *module, PyObject *args)
+_codecs_utf_7_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "U|z:utf_7_encode",
+    if (!_PyArg_ParseStack(args, nargs, "U|z:utf_7_encode",
         &str, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("utf_7_encode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_utf_7_encode_impl(module, str, errors);
@@ -981,21 +1077,25 @@ PyDoc_STRVAR(_codecs_utf_8_encode__doc__,
 "\n");
 
 #define _CODECS_UTF_8_ENCODE_METHODDEF    \
-    {"utf_8_encode", (PyCFunction)_codecs_utf_8_encode, METH_VARARGS, _codecs_utf_8_encode__doc__},
+    {"utf_8_encode", (PyCFunction)_codecs_utf_8_encode, METH_FASTCALL, _codecs_utf_8_encode__doc__},
 
 static PyObject *
 _codecs_utf_8_encode_impl(PyObject *module, PyObject *str,
                           const char *errors);
 
 static PyObject *
-_codecs_utf_8_encode(PyObject *module, PyObject *args)
+_codecs_utf_8_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "U|z:utf_8_encode",
+    if (!_PyArg_ParseStack(args, nargs, "U|z:utf_8_encode",
         &str, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("utf_8_encode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_utf_8_encode_impl(module, str, errors);
@@ -1010,22 +1110,26 @@ PyDoc_STRVAR(_codecs_utf_16_encode__doc__,
 "\n");
 
 #define _CODECS_UTF_16_ENCODE_METHODDEF    \
-    {"utf_16_encode", (PyCFunction)_codecs_utf_16_encode, METH_VARARGS, _codecs_utf_16_encode__doc__},
+    {"utf_16_encode", (PyCFunction)_codecs_utf_16_encode, METH_FASTCALL, _codecs_utf_16_encode__doc__},
 
 static PyObject *
 _codecs_utf_16_encode_impl(PyObject *module, PyObject *str,
                            const char *errors, int byteorder);
 
 static PyObject *
-_codecs_utf_16_encode(PyObject *module, PyObject *args)
+_codecs_utf_16_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
     int byteorder = 0;
 
-    if (!PyArg_ParseTuple(args, "U|zi:utf_16_encode",
+    if (!_PyArg_ParseStack(args, nargs, "U|zi:utf_16_encode",
         &str, &errors, &byteorder)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("utf_16_encode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_utf_16_encode_impl(module, str, errors, byteorder);
@@ -1040,21 +1144,25 @@ PyDoc_STRVAR(_codecs_utf_16_le_encode__doc__,
 "\n");
 
 #define _CODECS_UTF_16_LE_ENCODE_METHODDEF    \
-    {"utf_16_le_encode", (PyCFunction)_codecs_utf_16_le_encode, METH_VARARGS, _codecs_utf_16_le_encode__doc__},
+    {"utf_16_le_encode", (PyCFunction)_codecs_utf_16_le_encode, METH_FASTCALL, _codecs_utf_16_le_encode__doc__},
 
 static PyObject *
 _codecs_utf_16_le_encode_impl(PyObject *module, PyObject *str,
                               const char *errors);
 
 static PyObject *
-_codecs_utf_16_le_encode(PyObject *module, PyObject *args)
+_codecs_utf_16_le_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "U|z:utf_16_le_encode",
+    if (!_PyArg_ParseStack(args, nargs, "U|z:utf_16_le_encode",
         &str, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("utf_16_le_encode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_utf_16_le_encode_impl(module, str, errors);
@@ -1069,21 +1177,25 @@ PyDoc_STRVAR(_codecs_utf_16_be_encode__doc__,
 "\n");
 
 #define _CODECS_UTF_16_BE_ENCODE_METHODDEF    \
-    {"utf_16_be_encode", (PyCFunction)_codecs_utf_16_be_encode, METH_VARARGS, _codecs_utf_16_be_encode__doc__},
+    {"utf_16_be_encode", (PyCFunction)_codecs_utf_16_be_encode, METH_FASTCALL, _codecs_utf_16_be_encode__doc__},
 
 static PyObject *
 _codecs_utf_16_be_encode_impl(PyObject *module, PyObject *str,
                               const char *errors);
 
 static PyObject *
-_codecs_utf_16_be_encode(PyObject *module, PyObject *args)
+_codecs_utf_16_be_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "U|z:utf_16_be_encode",
+    if (!_PyArg_ParseStack(args, nargs, "U|z:utf_16_be_encode",
         &str, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("utf_16_be_encode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_utf_16_be_encode_impl(module, str, errors);
@@ -1098,22 +1210,26 @@ PyDoc_STRVAR(_codecs_utf_32_encode__doc__,
 "\n");
 
 #define _CODECS_UTF_32_ENCODE_METHODDEF    \
-    {"utf_32_encode", (PyCFunction)_codecs_utf_32_encode, METH_VARARGS, _codecs_utf_32_encode__doc__},
+    {"utf_32_encode", (PyCFunction)_codecs_utf_32_encode, METH_FASTCALL, _codecs_utf_32_encode__doc__},
 
 static PyObject *
 _codecs_utf_32_encode_impl(PyObject *module, PyObject *str,
                            const char *errors, int byteorder);
 
 static PyObject *
-_codecs_utf_32_encode(PyObject *module, PyObject *args)
+_codecs_utf_32_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
     int byteorder = 0;
 
-    if (!PyArg_ParseTuple(args, "U|zi:utf_32_encode",
+    if (!_PyArg_ParseStack(args, nargs, "U|zi:utf_32_encode",
         &str, &errors, &byteorder)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("utf_32_encode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_utf_32_encode_impl(module, str, errors, byteorder);
@@ -1128,21 +1244,25 @@ PyDoc_STRVAR(_codecs_utf_32_le_encode__doc__,
 "\n");
 
 #define _CODECS_UTF_32_LE_ENCODE_METHODDEF    \
-    {"utf_32_le_encode", (PyCFunction)_codecs_utf_32_le_encode, METH_VARARGS, _codecs_utf_32_le_encode__doc__},
+    {"utf_32_le_encode", (PyCFunction)_codecs_utf_32_le_encode, METH_FASTCALL, _codecs_utf_32_le_encode__doc__},
 
 static PyObject *
 _codecs_utf_32_le_encode_impl(PyObject *module, PyObject *str,
                               const char *errors);
 
 static PyObject *
-_codecs_utf_32_le_encode(PyObject *module, PyObject *args)
+_codecs_utf_32_le_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "U|z:utf_32_le_encode",
+    if (!_PyArg_ParseStack(args, nargs, "U|z:utf_32_le_encode",
         &str, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("utf_32_le_encode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_utf_32_le_encode_impl(module, str, errors);
@@ -1157,21 +1277,25 @@ PyDoc_STRVAR(_codecs_utf_32_be_encode__doc__,
 "\n");
 
 #define _CODECS_UTF_32_BE_ENCODE_METHODDEF    \
-    {"utf_32_be_encode", (PyCFunction)_codecs_utf_32_be_encode, METH_VARARGS, _codecs_utf_32_be_encode__doc__},
+    {"utf_32_be_encode", (PyCFunction)_codecs_utf_32_be_encode, METH_FASTCALL, _codecs_utf_32_be_encode__doc__},
 
 static PyObject *
 _codecs_utf_32_be_encode_impl(PyObject *module, PyObject *str,
                               const char *errors);
 
 static PyObject *
-_codecs_utf_32_be_encode(PyObject *module, PyObject *args)
+_codecs_utf_32_be_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "U|z:utf_32_be_encode",
+    if (!_PyArg_ParseStack(args, nargs, "U|z:utf_32_be_encode",
         &str, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("utf_32_be_encode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_utf_32_be_encode_impl(module, str, errors);
@@ -1186,21 +1310,25 @@ PyDoc_STRVAR(_codecs_unicode_escape_encode__doc__,
 "\n");
 
 #define _CODECS_UNICODE_ESCAPE_ENCODE_METHODDEF    \
-    {"unicode_escape_encode", (PyCFunction)_codecs_unicode_escape_encode, METH_VARARGS, _codecs_unicode_escape_encode__doc__},
+    {"unicode_escape_encode", (PyCFunction)_codecs_unicode_escape_encode, METH_FASTCALL, _codecs_unicode_escape_encode__doc__},
 
 static PyObject *
 _codecs_unicode_escape_encode_impl(PyObject *module, PyObject *str,
                                    const char *errors);
 
 static PyObject *
-_codecs_unicode_escape_encode(PyObject *module, PyObject *args)
+_codecs_unicode_escape_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "U|z:unicode_escape_encode",
+    if (!_PyArg_ParseStack(args, nargs, "U|z:unicode_escape_encode",
         &str, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("unicode_escape_encode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_unicode_escape_encode_impl(module, str, errors);
@@ -1215,21 +1343,25 @@ PyDoc_STRVAR(_codecs_raw_unicode_escape_encode__doc__,
 "\n");
 
 #define _CODECS_RAW_UNICODE_ESCAPE_ENCODE_METHODDEF    \
-    {"raw_unicode_escape_encode", (PyCFunction)_codecs_raw_unicode_escape_encode, METH_VARARGS, _codecs_raw_unicode_escape_encode__doc__},
+    {"raw_unicode_escape_encode", (PyCFunction)_codecs_raw_unicode_escape_encode, METH_FASTCALL, _codecs_raw_unicode_escape_encode__doc__},
 
 static PyObject *
 _codecs_raw_unicode_escape_encode_impl(PyObject *module, PyObject *str,
                                        const char *errors);
 
 static PyObject *
-_codecs_raw_unicode_escape_encode(PyObject *module, PyObject *args)
+_codecs_raw_unicode_escape_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "U|z:raw_unicode_escape_encode",
+    if (!_PyArg_ParseStack(args, nargs, "U|z:raw_unicode_escape_encode",
         &str, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("raw_unicode_escape_encode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_raw_unicode_escape_encode_impl(module, str, errors);
@@ -1244,21 +1376,25 @@ PyDoc_STRVAR(_codecs_latin_1_encode__doc__,
 "\n");
 
 #define _CODECS_LATIN_1_ENCODE_METHODDEF    \
-    {"latin_1_encode", (PyCFunction)_codecs_latin_1_encode, METH_VARARGS, _codecs_latin_1_encode__doc__},
+    {"latin_1_encode", (PyCFunction)_codecs_latin_1_encode, METH_FASTCALL, _codecs_latin_1_encode__doc__},
 
 static PyObject *
 _codecs_latin_1_encode_impl(PyObject *module, PyObject *str,
                             const char *errors);
 
 static PyObject *
-_codecs_latin_1_encode(PyObject *module, PyObject *args)
+_codecs_latin_1_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "U|z:latin_1_encode",
+    if (!_PyArg_ParseStack(args, nargs, "U|z:latin_1_encode",
         &str, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("latin_1_encode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_latin_1_encode_impl(module, str, errors);
@@ -1273,21 +1409,25 @@ PyDoc_STRVAR(_codecs_ascii_encode__doc__,
 "\n");
 
 #define _CODECS_ASCII_ENCODE_METHODDEF    \
-    {"ascii_encode", (PyCFunction)_codecs_ascii_encode, METH_VARARGS, _codecs_ascii_encode__doc__},
+    {"ascii_encode", (PyCFunction)_codecs_ascii_encode, METH_FASTCALL, _codecs_ascii_encode__doc__},
 
 static PyObject *
 _codecs_ascii_encode_impl(PyObject *module, PyObject *str,
                           const char *errors);
 
 static PyObject *
-_codecs_ascii_encode(PyObject *module, PyObject *args)
+_codecs_ascii_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "U|z:ascii_encode",
+    if (!_PyArg_ParseStack(args, nargs, "U|z:ascii_encode",
         &str, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("ascii_encode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_ascii_encode_impl(module, str, errors);
@@ -1302,22 +1442,26 @@ PyDoc_STRVAR(_codecs_charmap_encode__doc__,
 "\n");
 
 #define _CODECS_CHARMAP_ENCODE_METHODDEF    \
-    {"charmap_encode", (PyCFunction)_codecs_charmap_encode, METH_VARARGS, _codecs_charmap_encode__doc__},
+    {"charmap_encode", (PyCFunction)_codecs_charmap_encode, METH_FASTCALL, _codecs_charmap_encode__doc__},
 
 static PyObject *
 _codecs_charmap_encode_impl(PyObject *module, PyObject *str,
                             const char *errors, PyObject *mapping);
 
 static PyObject *
-_codecs_charmap_encode(PyObject *module, PyObject *args)
+_codecs_charmap_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
     PyObject *mapping = NULL;
 
-    if (!PyArg_ParseTuple(args, "U|zO:charmap_encode",
+    if (!_PyArg_ParseStack(args, nargs, "U|zO:charmap_encode",
         &str, &errors, &mapping)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("charmap_encode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_charmap_encode_impl(module, str, errors, mapping);
@@ -1360,20 +1504,24 @@ PyDoc_STRVAR(_codecs_mbcs_encode__doc__,
 "\n");
 
 #define _CODECS_MBCS_ENCODE_METHODDEF    \
-    {"mbcs_encode", (PyCFunction)_codecs_mbcs_encode, METH_VARARGS, _codecs_mbcs_encode__doc__},
+    {"mbcs_encode", (PyCFunction)_codecs_mbcs_encode, METH_FASTCALL, _codecs_mbcs_encode__doc__},
 
 static PyObject *
 _codecs_mbcs_encode_impl(PyObject *module, PyObject *str, const char *errors);
 
 static PyObject *
-_codecs_mbcs_encode(PyObject *module, PyObject *args)
+_codecs_mbcs_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "U|z:mbcs_encode",
+    if (!_PyArg_ParseStack(args, nargs, "U|z:mbcs_encode",
         &str, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("mbcs_encode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_mbcs_encode_impl(module, str, errors);
@@ -1392,20 +1540,24 @@ PyDoc_STRVAR(_codecs_oem_encode__doc__,
 "\n");
 
 #define _CODECS_OEM_ENCODE_METHODDEF    \
-    {"oem_encode", (PyCFunction)_codecs_oem_encode, METH_VARARGS, _codecs_oem_encode__doc__},
+    {"oem_encode", (PyCFunction)_codecs_oem_encode, METH_FASTCALL, _codecs_oem_encode__doc__},
 
 static PyObject *
 _codecs_oem_encode_impl(PyObject *module, PyObject *str, const char *errors);
 
 static PyObject *
-_codecs_oem_encode(PyObject *module, PyObject *args)
+_codecs_oem_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "U|z:oem_encode",
+    if (!_PyArg_ParseStack(args, nargs, "U|z:oem_encode",
         &str, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("oem_encode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_oem_encode_impl(module, str, errors);
@@ -1424,22 +1576,26 @@ PyDoc_STRVAR(_codecs_code_page_encode__doc__,
 "\n");
 
 #define _CODECS_CODE_PAGE_ENCODE_METHODDEF    \
-    {"code_page_encode", (PyCFunction)_codecs_code_page_encode, METH_VARARGS, _codecs_code_page_encode__doc__},
+    {"code_page_encode", (PyCFunction)_codecs_code_page_encode, METH_FASTCALL, _codecs_code_page_encode__doc__},
 
 static PyObject *
 _codecs_code_page_encode_impl(PyObject *module, int code_page, PyObject *str,
                               const char *errors);
 
 static PyObject *
-_codecs_code_page_encode(PyObject *module, PyObject *args)
+_codecs_code_page_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int code_page;
     PyObject *str;
     const char *errors = NULL;
 
-    if (!PyArg_ParseTuple(args, "iU|z:code_page_encode",
+    if (!_PyArg_ParseStack(args, nargs, "iU|z:code_page_encode",
         &code_page, &str, &errors)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("code_page_encode", kwnames)) {
         goto exit;
     }
     return_value = _codecs_code_page_encode_impl(module, code_page, str, errors);
@@ -1461,21 +1617,25 @@ PyDoc_STRVAR(_codecs_register_error__doc__,
 "error and must return a (replacement, new position) tuple.");
 
 #define _CODECS_REGISTER_ERROR_METHODDEF    \
-    {"register_error", (PyCFunction)_codecs_register_error, METH_VARARGS, _codecs_register_error__doc__},
+    {"register_error", (PyCFunction)_codecs_register_error, METH_FASTCALL, _codecs_register_error__doc__},
 
 static PyObject *
 _codecs_register_error_impl(PyObject *module, const char *errors,
                             PyObject *handler);
 
 static PyObject *
-_codecs_register_error(PyObject *module, PyObject *args)
+_codecs_register_error(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     const char *errors;
     PyObject *handler;
 
-    if (!PyArg_ParseTuple(args, "sO:register_error",
+    if (!_PyArg_ParseStack(args, nargs, "sO:register_error",
         &errors, &handler)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("register_error", kwnames)) {
         goto exit;
     }
     return_value = _codecs_register_error_impl(module, errors, handler);
@@ -1537,4 +1697,4 @@ exit:
 #ifndef _CODECS_CODE_PAGE_ENCODE_METHODDEF
     #define _CODECS_CODE_PAGE_ENCODE_METHODDEF
 #endif /* !defined(_CODECS_CODE_PAGE_ENCODE_METHODDEF) */
-/*[clinic end generated code: output=6d6afcabde10ed79 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=36fb42f450a3b4dc input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/_cryptmodule.inc
+++ b/third_party/python/Modules/clinic/_cryptmodule.inc
@@ -15,20 +15,24 @@ PyDoc_STRVAR(crypt_crypt__doc__,
 "results for a given *word*.");
 
 #define CRYPT_CRYPT_METHODDEF    \
-    {"crypt", (PyCFunction)crypt_crypt, METH_VARARGS, crypt_crypt__doc__},
+    {"crypt", (PyCFunction)crypt_crypt, METH_FASTCALL, crypt_crypt__doc__},
 
 static PyObject *
 crypt_crypt_impl(PyObject *module, const char *word, const char *salt);
 
 static PyObject *
-crypt_crypt(PyObject *module, PyObject *args)
+crypt_crypt(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     const char *word;
     const char *salt;
 
-    if (!PyArg_ParseTuple(args, "ss:crypt",
+    if (!_PyArg_ParseStack(args, nargs, "ss:crypt",
         &word, &salt)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("crypt", kwnames)) {
         goto exit;
     }
     return_value = crypt_crypt_impl(module, word, salt);
@@ -36,4 +40,4 @@ crypt_crypt(PyObject *module, PyObject *args)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=8dfc88264e662df4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=3fd5d3625a6f32fe input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/_datetimemodule.inc
+++ b/third_party/python/Modules/clinic/_datetimemodule.inc
@@ -37,4 +37,4 @@ datetime_datetime_now(PyTypeObject *type, PyObject **args, Py_ssize_t nargs, PyO
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=8aaac0705add61ca input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ff78f2f51687e9a9 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/_datetimemodule.inc
+++ b/third_party/python/Modules/clinic/_datetimemodule.inc
@@ -28,7 +28,7 @@ datetime_datetime_now(PyTypeObject *type, PyObject **args, Py_ssize_t nargs, PyO
     static _PyArg_Parser _parser = {"|O:now", _keywords, 0};
     PyObject *tz = Py_None;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &tz)) {
         goto exit;
     }

--- a/third_party/python/Modules/clinic/_dbmmodule.inc
+++ b/third_party/python/Modules/clinic/_dbmmodule.inc
@@ -46,22 +46,26 @@ PyDoc_STRVAR(_dbm_dbm_get__doc__,
 "Return the value for key if present, otherwise default.");
 
 #define _DBM_DBM_GET_METHODDEF    \
-    {"get", (PyCFunction)_dbm_dbm_get, METH_VARARGS, _dbm_dbm_get__doc__},
+    {"get", (PyCFunction)_dbm_dbm_get, METH_FASTCALL, _dbm_dbm_get__doc__},
 
 static PyObject *
 _dbm_dbm_get_impl(dbmobject *self, const char *key,
                   Py_ssize_clean_t key_length, PyObject *default_value);
 
 static PyObject *
-_dbm_dbm_get(dbmobject *self, PyObject *args)
+_dbm_dbm_get(dbmobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     const char *key;
     Py_ssize_clean_t key_length;
     PyObject *default_value = Py_None;
 
-    if (!PyArg_ParseTuple(args, "s#|O:get",
+    if (!_PyArg_ParseStack(args, nargs, "s#|O:get",
         &key, &key_length, &default_value)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("get", kwnames)) {
         goto exit;
     }
     return_value = _dbm_dbm_get_impl(self, key, key_length, default_value);
@@ -79,7 +83,7 @@ PyDoc_STRVAR(_dbm_dbm_setdefault__doc__,
 "If key is not in the database, it is inserted with default as the value.");
 
 #define _DBM_DBM_SETDEFAULT_METHODDEF    \
-    {"setdefault", (PyCFunction)_dbm_dbm_setdefault, METH_VARARGS, _dbm_dbm_setdefault__doc__},
+    {"setdefault", (PyCFunction)_dbm_dbm_setdefault, METH_FASTCALL, _dbm_dbm_setdefault__doc__},
 
 static PyObject *
 _dbm_dbm_setdefault_impl(dbmobject *self, const char *key,
@@ -87,15 +91,19 @@ _dbm_dbm_setdefault_impl(dbmobject *self, const char *key,
                          PyObject *default_value);
 
 static PyObject *
-_dbm_dbm_setdefault(dbmobject *self, PyObject *args)
+_dbm_dbm_setdefault(dbmobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     const char *key;
     Py_ssize_clean_t key_length;
     PyObject *default_value = NULL;
 
-    if (!PyArg_ParseTuple(args, "s#|O:setdefault",
+    if (!_PyArg_ParseStack(args, nargs, "s#|O:setdefault",
         &key, &key_length, &default_value)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("setdefault", kwnames)) {
         goto exit;
     }
     return_value = _dbm_dbm_setdefault_impl(self, key, key_length, default_value);
@@ -119,22 +127,26 @@ PyDoc_STRVAR(dbmopen__doc__,
 "    (e.g. os.O_RDWR).");
 
 #define DBMOPEN_METHODDEF    \
-    {"open", (PyCFunction)dbmopen, METH_VARARGS, dbmopen__doc__},
+    {"open", (PyCFunction)dbmopen, METH_FASTCALL, dbmopen__doc__},
 
 static PyObject *
 dbmopen_impl(PyObject *module, PyObject *filename, const char *flags,
              int mode);
 
 static PyObject *
-dbmopen(PyObject *module, PyObject *args)
+dbmopen(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *filename;
     const char *flags = "r";
     int mode = 438;
 
-    if (!PyArg_ParseTuple(args, "U|si:open",
+    if (!_PyArg_ParseStack(args, nargs, "U|si:open",
         &filename, &flags, &mode)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("open", kwnames)) {
         goto exit;
     }
     return_value = dbmopen_impl(module, filename, flags, mode);
@@ -142,4 +154,4 @@ dbmopen(PyObject *module, PyObject *args)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=919cc4337be4a5d3 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=60482e924110a70a input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/_elementtree.inc
+++ b/third_party/python/Modules/clinic/_elementtree.inc
@@ -152,7 +152,7 @@ _elementtree_Element_find(ElementObject *self, PyObject **args, Py_ssize_t nargs
     PyObject *path;
     PyObject *namespaces = Py_None;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &path, &namespaces)) {
         goto exit;
     }
@@ -185,7 +185,7 @@ _elementtree_Element_findtext(ElementObject *self, PyObject **args, Py_ssize_t n
     PyObject *default_value = Py_None;
     PyObject *namespaces = Py_None;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &path, &default_value, &namespaces)) {
         goto exit;
     }
@@ -216,7 +216,7 @@ _elementtree_Element_findall(ElementObject *self, PyObject **args, Py_ssize_t na
     PyObject *path;
     PyObject *namespaces = Py_None;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &path, &namespaces)) {
         goto exit;
     }
@@ -247,7 +247,7 @@ _elementtree_Element_iterfind(ElementObject *self, PyObject **args, Py_ssize_t n
     PyObject *path;
     PyObject *namespaces = Py_None;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &path, &namespaces)) {
         goto exit;
     }
@@ -278,7 +278,7 @@ _elementtree_Element_get(ElementObject *self, PyObject **args, Py_ssize_t nargs,
     PyObject *key;
     PyObject *default_value = Py_None;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &key, &default_value)) {
         goto exit;
     }
@@ -324,7 +324,7 @@ _elementtree_Element_iter(ElementObject *self, PyObject **args, Py_ssize_t nargs
     static _PyArg_Parser _parser = {"|O:iter", _keywords, 0};
     PyObject *tag = Py_None;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &tag)) {
         goto exit;
     }

--- a/third_party/python/Modules/clinic/_elementtree.inc
+++ b/third_party/python/Modules/clinic/_elementtree.inc
@@ -424,22 +424,26 @@ PyDoc_STRVAR(_elementtree_Element_makeelement__doc__,
 "\n");
 
 #define _ELEMENTTREE_ELEMENT_MAKEELEMENT_METHODDEF    \
-    {"makeelement", (PyCFunction)_elementtree_Element_makeelement, METH_VARARGS, _elementtree_Element_makeelement__doc__},
+    {"makeelement", (PyCFunction)_elementtree_Element_makeelement, METH_FASTCALL, _elementtree_Element_makeelement__doc__},
 
 static PyObject *
 _elementtree_Element_makeelement_impl(ElementObject *self, PyObject *tag,
                                       PyObject *attrib);
 
 static PyObject *
-_elementtree_Element_makeelement(ElementObject *self, PyObject *args)
+_elementtree_Element_makeelement(ElementObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *tag;
     PyObject *attrib;
 
-    if (!PyArg_UnpackTuple(args, "makeelement",
+    if (!_PyArg_UnpackStack(args, nargs, "makeelement",
         2, 2,
         &tag, &attrib)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("makeelement", kwnames)) {
         goto exit;
     }
     return_value = _elementtree_Element_makeelement_impl(self, tag, attrib);
@@ -480,22 +484,26 @@ PyDoc_STRVAR(_elementtree_Element_set__doc__,
 "\n");
 
 #define _ELEMENTTREE_ELEMENT_SET_METHODDEF    \
-    {"set", (PyCFunction)_elementtree_Element_set, METH_VARARGS, _elementtree_Element_set__doc__},
+    {"set", (PyCFunction)_elementtree_Element_set, METH_FASTCALL, _elementtree_Element_set__doc__},
 
 static PyObject *
 _elementtree_Element_set_impl(ElementObject *self, PyObject *key,
                               PyObject *value);
 
 static PyObject *
-_elementtree_Element_set(ElementObject *self, PyObject *args)
+_elementtree_Element_set(ElementObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *key;
     PyObject *value;
 
-    if (!PyArg_UnpackTuple(args, "set",
+    if (!_PyArg_UnpackStack(args, nargs, "set",
         2, 2,
         &key, &value)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("set", kwnames)) {
         goto exit;
     }
     return_value = _elementtree_Element_set_impl(self, key, value);
@@ -565,22 +573,26 @@ PyDoc_STRVAR(_elementtree_TreeBuilder_start__doc__,
 "\n");
 
 #define _ELEMENTTREE_TREEBUILDER_START_METHODDEF    \
-    {"start", (PyCFunction)_elementtree_TreeBuilder_start, METH_VARARGS, _elementtree_TreeBuilder_start__doc__},
+    {"start", (PyCFunction)_elementtree_TreeBuilder_start, METH_FASTCALL, _elementtree_TreeBuilder_start__doc__},
 
 static PyObject *
 _elementtree_TreeBuilder_start_impl(TreeBuilderObject *self, PyObject *tag,
                                     PyObject *attrs);
 
 static PyObject *
-_elementtree_TreeBuilder_start(TreeBuilderObject *self, PyObject *args)
+_elementtree_TreeBuilder_start(TreeBuilderObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *tag;
     PyObject *attrs = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "start",
+    if (!_PyArg_UnpackStack(args, nargs, "start",
         1, 2,
         &tag, &attrs)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("start", kwnames)) {
         goto exit;
     }
     return_value = _elementtree_TreeBuilder_start_impl(self, tag, attrs);
@@ -652,23 +664,27 @@ PyDoc_STRVAR(_elementtree_XMLParser_doctype__doc__,
 "\n");
 
 #define _ELEMENTTREE_XMLPARSER_DOCTYPE_METHODDEF    \
-    {"doctype", (PyCFunction)_elementtree_XMLParser_doctype, METH_VARARGS, _elementtree_XMLParser_doctype__doc__},
+    {"doctype", (PyCFunction)_elementtree_XMLParser_doctype, METH_FASTCALL, _elementtree_XMLParser_doctype__doc__},
 
 static PyObject *
 _elementtree_XMLParser_doctype_impl(XMLParserObject *self, PyObject *name,
                                     PyObject *pubid, PyObject *system);
 
 static PyObject *
-_elementtree_XMLParser_doctype(XMLParserObject *self, PyObject *args)
+_elementtree_XMLParser_doctype(XMLParserObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *name;
     PyObject *pubid;
     PyObject *system;
 
-    if (!PyArg_UnpackTuple(args, "doctype",
+    if (!_PyArg_UnpackStack(args, nargs, "doctype",
         3, 3,
         &name, &pubid, &system)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("doctype", kwnames)) {
         goto exit;
     }
     return_value = _elementtree_XMLParser_doctype_impl(self, name, pubid, system);
@@ -683,7 +699,7 @@ PyDoc_STRVAR(_elementtree_XMLParser__setevents__doc__,
 "\n");
 
 #define _ELEMENTTREE_XMLPARSER__SETEVENTS_METHODDEF    \
-    {"_setevents", (PyCFunction)_elementtree_XMLParser__setevents, METH_VARARGS, _elementtree_XMLParser__setevents__doc__},
+    {"_setevents", (PyCFunction)_elementtree_XMLParser__setevents, METH_FASTCALL, _elementtree_XMLParser__setevents__doc__},
 
 static PyObject *
 _elementtree_XMLParser__setevents_impl(XMLParserObject *self,
@@ -691,15 +707,19 @@ _elementtree_XMLParser__setevents_impl(XMLParserObject *self,
                                        PyObject *events_to_report);
 
 static PyObject *
-_elementtree_XMLParser__setevents(XMLParserObject *self, PyObject *args)
+_elementtree_XMLParser__setevents(XMLParserObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *events_queue;
     PyObject *events_to_report = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "_setevents",
+    if (!_PyArg_UnpackStack(args, nargs, "_setevents",
         1, 2,
         &events_queue, &events_to_report)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("_setevents", kwnames)) {
         goto exit;
     }
     return_value = _elementtree_XMLParser__setevents_impl(self, events_queue, events_to_report);
@@ -707,4 +727,4 @@ _elementtree_XMLParser__setevents(XMLParserObject *self, PyObject *args)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=4e3d22c6f6d832b2 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b69fa98c40917f58 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/_elementtree.inc
+++ b/third_party/python/Modules/clinic/_elementtree.inc
@@ -357,21 +357,25 @@ PyDoc_STRVAR(_elementtree_Element_insert__doc__,
 "\n");
 
 #define _ELEMENTTREE_ELEMENT_INSERT_METHODDEF    \
-    {"insert", (PyCFunction)_elementtree_Element_insert, METH_VARARGS, _elementtree_Element_insert__doc__},
+    {"insert", (PyCFunction)_elementtree_Element_insert, METH_FASTCALL, _elementtree_Element_insert__doc__},
 
 static PyObject *
 _elementtree_Element_insert_impl(ElementObject *self, Py_ssize_t index,
                                  PyObject *subelement);
 
 static PyObject *
-_elementtree_Element_insert(ElementObject *self, PyObject *args)
+_elementtree_Element_insert(ElementObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_ssize_t index;
     PyObject *subelement;
 
-    if (!PyArg_ParseTuple(args, "nO!:insert",
+    if (!_PyArg_ParseStack(args, nargs, "nO!:insert",
         &index, &Element_Type, &subelement)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("insert", kwnames)) {
         goto exit;
     }
     return_value = _elementtree_Element_insert_impl(self, index, subelement);
@@ -703,4 +707,4 @@ _elementtree_XMLParser__setevents(XMLParserObject *self, PyObject *args)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=b4a571a98ced3163 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4e3d22c6f6d832b2 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/_gdbmmodule.inc
+++ b/third_party/python/Modules/clinic/_gdbmmodule.inc
@@ -232,22 +232,26 @@ PyDoc_STRVAR(dbmopen__doc__,
 "when the database has to be created.  It defaults to octal 0o666.");
 
 #define DBMOPEN_METHODDEF    \
-    {"open", (PyCFunction)dbmopen, METH_VARARGS, dbmopen__doc__},
+    {"open", (PyCFunction)dbmopen, METH_FASTCALL, dbmopen__doc__},
 
 static PyObject *
 dbmopen_impl(PyObject *module, PyObject *filename, const char *flags,
              int mode);
 
 static PyObject *
-dbmopen(PyObject *module, PyObject *args)
+dbmopen(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *filename;
     const char *flags = "r";
     int mode = 438;
 
-    if (!PyArg_ParseTuple(args, "U|si:open",
+    if (!_PyArg_ParseStack(args, nargs, "U|si:open",
         &filename, &flags, &mode)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("open", kwnames)) {
         goto exit;
     }
     return_value = dbmopen_impl(module, filename, flags, mode);
@@ -255,4 +259,4 @@ dbmopen(PyObject *module, PyObject *args)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=afb99364ac420d10 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=16874d4acd7e7749 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/_gdbmmodule.inc
+++ b/third_party/python/Modules/clinic/_gdbmmodule.inc
@@ -10,21 +10,25 @@ PyDoc_STRVAR(_gdbm_gdbm_get__doc__,
 "Get the value for key, or default if not present.");
 
 #define _GDBM_GDBM_GET_METHODDEF    \
-    {"get", (PyCFunction)_gdbm_gdbm_get, METH_VARARGS, _gdbm_gdbm_get__doc__},
+    {"get", (PyCFunction)_gdbm_gdbm_get, METH_FASTCALL, _gdbm_gdbm_get__doc__},
 
 static PyObject *
 _gdbm_gdbm_get_impl(dbmobject *self, PyObject *key, PyObject *default_value);
 
 static PyObject *
-_gdbm_gdbm_get(dbmobject *self, PyObject *args)
+_gdbm_gdbm_get(dbmobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *key;
     PyObject *default_value = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "get",
+    if (!_PyArg_UnpackStack(args, nargs, "get",
         1, 2,
         &key, &default_value)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("get", kwnames)) {
         goto exit;
     }
     return_value = _gdbm_gdbm_get_impl(self, key, default_value);
@@ -40,22 +44,26 @@ PyDoc_STRVAR(_gdbm_gdbm_setdefault__doc__,
 "Get value for key, or set it to default and return default if not present.");
 
 #define _GDBM_GDBM_SETDEFAULT_METHODDEF    \
-    {"setdefault", (PyCFunction)_gdbm_gdbm_setdefault, METH_VARARGS, _gdbm_gdbm_setdefault__doc__},
+    {"setdefault", (PyCFunction)_gdbm_gdbm_setdefault, METH_FASTCALL, _gdbm_gdbm_setdefault__doc__},
 
 static PyObject *
 _gdbm_gdbm_setdefault_impl(dbmobject *self, PyObject *key,
                            PyObject *default_value);
 
 static PyObject *
-_gdbm_gdbm_setdefault(dbmobject *self, PyObject *args)
+_gdbm_gdbm_setdefault(dbmobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *key;
     PyObject *default_value = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "setdefault",
+    if (!_PyArg_UnpackStack(args, nargs, "setdefault",
         1, 2,
         &key, &default_value)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("setdefault", kwnames)) {
         goto exit;
     }
     return_value = _gdbm_gdbm_setdefault_impl(self, key, default_value);
@@ -259,4 +267,4 @@ dbmopen(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=16874d4acd7e7749 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d12de247acddccc3 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/_lzmamodule.inc
+++ b/third_party/python/Modules/clinic/_lzmamodule.inc
@@ -230,21 +230,25 @@ PyDoc_STRVAR(_lzma__decode_filter_properties__doc__,
 "The result does not include the filter ID itself, only the options.");
 
 #define _LZMA__DECODE_FILTER_PROPERTIES_METHODDEF    \
-    {"_decode_filter_properties", (PyCFunction)_lzma__decode_filter_properties, METH_VARARGS, _lzma__decode_filter_properties__doc__},
+    {"_decode_filter_properties", (PyCFunction)_lzma__decode_filter_properties, METH_FASTCALL, _lzma__decode_filter_properties__doc__},
 
 static PyObject *
 _lzma__decode_filter_properties_impl(PyObject *module, lzma_vli filter_id,
                                      Py_buffer *encoded_props);
 
 static PyObject *
-_lzma__decode_filter_properties(PyObject *module, PyObject *args)
+_lzma__decode_filter_properties(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     lzma_vli filter_id;
     Py_buffer encoded_props = {NULL, NULL};
 
-    if (!PyArg_ParseTuple(args, "O&y*:_decode_filter_properties",
+    if (!_PyArg_ParseStack(args, nargs, "O&y*:_decode_filter_properties",
         lzma_vli_converter, &filter_id, &encoded_props)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("_decode_filter_properties", kwnames)) {
         goto exit;
     }
     return_value = _lzma__decode_filter_properties_impl(module, filter_id, &encoded_props);
@@ -257,4 +261,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=f27abae460122706 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5f7a915fb7e41453 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/_lzmamodule.inc
+++ b/third_party/python/Modules/clinic/_lzmamodule.inc
@@ -97,7 +97,7 @@ _lzma_LZMADecompressor_decompress(Decompressor *self, PyObject **args, Py_ssize_
     Py_buffer data = {NULL, NULL};
     Py_ssize_t max_length = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &data, &max_length)) {
         goto exit;
     }

--- a/third_party/python/Modules/clinic/_opcode.inc
+++ b/third_party/python/Modules/clinic/_opcode.inc
@@ -10,21 +10,25 @@ PyDoc_STRVAR(_opcode_stack_effect__doc__,
 "Compute the stack effect of the opcode.");
 
 #define _OPCODE_STACK_EFFECT_METHODDEF    \
-    {"stack_effect", (PyCFunction)_opcode_stack_effect, METH_VARARGS, _opcode_stack_effect__doc__},
+    {"stack_effect", (PyCFunction)_opcode_stack_effect, METH_FASTCALL, _opcode_stack_effect__doc__},
 
 static int
 _opcode_stack_effect_impl(PyObject *module, int opcode, PyObject *oparg);
 
 static PyObject *
-_opcode_stack_effect(PyObject *module, PyObject *args)
+_opcode_stack_effect(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int opcode;
     PyObject *oparg = Py_None;
     int _return_value;
 
-    if (!PyArg_ParseTuple(args, "i|O:stack_effect",
+    if (!_PyArg_ParseStack(args, nargs, "i|O:stack_effect",
         &opcode, &oparg)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("stack_effect", kwnames)) {
         goto exit;
     }
     _return_value = _opcode_stack_effect_impl(module, opcode, oparg);
@@ -36,4 +40,4 @@ _opcode_stack_effect(PyObject *module, PyObject *args)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=4d91c6a765097853 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=62858005ac85baa9 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/_pickle.inc
+++ b/third_party/python/Modules/clinic/_pickle.inc
@@ -561,4 +561,4 @@ _pickle_loads(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=82be137b3c09cb9f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d7222d1219039fbd input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/_pickle.inc
+++ b/third_party/python/Modules/clinic/_pickle.inc
@@ -200,7 +200,7 @@ PyDoc_STRVAR(_pickle_Unpickler_find_class__doc__,
 "needed.  Both arguments passed are str objects.");
 
 #define _PICKLE_UNPICKLER_FIND_CLASS_METHODDEF    \
-    {"find_class", (PyCFunction)_pickle_Unpickler_find_class, METH_VARARGS, _pickle_Unpickler_find_class__doc__},
+    {"find_class", (PyCFunction)_pickle_Unpickler_find_class, METH_FASTCALL, _pickle_Unpickler_find_class__doc__},
 
 static PyObject *
 _pickle_Unpickler_find_class_impl(UnpicklerObject *self,
@@ -208,15 +208,19 @@ _pickle_Unpickler_find_class_impl(UnpicklerObject *self,
                                   PyObject *global_name);
 
 static PyObject *
-_pickle_Unpickler_find_class(UnpicklerObject *self, PyObject *args)
+_pickle_Unpickler_find_class(UnpicklerObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *module_name;
     PyObject *global_name;
 
-    if (!PyArg_UnpackTuple(args, "find_class",
+    if (!_PyArg_UnpackStack(args, nargs, "find_class",
         2, 2,
         &module_name, &global_name)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("find_class", kwnames)) {
         goto exit;
     }
     return_value = _pickle_Unpickler_find_class_impl(self, module_name, global_name);
@@ -561,4 +565,4 @@ _pickle_loads(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=d7222d1219039fbd input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b921d325b2f7a096 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/_pickle.inc
+++ b/third_party/python/Modules/clinic/_pickle.inc
@@ -402,7 +402,7 @@ _pickle_dump(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     PyObject *protocol = NULL;
     int fix_imports = 1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &obj, &file, &protocol, &fix_imports)) {
         goto exit;
     }
@@ -447,7 +447,7 @@ _pickle_dumps(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     PyObject *protocol = NULL;
     int fix_imports = 1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &obj, &protocol, &fix_imports)) {
         goto exit;
     }
@@ -504,7 +504,7 @@ _pickle_load(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     const char *encoding = "ASCII";
     const char *errors = "strict";
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &file, &fix_imports, &encoding, &errors)) {
         goto exit;
     }
@@ -552,7 +552,7 @@ _pickle_loads(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     const char *encoding = "ASCII";
     const char *errors = "strict";
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &data, &fix_imports, &encoding, &errors)) {
         goto exit;
     }

--- a/third_party/python/Modules/clinic/_sre.inc
+++ b/third_party/python/Modules/clinic/_sre.inc
@@ -564,21 +564,25 @@ PyDoc_STRVAR(_sre_SRE_Match_start__doc__,
 "Return index of the start of the substring matched by group.");
 
 #define _SRE_SRE_MATCH_START_METHODDEF    \
-    {"start", (PyCFunction)_sre_SRE_Match_start, METH_VARARGS, _sre_SRE_Match_start__doc__},
+    {"start", (PyCFunction)_sre_SRE_Match_start, METH_FASTCALL, _sre_SRE_Match_start__doc__},
 
 static Py_ssize_t
 _sre_SRE_Match_start_impl(MatchObject *self, PyObject *group);
 
 static PyObject *
-_sre_SRE_Match_start(MatchObject *self, PyObject *args)
+_sre_SRE_Match_start(MatchObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *group = NULL;
     Py_ssize_t _return_value;
 
-    if (!PyArg_UnpackTuple(args, "start",
+    if (!_PyArg_UnpackStack(args, nargs, "start",
         0, 1,
         &group)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("start", kwnames)) {
         goto exit;
     }
     _return_value = _sre_SRE_Match_start_impl(self, group);
@@ -598,21 +602,25 @@ PyDoc_STRVAR(_sre_SRE_Match_end__doc__,
 "Return index of the end of the substring matched by group.");
 
 #define _SRE_SRE_MATCH_END_METHODDEF    \
-    {"end", (PyCFunction)_sre_SRE_Match_end, METH_VARARGS, _sre_SRE_Match_end__doc__},
+    {"end", (PyCFunction)_sre_SRE_Match_end, METH_FASTCALL, _sre_SRE_Match_end__doc__},
 
 static Py_ssize_t
 _sre_SRE_Match_end_impl(MatchObject *self, PyObject *group);
 
 static PyObject *
-_sre_SRE_Match_end(MatchObject *self, PyObject *args)
+_sre_SRE_Match_end(MatchObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *group = NULL;
     Py_ssize_t _return_value;
 
-    if (!PyArg_UnpackTuple(args, "end",
+    if (!_PyArg_UnpackStack(args, nargs, "end",
         0, 1,
         &group)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("end", kwnames)) {
         goto exit;
     }
     _return_value = _sre_SRE_Match_end_impl(self, group);
@@ -632,20 +640,24 @@ PyDoc_STRVAR(_sre_SRE_Match_span__doc__,
 "For MatchObject m, return the 2-tuple (m.start(group), m.end(group)).");
 
 #define _SRE_SRE_MATCH_SPAN_METHODDEF    \
-    {"span", (PyCFunction)_sre_SRE_Match_span, METH_VARARGS, _sre_SRE_Match_span__doc__},
+    {"span", (PyCFunction)_sre_SRE_Match_span, METH_FASTCALL, _sre_SRE_Match_span__doc__},
 
 static PyObject *
 _sre_SRE_Match_span_impl(MatchObject *self, PyObject *group);
 
 static PyObject *
-_sre_SRE_Match_span(MatchObject *self, PyObject *args)
+_sre_SRE_Match_span(MatchObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *group = NULL;
 
-    if (!PyArg_UnpackTuple(args, "span",
+    if (!_PyArg_UnpackStack(args, nargs, "span",
         0, 1,
         &group)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("span", kwnames)) {
         goto exit;
     }
     return_value = _sre_SRE_Match_span_impl(self, group);
@@ -733,4 +745,4 @@ _sre_SRE_Scanner_search(ScannerObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _sre_SRE_Scanner_search_impl(self);
 }
-/*[clinic end generated code: output=b347a5bd7e21cfd4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ddfd6158e7ca39a3 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/_sre.inc
+++ b/third_party/python/Modules/clinic/_sre.inc
@@ -36,21 +36,25 @@ PyDoc_STRVAR(_sre_getlower__doc__,
 "\n");
 
 #define _SRE_GETLOWER_METHODDEF    \
-    {"getlower", (PyCFunction)_sre_getlower, METH_VARARGS, _sre_getlower__doc__},
+    {"getlower", (PyCFunction)_sre_getlower, METH_FASTCALL, _sre_getlower__doc__},
 
 static int
 _sre_getlower_impl(PyObject *module, int character, int flags);
 
 static PyObject *
-_sre_getlower(PyObject *module, PyObject *args)
+_sre_getlower(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int character;
     int flags;
     int _return_value;
 
-    if (!PyArg_ParseTuple(args, "ii:getlower",
+    if (!_PyArg_ParseStack(args, nargs, "ii:getlower",
         &character, &flags)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("getlower", kwnames)) {
         goto exit;
     }
     _return_value = _sre_getlower_impl(module, character, flags);
@@ -729,4 +733,4 @@ _sre_SRE_Scanner_search(ScannerObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _sre_SRE_Scanner_search_impl(self);
 }
-/*[clinic end generated code: output=a4a246bca1963bc9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b347a5bd7e21cfd4 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/_sre.inc
+++ b/third_party/python/Modules/clinic/_sre.inc
@@ -88,7 +88,7 @@ _sre_SRE_Pattern_match(PatternObject *self, PyObject **args, Py_ssize_t nargs, P
     Py_ssize_t endpos = PY_SSIZE_T_MAX;
     PyObject *pattern = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &string, &pos, &endpos, &pattern)) {
         goto exit;
     }
@@ -124,7 +124,7 @@ _sre_SRE_Pattern_fullmatch(PatternObject *self, PyObject **args, Py_ssize_t narg
     Py_ssize_t endpos = PY_SSIZE_T_MAX;
     PyObject *pattern = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &string, &pos, &endpos, &pattern)) {
         goto exit;
     }
@@ -162,7 +162,7 @@ _sre_SRE_Pattern_search(PatternObject *self, PyObject **args, Py_ssize_t nargs, 
     Py_ssize_t endpos = PY_SSIZE_T_MAX;
     PyObject *pattern = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &string, &pos, &endpos, &pattern)) {
         goto exit;
     }
@@ -198,7 +198,7 @@ _sre_SRE_Pattern_findall(PatternObject *self, PyObject **args, Py_ssize_t nargs,
     Py_ssize_t endpos = PY_SSIZE_T_MAX;
     PyObject *source = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &string, &pos, &endpos, &source)) {
         goto exit;
     }
@@ -233,7 +233,7 @@ _sre_SRE_Pattern_finditer(PatternObject *self, PyObject **args, Py_ssize_t nargs
     Py_ssize_t pos = 0;
     Py_ssize_t endpos = PY_SSIZE_T_MAX;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &string, &pos, &endpos)) {
         goto exit;
     }
@@ -265,7 +265,7 @@ _sre_SRE_Pattern_scanner(PatternObject *self, PyObject **args, Py_ssize_t nargs,
     Py_ssize_t pos = 0;
     Py_ssize_t endpos = PY_SSIZE_T_MAX;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &string, &pos, &endpos)) {
         goto exit;
     }
@@ -298,7 +298,7 @@ _sre_SRE_Pattern_split(PatternObject *self, PyObject **args, Py_ssize_t nargs, P
     Py_ssize_t maxsplit = 0;
     PyObject *source = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &string, &maxsplit, &source)) {
         goto exit;
     }
@@ -331,7 +331,7 @@ _sre_SRE_Pattern_sub(PatternObject *self, PyObject **args, Py_ssize_t nargs, PyO
     PyObject *string;
     Py_ssize_t count = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &repl, &string, &count)) {
         goto exit;
     }
@@ -364,7 +364,7 @@ _sre_SRE_Pattern_subn(PatternObject *self, PyObject **args, Py_ssize_t nargs, Py
     PyObject *string;
     Py_ssize_t count = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &repl, &string, &count)) {
         goto exit;
     }
@@ -410,7 +410,7 @@ _sre_SRE_Pattern___deepcopy__(PatternObject *self, PyObject **args, Py_ssize_t n
     static _PyArg_Parser _parser = {"O:__deepcopy__", _keywords, 0};
     PyObject *memo;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &memo)) {
         goto exit;
     }
@@ -447,7 +447,7 @@ _sre_compile(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     PyObject *groupindex;
     PyObject *indexgroup;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &pattern, &flags, &PyList_Type, &code, &groups, &groupindex, &indexgroup)) {
         goto exit;
     }
@@ -477,7 +477,7 @@ _sre_SRE_Match_expand(MatchObject *self, PyObject **args, Py_ssize_t nargs, PyOb
     static _PyArg_Parser _parser = {"O:expand", _keywords, 0};
     PyObject *template;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &template)) {
         goto exit;
     }
@@ -510,7 +510,7 @@ _sre_SRE_Match_groups(MatchObject *self, PyObject **args, Py_ssize_t nargs, PyOb
     static _PyArg_Parser _parser = {"|O:groups", _keywords, 0};
     PyObject *default_value = Py_None;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &default_value)) {
         goto exit;
     }
@@ -543,7 +543,7 @@ _sre_SRE_Match_groupdict(MatchObject *self, PyObject **args, Py_ssize_t nargs, P
     static _PyArg_Parser _parser = {"|O:groupdict", _keywords, 0};
     PyObject *default_value = Py_None;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &default_value)) {
         goto exit;
     }
@@ -686,7 +686,7 @@ _sre_SRE_Match___deepcopy__(MatchObject *self, PyObject **args, Py_ssize_t nargs
     static _PyArg_Parser _parser = {"O:__deepcopy__", _keywords, 0};
     PyObject *memo;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &memo)) {
         goto exit;
     }

--- a/third_party/python/Modules/clinic/_ssl.inc
+++ b/third_party/python/Modules/clinic/_ssl.inc
@@ -504,7 +504,7 @@ _ssl__SSLContext_load_cert_chain(PySSLContext *self, PyObject **args, Py_ssize_t
     PyObject *keyfile = NULL;
     PyObject *password = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &certfile, &keyfile, &password)) {
         goto exit;
     }
@@ -538,7 +538,7 @@ _ssl__SSLContext_load_verify_locations(PySSLContext *self, PyObject **args, Py_s
     PyObject *capath = NULL;
     PyObject *cadata = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &cafile, &capath, &cadata)) {
         goto exit;
     }
@@ -578,7 +578,7 @@ _ssl__SSLContext__wrap_socket(PySSLContext *self, PyObject **args, Py_ssize_t na
     int server_side;
     PyObject *hostname_obj = Py_None;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         PySocketModule.Sock_Type, &sock, &server_side, &hostname_obj)) {
         goto exit;
     }
@@ -613,7 +613,7 @@ _ssl__SSLContext__wrap_bio(PySSLContext *self, PyObject **args, Py_ssize_t nargs
     int server_side;
     PyObject *hostname_obj = Py_None;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &PySSLMemoryBIO_Type, &incoming, &PySSLMemoryBIO_Type, &outgoing, &server_side, &hostname_obj)) {
         goto exit;
     }
@@ -732,7 +732,7 @@ _ssl__SSLContext_get_ca_certs(PySSLContext *self, PyObject **args, Py_ssize_t na
     static _PyArg_Parser _parser = {"|p:get_ca_certs", _keywords, 0};
     int binary_form = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &binary_form)) {
         goto exit;
     }
@@ -1044,7 +1044,7 @@ _ssl_txt2obj(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     const char *txt;
     int name = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &txt, &name)) {
         goto exit;
     }
@@ -1109,7 +1109,7 @@ _ssl_enum_certificates(PyObject *module, PyObject **args, Py_ssize_t nargs, PyOb
     static _PyArg_Parser _parser = {"s:enum_certificates", _keywords, 0};
     const char *store_name;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &store_name)) {
         goto exit;
     }
@@ -1148,7 +1148,7 @@ _ssl_enum_crls(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     static _PyArg_Parser _parser = {"s:enum_crls", _keywords, 0};
     const char *store_name;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &store_name)) {
         goto exit;
     }

--- a/third_party/python/Modules/clinic/_struct.inc
+++ b/third_party/python/Modules/clinic/_struct.inc
@@ -1,0 +1,277 @@
+/* clang-format off */
+/*[clinic input]
+preserve
+[clinic start generated code]*/
+
+PyDoc_STRVAR(Struct___init____doc__,
+"Struct(format)\n"
+"--\n"
+"\n"
+"Create a compiled struct object.\n"
+"\n"
+"Return a new Struct object which writes and reads binary data according to\n"
+"the format string.\n"
+"\n"
+"See help(struct) for more on format strings.");
+
+static int
+Struct___init___impl(PyStructObject *self, PyObject *format);
+
+static int
+Struct___init__(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    int return_value = -1;
+    static const char * const _keywords[] = {"format", NULL};
+    static _PyArg_Parser _parser = {"O:Struct", _keywords, 0};
+    PyObject *format;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &format)) {
+        goto exit;
+    }
+    return_value = Struct___init___impl((PyStructObject *)self, format);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(Struct_unpack__doc__,
+"unpack($self, buffer, /)\n"
+"--\n"
+"\n"
+"Return a tuple containing unpacked values.\n"
+"\n"
+"Unpack according to the format string Struct.format. The buffer\'s size\n"
+"in bytes must be Struct.size.\n"
+"\n"
+"See help(struct) for more on format strings.");
+
+#define STRUCT_UNPACK_METHODDEF    \
+    {"unpack", (PyCFunction)Struct_unpack, METH_O, Struct_unpack__doc__},
+
+static PyObject *
+Struct_unpack_impl(PyStructObject *self, Py_buffer *buffer);
+
+static PyObject *
+Struct_unpack(PyStructObject *self, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    Py_buffer buffer = {NULL, NULL};
+
+    if (!PyArg_Parse(arg, "y*:unpack", &buffer)) {
+        goto exit;
+    }
+    return_value = Struct_unpack_impl(self, &buffer);
+
+exit:
+    /* Cleanup for buffer */
+    if (buffer.obj) {
+       PyBuffer_Release(&buffer);
+    }
+
+    return return_value;
+}
+
+PyDoc_STRVAR(Struct_unpack_from__doc__,
+"unpack_from($self, /, buffer, offset=0)\n"
+"--\n"
+"\n"
+"Return a tuple containing unpacked values.\n"
+"\n"
+"Values are unpacked according to the format string Struct.format.\n"
+"\n"
+"The buffer\'s size in bytes, minus offset, must be at least Struct.size.\n"
+"\n"
+"See help(struct) for more on format strings.");
+
+#define STRUCT_UNPACK_FROM_METHODDEF    \
+    {"unpack_from", (PyCFunction)Struct_unpack_from, METH_FASTCALL, Struct_unpack_from__doc__},
+
+static PyObject *
+Struct_unpack_from_impl(PyStructObject *self, Py_buffer *buffer,
+                        Py_ssize_t offset);
+
+static PyObject *
+Struct_unpack_from(PyStructObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"buffer", "offset", NULL};
+    static _PyArg_Parser _parser = {"y*|n:unpack_from", _keywords, 0};
+    Py_buffer buffer = {NULL, NULL};
+    Py_ssize_t offset = 0;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &buffer, &offset)) {
+        goto exit;
+    }
+    return_value = Struct_unpack_from_impl(self, &buffer, offset);
+
+exit:
+    /* Cleanup for buffer */
+    if (buffer.obj) {
+       PyBuffer_Release(&buffer);
+    }
+
+    return return_value;
+}
+
+PyDoc_STRVAR(Struct_iter_unpack__doc__,
+"iter_unpack($self, buffer, /)\n"
+"--\n"
+"\n"
+"Return an iterator yielding tuples.\n"
+"\n"
+"Tuples are unpacked from the given bytes source, like a repeated\n"
+"invocation of unpack_from().\n"
+"\n"
+"Requires that the bytes length be a multiple of the struct size.");
+
+#define STRUCT_ITER_UNPACK_METHODDEF    \
+    {"iter_unpack", (PyCFunction)Struct_iter_unpack, METH_O, Struct_iter_unpack__doc__},
+
+PyDoc_STRVAR(_clearcache__doc__,
+"_clearcache($module, /)\n"
+"--\n"
+"\n"
+"Clear the internal cache.");
+
+#define _CLEARCACHE_METHODDEF    \
+    {"_clearcache", (PyCFunction)_clearcache, METH_NOARGS, _clearcache__doc__},
+
+static PyObject *
+_clearcache_impl(PyObject *module);
+
+static PyObject *
+_clearcache(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    return _clearcache_impl(module);
+}
+
+PyDoc_STRVAR(calcsize__doc__,
+"calcsize($module, format, /)\n"
+"--\n"
+"\n"
+"Return size in bytes of the struct described by the format string.");
+
+#define CALCSIZE_METHODDEF    \
+    {"calcsize", (PyCFunction)calcsize, METH_O, calcsize__doc__},
+
+PyDoc_STRVAR(unpack__doc__,
+"unpack($module, format, inputstr, /)\n"
+"--\n"
+"\n"
+"Return a tuple containing values unpacked according to the format string.\n"
+"\n"
+"The buffer\'s size in bytes must be calcsize(format).\n"
+"\n"
+"See help(struct) for more on format strings.");
+
+#define UNPACK_METHODDEF    \
+    {"unpack", (PyCFunction)unpack, METH_FASTCALL, unpack__doc__},
+
+static PyObject *
+unpack_impl(PyObject *module, PyObject *format, PyObject *inputstr);
+
+static PyObject *
+unpack(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    PyObject *format;
+    PyObject *inputstr;
+
+    if (!_PyArg_UnpackStack(args, nargs, "unpack",
+        2, 2,
+        &format, &inputstr)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("unpack", kwnames)) {
+        goto exit;
+    }
+    return_value = unpack_impl(module, format, inputstr);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(unpack_from__doc__,
+"unpack_from($module, format, /, buffer, offset=0)\n"
+"--\n"
+"\n"
+"Return a tuple containing values unpacked according to the format string.\n"
+"\n"
+"The buffer\'s size, minus offset, must be at least calcsize(format).\n"
+"\n"
+"See help(struct) for more on format strings.");
+
+#define UNPACK_FROM_METHODDEF    \
+    {"unpack_from", (PyCFunction)unpack_from, METH_FASTCALL, unpack_from__doc__},
+
+static PyObject *
+unpack_from_impl(PyObject *module, PyObject *format, Py_buffer *buffer,
+                 Py_ssize_t offset);
+
+static PyObject *
+unpack_from(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"", "buffer", "offset", NULL};
+    static _PyArg_Parser _parser = {"Oy*|n:unpack_from", _keywords, 0};
+    PyObject *format;
+    Py_buffer buffer = {NULL, NULL};
+    Py_ssize_t offset = 0;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &format, &buffer, &offset)) {
+        goto exit;
+    }
+    return_value = unpack_from_impl(module, format, &buffer, offset);
+
+exit:
+    /* Cleanup for buffer */
+    if (buffer.obj) {
+       PyBuffer_Release(&buffer);
+    }
+
+    return return_value;
+}
+
+PyDoc_STRVAR(iter_unpack__doc__,
+"iter_unpack($module, format, buffer, /)\n"
+"--\n"
+"\n"
+"Return an iterator yielding tuples unpacked from the given bytes.\n"
+"\n"
+"The bytes are unpacked according to the format string, like\n"
+"a repeated invocation of unpack_from().\n"
+"\n"
+"Requires that the bytes length be a multiple of the format struct size.");
+
+#define ITER_UNPACK_METHODDEF    \
+    {"iter_unpack", (PyCFunction)iter_unpack, METH_FASTCALL, iter_unpack__doc__},
+
+static PyObject *
+iter_unpack_impl(PyObject *module, PyObject *format, PyObject *buffer);
+
+static PyObject *
+iter_unpack(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    PyObject *format;
+    PyObject *buffer;
+
+    if (!_PyArg_UnpackStack(args, nargs, "iter_unpack",
+        2, 2,
+        &format, &buffer)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("iter_unpack", kwnames)) {
+        goto exit;
+    }
+    return_value = iter_unpack_impl(module, format, buffer);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=db8152ad222fa3d0 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/_weakref.inc
+++ b/third_party/python/Modules/clinic/_weakref.inc
@@ -38,21 +38,25 @@ PyDoc_STRVAR(_weakref__remove_dead_weakref__doc__,
 "Atomically remove key from dict if it points to a dead weakref.");
 
 #define _WEAKREF__REMOVE_DEAD_WEAKREF_METHODDEF    \
-    {"_remove_dead_weakref", (PyCFunction)_weakref__remove_dead_weakref, METH_VARARGS, _weakref__remove_dead_weakref__doc__},
+    {"_remove_dead_weakref", (PyCFunction)_weakref__remove_dead_weakref, METH_FASTCALL, _weakref__remove_dead_weakref__doc__},
 
 static PyObject *
 _weakref__remove_dead_weakref_impl(PyObject *module, PyObject *dct,
                                    PyObject *key);
 
 static PyObject *
-_weakref__remove_dead_weakref(PyObject *module, PyObject *args)
+_weakref__remove_dead_weakref(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *dct;
     PyObject *key;
 
-    if (!PyArg_ParseTuple(args, "O!O:_remove_dead_weakref",
+    if (!_PyArg_ParseStack(args, nargs, "O!O:_remove_dead_weakref",
         &PyDict_Type, &dct, &key)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("_remove_dead_weakref", kwnames)) {
         goto exit;
     }
     return_value = _weakref__remove_dead_weakref_impl(module, dct, key);
@@ -60,4 +64,4 @@ _weakref__remove_dead_weakref(PyObject *module, PyObject *args)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=e860dd818a44bc9b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b686303486bdfefd input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/_winapi.inc
+++ b/third_party/python/Modules/clinic/_winapi.inc
@@ -111,7 +111,7 @@ _winapi_ConnectNamedPipe(PyObject *module, PyObject **args, Py_ssize_t nargs, Py
     int64_t handle;
     int use_overlapped = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &handle, &use_overlapped)) {
         goto exit;
     }
@@ -685,7 +685,7 @@ _winapi_ReadFile(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     uint32_t size;
     int use_overlapped = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &handle, &size, &use_overlapped)) {
         goto exit;
     }
@@ -879,7 +879,7 @@ _winapi_WriteFile(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
     PyObject *buffer;
     int use_overlapped = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &handle, &buffer, &use_overlapped)) {
         goto exit;
     }

--- a/third_party/python/Modules/clinic/arraymodule.inc
+++ b/third_party/python/Modules/clinic/arraymodule.inc
@@ -66,19 +66,23 @@ PyDoc_STRVAR(array_array_pop__doc__,
 "i defaults to -1.");
 
 #define ARRAY_ARRAY_POP_METHODDEF    \
-    {"pop", (PyCFunction)array_array_pop, METH_VARARGS, array_array_pop__doc__},
+    {"pop", (PyCFunction)array_array_pop, METH_FASTCALL, array_array_pop__doc__},
 
 static PyObject *
 array_array_pop_impl(arrayobject *self, Py_ssize_t i);
 
 static PyObject *
-array_array_pop(arrayobject *self, PyObject *args)
+array_array_pop(arrayobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_ssize_t i = -1;
 
-    if (!PyArg_ParseTuple(args, "|n:pop",
+    if (!_PyArg_ParseStack(args, nargs, "|n:pop",
         &i)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("pop", kwnames)) {
         goto exit;
     }
     return_value = array_array_pop_impl(self, i);
@@ -103,20 +107,24 @@ PyDoc_STRVAR(array_array_insert__doc__,
 "Insert a new item v into the array before position i.");
 
 #define ARRAY_ARRAY_INSERT_METHODDEF    \
-    {"insert", (PyCFunction)array_array_insert, METH_VARARGS, array_array_insert__doc__},
+    {"insert", (PyCFunction)array_array_insert, METH_FASTCALL, array_array_insert__doc__},
 
 static PyObject *
 array_array_insert_impl(arrayobject *self, Py_ssize_t i, PyObject *v);
 
 static PyObject *
-array_array_insert(arrayobject *self, PyObject *args)
+array_array_insert(arrayobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_ssize_t i;
     PyObject *v;
 
-    if (!PyArg_ParseTuple(args, "nO:insert",
+    if (!_PyArg_ParseStack(args, nargs, "nO:insert",
         &i, &v)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("insert", kwnames)) {
         goto exit;
     }
     return_value = array_array_insert_impl(self, i, v);
@@ -201,20 +209,24 @@ PyDoc_STRVAR(array_array_fromfile__doc__,
 "Read n objects from the file object f and append them to the end of the array.");
 
 #define ARRAY_ARRAY_FROMFILE_METHODDEF    \
-    {"fromfile", (PyCFunction)array_array_fromfile, METH_VARARGS, array_array_fromfile__doc__},
+    {"fromfile", (PyCFunction)array_array_fromfile, METH_FASTCALL, array_array_fromfile__doc__},
 
 static PyObject *
 array_array_fromfile_impl(arrayobject *self, PyObject *f, Py_ssize_t n);
 
 static PyObject *
-array_array_fromfile(arrayobject *self, PyObject *args)
+array_array_fromfile(arrayobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *f;
     Py_ssize_t n;
 
-    if (!PyArg_ParseTuple(args, "On:fromfile",
+    if (!_PyArg_ParseStack(args, nargs, "On:fromfile",
         &f, &n)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("fromfile", kwnames)) {
         goto exit;
     }
     return_value = array_array_fromfile_impl(self, f, n);
@@ -444,7 +456,7 @@ PyDoc_STRVAR(array__array_reconstructor__doc__,
 "Internal. Used for pickling support.");
 
 #define ARRAY__ARRAY_RECONSTRUCTOR_METHODDEF    \
-    {"_array_reconstructor", (PyCFunction)array__array_reconstructor, METH_VARARGS, array__array_reconstructor__doc__},
+    {"_array_reconstructor", (PyCFunction)array__array_reconstructor, METH_FASTCALL, array__array_reconstructor__doc__},
 
 static PyObject *
 array__array_reconstructor_impl(PyObject *module, PyTypeObject *arraytype,
@@ -453,7 +465,7 @@ array__array_reconstructor_impl(PyObject *module, PyTypeObject *arraytype,
                                 PyObject *items);
 
 static PyObject *
-array__array_reconstructor(PyObject *module, PyObject *args)
+array__array_reconstructor(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyTypeObject *arraytype;
@@ -461,8 +473,12 @@ array__array_reconstructor(PyObject *module, PyObject *args)
     enum machine_format_code mformat_code;
     PyObject *items;
 
-    if (!PyArg_ParseTuple(args, "OCiO:_array_reconstructor",
+    if (!_PyArg_ParseStack(args, nargs, "OCiO:_array_reconstructor",
         &arraytype, &typecode, &mformat_code, &items)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("_array_reconstructor", kwnames)) {
         goto exit;
     }
     return_value = array__array_reconstructor_impl(module, arraytype, typecode, mformat_code, items);
@@ -506,4 +522,4 @@ PyDoc_STRVAR(array_arrayiterator___setstate____doc__,
 
 #define ARRAY_ARRAYITERATOR___SETSTATE___METHODDEF    \
     {"__setstate__", (PyCFunction)array_arrayiterator___setstate__, METH_O, array_arrayiterator___setstate____doc__},
-/*[clinic end generated code: output=b2054fb764c8cc64 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d186a7553c1f1a41 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/audioop.inc
+++ b/third_party/python/Modules/clinic/audioop.inc
@@ -1,3 +1,4 @@
+/* clang-format off */
 /*[clinic input]
 preserve
 [clinic start generated code]*/

--- a/third_party/python/Modules/clinic/audioop.inc
+++ b/third_party/python/Modules/clinic/audioop.inc
@@ -1,8 +1,6 @@
-/* clang-format off */
 /*[clinic input]
 preserve
 [clinic start generated code]*/
-#include "third_party/python/Include/abstract.h"
 
 PyDoc_STRVAR(audioop_getsample__doc__,
 "getsample($module, fragment, width, index, /)\n"
@@ -11,22 +9,26 @@ PyDoc_STRVAR(audioop_getsample__doc__,
 "Return the value of sample index from the fragment.");
 
 #define AUDIOOP_GETSAMPLE_METHODDEF    \
-    {"getsample", (PyCFunction)audioop_getsample, METH_VARARGS, audioop_getsample__doc__},
+    {"getsample", (PyCFunction)audioop_getsample, METH_FASTCALL, audioop_getsample__doc__},
 
 static PyObject *
 audioop_getsample_impl(PyObject *module, Py_buffer *fragment, int width,
                        Py_ssize_t index);
 
 static PyObject *
-audioop_getsample(PyObject *module, PyObject *args)
+audioop_getsample(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
     Py_ssize_t index;
 
-    if (!PyArg_ParseTuple(args, "y*in:getsample",
+    if (!_PyArg_ParseStack(args, nargs, "y*in:getsample",
         &fragment, &width, &index)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("getsample", kwnames)) {
         goto exit;
     }
     return_value = audioop_getsample_impl(module, &fragment, width, index);
@@ -47,20 +49,24 @@ PyDoc_STRVAR(audioop_max__doc__,
 "Return the maximum of the absolute value of all samples in a fragment.");
 
 #define AUDIOOP_MAX_METHODDEF    \
-    {"max", (PyCFunction)audioop_max, METH_VARARGS, audioop_max__doc__},
+    {"max", (PyCFunction)audioop_max, METH_FASTCALL, audioop_max__doc__},
 
 static PyObject *
 audioop_max_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_max(PyObject *module, PyObject *args)
+audioop_max(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!PyArg_ParseTuple(args, "y*i:max",
+    if (!_PyArg_ParseStack(args, nargs, "y*i:max",
         &fragment, &width)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("max", kwnames)) {
         goto exit;
     }
     return_value = audioop_max_impl(module, &fragment, width);
@@ -81,20 +87,24 @@ PyDoc_STRVAR(audioop_minmax__doc__,
 "Return the minimum and maximum values of all samples in the sound fragment.");
 
 #define AUDIOOP_MINMAX_METHODDEF    \
-    {"minmax", (PyCFunction)audioop_minmax, METH_VARARGS, audioop_minmax__doc__},
+    {"minmax", (PyCFunction)audioop_minmax, METH_FASTCALL, audioop_minmax__doc__},
 
 static PyObject *
 audioop_minmax_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_minmax(PyObject *module, PyObject *args)
+audioop_minmax(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!PyArg_ParseTuple(args, "y*i:minmax",
+    if (!_PyArg_ParseStack(args, nargs, "y*i:minmax",
         &fragment, &width)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("minmax", kwnames)) {
         goto exit;
     }
     return_value = audioop_minmax_impl(module, &fragment, width);
@@ -115,20 +125,24 @@ PyDoc_STRVAR(audioop_avg__doc__,
 "Return the average over all samples in the fragment.");
 
 #define AUDIOOP_AVG_METHODDEF    \
-    {"avg", (PyCFunction)audioop_avg, METH_VARARGS, audioop_avg__doc__},
+    {"avg", (PyCFunction)audioop_avg, METH_FASTCALL, audioop_avg__doc__},
 
 static PyObject *
 audioop_avg_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_avg(PyObject *module, PyObject *args)
+audioop_avg(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!PyArg_ParseTuple(args, "y*i:avg",
+    if (!_PyArg_ParseStack(args, nargs, "y*i:avg",
         &fragment, &width)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("avg", kwnames)) {
         goto exit;
     }
     return_value = audioop_avg_impl(module, &fragment, width);
@@ -149,20 +163,24 @@ PyDoc_STRVAR(audioop_rms__doc__,
 "Return the root-mean-square of the fragment, i.e. sqrt(sum(S_i^2)/n).");
 
 #define AUDIOOP_RMS_METHODDEF    \
-    {"rms", (PyCFunction)audioop_rms, METH_VARARGS, audioop_rms__doc__},
+    {"rms", (PyCFunction)audioop_rms, METH_FASTCALL, audioop_rms__doc__},
 
 static PyObject *
 audioop_rms_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_rms(PyObject *module, PyObject *args)
+audioop_rms(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!PyArg_ParseTuple(args, "y*i:rms",
+    if (!_PyArg_ParseStack(args, nargs, "y*i:rms",
         &fragment, &width)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("rms", kwnames)) {
         goto exit;
     }
     return_value = audioop_rms_impl(module, &fragment, width);
@@ -183,21 +201,25 @@ PyDoc_STRVAR(audioop_findfit__doc__,
 "Try to match reference as well as possible to a portion of fragment.");
 
 #define AUDIOOP_FINDFIT_METHODDEF    \
-    {"findfit", (PyCFunction)audioop_findfit, METH_VARARGS, audioop_findfit__doc__},
+    {"findfit", (PyCFunction)audioop_findfit, METH_FASTCALL, audioop_findfit__doc__},
 
 static PyObject *
 audioop_findfit_impl(PyObject *module, Py_buffer *fragment,
                      Py_buffer *reference);
 
 static PyObject *
-audioop_findfit(PyObject *module, PyObject *args)
+audioop_findfit(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     Py_buffer reference = {NULL, NULL};
 
-    if (!PyArg_ParseTuple(args, "y*y*:findfit",
+    if (!_PyArg_ParseStack(args, nargs, "y*y*:findfit",
         &fragment, &reference)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("findfit", kwnames)) {
         goto exit;
     }
     return_value = audioop_findfit_impl(module, &fragment, &reference);
@@ -222,21 +244,25 @@ PyDoc_STRVAR(audioop_findfactor__doc__,
 "Return a factor F such that rms(add(fragment, mul(reference, -F))) is minimal.");
 
 #define AUDIOOP_FINDFACTOR_METHODDEF    \
-    {"findfactor", (PyCFunction)audioop_findfactor, METH_VARARGS, audioop_findfactor__doc__},
+    {"findfactor", (PyCFunction)audioop_findfactor, METH_FASTCALL, audioop_findfactor__doc__},
 
 static PyObject *
 audioop_findfactor_impl(PyObject *module, Py_buffer *fragment,
                         Py_buffer *reference);
 
 static PyObject *
-audioop_findfactor(PyObject *module, PyObject *args)
+audioop_findfactor(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     Py_buffer reference = {NULL, NULL};
 
-    if (!PyArg_ParseTuple(args, "y*y*:findfactor",
+    if (!_PyArg_ParseStack(args, nargs, "y*y*:findfactor",
         &fragment, &reference)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("findfactor", kwnames)) {
         goto exit;
     }
     return_value = audioop_findfactor_impl(module, &fragment, &reference);
@@ -261,21 +287,25 @@ PyDoc_STRVAR(audioop_findmax__doc__,
 "Search fragment for a slice of specified number of samples with maximum energy.");
 
 #define AUDIOOP_FINDMAX_METHODDEF    \
-    {"findmax", (PyCFunction)audioop_findmax, METH_VARARGS, audioop_findmax__doc__},
+    {"findmax", (PyCFunction)audioop_findmax, METH_FASTCALL, audioop_findmax__doc__},
 
 static PyObject *
 audioop_findmax_impl(PyObject *module, Py_buffer *fragment,
                      Py_ssize_t length);
 
 static PyObject *
-audioop_findmax(PyObject *module, PyObject *args)
+audioop_findmax(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     Py_ssize_t length;
 
-    if (!PyArg_ParseTuple(args, "y*n:findmax",
+    if (!_PyArg_ParseStack(args, nargs, "y*n:findmax",
         &fragment, &length)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("findmax", kwnames)) {
         goto exit;
     }
     return_value = audioop_findmax_impl(module, &fragment, length);
@@ -296,20 +326,24 @@ PyDoc_STRVAR(audioop_avgpp__doc__,
 "Return the average peak-peak value over all samples in the fragment.");
 
 #define AUDIOOP_AVGPP_METHODDEF    \
-    {"avgpp", (PyCFunction)audioop_avgpp, METH_VARARGS, audioop_avgpp__doc__},
+    {"avgpp", (PyCFunction)audioop_avgpp, METH_FASTCALL, audioop_avgpp__doc__},
 
 static PyObject *
 audioop_avgpp_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_avgpp(PyObject *module, PyObject *args)
+audioop_avgpp(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!PyArg_ParseTuple(args, "y*i:avgpp",
+    if (!_PyArg_ParseStack(args, nargs, "y*i:avgpp",
         &fragment, &width)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("avgpp", kwnames)) {
         goto exit;
     }
     return_value = audioop_avgpp_impl(module, &fragment, width);
@@ -330,20 +364,24 @@ PyDoc_STRVAR(audioop_maxpp__doc__,
 "Return the maximum peak-peak value in the sound fragment.");
 
 #define AUDIOOP_MAXPP_METHODDEF    \
-    {"maxpp", (PyCFunction)audioop_maxpp, METH_VARARGS, audioop_maxpp__doc__},
+    {"maxpp", (PyCFunction)audioop_maxpp, METH_FASTCALL, audioop_maxpp__doc__},
 
 static PyObject *
 audioop_maxpp_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_maxpp(PyObject *module, PyObject *args)
+audioop_maxpp(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!PyArg_ParseTuple(args, "y*i:maxpp",
+    if (!_PyArg_ParseStack(args, nargs, "y*i:maxpp",
         &fragment, &width)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("maxpp", kwnames)) {
         goto exit;
     }
     return_value = audioop_maxpp_impl(module, &fragment, width);
@@ -364,20 +402,24 @@ PyDoc_STRVAR(audioop_cross__doc__,
 "Return the number of zero crossings in the fragment passed as an argument.");
 
 #define AUDIOOP_CROSS_METHODDEF    \
-    {"cross", (PyCFunction)audioop_cross, METH_VARARGS, audioop_cross__doc__},
+    {"cross", (PyCFunction)audioop_cross, METH_FASTCALL, audioop_cross__doc__},
 
 static PyObject *
 audioop_cross_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_cross(PyObject *module, PyObject *args)
+audioop_cross(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!PyArg_ParseTuple(args, "y*i:cross",
+    if (!_PyArg_ParseStack(args, nargs, "y*i:cross",
         &fragment, &width)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("cross", kwnames)) {
         goto exit;
     }
     return_value = audioop_cross_impl(module, &fragment, width);
@@ -398,22 +440,26 @@ PyDoc_STRVAR(audioop_mul__doc__,
 "Return a fragment that has all samples in the original fragment multiplied by the floating-point value factor.");
 
 #define AUDIOOP_MUL_METHODDEF    \
-    {"mul", (PyCFunction)audioop_mul, METH_VARARGS, audioop_mul__doc__},
+    {"mul", (PyCFunction)audioop_mul, METH_FASTCALL, audioop_mul__doc__},
 
 static PyObject *
 audioop_mul_impl(PyObject *module, Py_buffer *fragment, int width,
                  double factor);
 
 static PyObject *
-audioop_mul(PyObject *module, PyObject *args)
+audioop_mul(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
     double factor;
 
-    if (!PyArg_ParseTuple(args, "y*id:mul",
+    if (!_PyArg_ParseStack(args, nargs, "y*id:mul",
         &fragment, &width, &factor)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("mul", kwnames)) {
         goto exit;
     }
     return_value = audioop_mul_impl(module, &fragment, width, factor);
@@ -434,14 +480,14 @@ PyDoc_STRVAR(audioop_tomono__doc__,
 "Convert a stereo fragment to a mono fragment.");
 
 #define AUDIOOP_TOMONO_METHODDEF    \
-    {"tomono", (PyCFunction)audioop_tomono, METH_VARARGS, audioop_tomono__doc__},
+    {"tomono", (PyCFunction)audioop_tomono, METH_FASTCALL, audioop_tomono__doc__},
 
 static PyObject *
 audioop_tomono_impl(PyObject *module, Py_buffer *fragment, int width,
                     double lfactor, double rfactor);
 
 static PyObject *
-audioop_tomono(PyObject *module, PyObject *args)
+audioop_tomono(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
@@ -449,8 +495,12 @@ audioop_tomono(PyObject *module, PyObject *args)
     double lfactor;
     double rfactor;
 
-    if (!PyArg_ParseTuple(args, "y*idd:tomono",
+    if (!_PyArg_ParseStack(args, nargs, "y*idd:tomono",
         &fragment, &width, &lfactor, &rfactor)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("tomono", kwnames)) {
         goto exit;
     }
     return_value = audioop_tomono_impl(module, &fragment, width, lfactor, rfactor);
@@ -471,14 +521,14 @@ PyDoc_STRVAR(audioop_tostereo__doc__,
 "Generate a stereo fragment from a mono fragment.");
 
 #define AUDIOOP_TOSTEREO_METHODDEF    \
-    {"tostereo", (PyCFunction)audioop_tostereo, METH_VARARGS, audioop_tostereo__doc__},
+    {"tostereo", (PyCFunction)audioop_tostereo, METH_FASTCALL, audioop_tostereo__doc__},
 
 static PyObject *
 audioop_tostereo_impl(PyObject *module, Py_buffer *fragment, int width,
                       double lfactor, double rfactor);
 
 static PyObject *
-audioop_tostereo(PyObject *module, PyObject *args)
+audioop_tostereo(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
@@ -486,8 +536,12 @@ audioop_tostereo(PyObject *module, PyObject *args)
     double lfactor;
     double rfactor;
 
-    if (!PyArg_ParseTuple(args, "y*idd:tostereo",
+    if (!_PyArg_ParseStack(args, nargs, "y*idd:tostereo",
         &fragment, &width, &lfactor, &rfactor)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("tostereo", kwnames)) {
         goto exit;
     }
     return_value = audioop_tostereo_impl(module, &fragment, width, lfactor, rfactor);
@@ -508,22 +562,26 @@ PyDoc_STRVAR(audioop_add__doc__,
 "Return a fragment which is the addition of the two samples passed as parameters.");
 
 #define AUDIOOP_ADD_METHODDEF    \
-    {"add", (PyCFunction)audioop_add, METH_VARARGS, audioop_add__doc__},
+    {"add", (PyCFunction)audioop_add, METH_FASTCALL, audioop_add__doc__},
 
 static PyObject *
 audioop_add_impl(PyObject *module, Py_buffer *fragment1,
                  Py_buffer *fragment2, int width);
 
 static PyObject *
-audioop_add(PyObject *module, PyObject *args)
+audioop_add(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment1 = {NULL, NULL};
     Py_buffer fragment2 = {NULL, NULL};
     int width;
 
-    if (!PyArg_ParseTuple(args, "y*y*i:add",
+    if (!_PyArg_ParseStack(args, nargs, "y*y*i:add",
         &fragment1, &fragment2, &width)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("add", kwnames)) {
         goto exit;
     }
     return_value = audioop_add_impl(module, &fragment1, &fragment2, width);
@@ -548,21 +606,25 @@ PyDoc_STRVAR(audioop_bias__doc__,
 "Return a fragment that is the original fragment with a bias added to each sample.");
 
 #define AUDIOOP_BIAS_METHODDEF    \
-    {"bias", (PyCFunction)audioop_bias, METH_VARARGS, audioop_bias__doc__},
+    {"bias", (PyCFunction)audioop_bias, METH_FASTCALL, audioop_bias__doc__},
 
 static PyObject *
 audioop_bias_impl(PyObject *module, Py_buffer *fragment, int width, int bias);
 
 static PyObject *
-audioop_bias(PyObject *module, PyObject *args)
+audioop_bias(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
     int bias;
 
-    if (!PyArg_ParseTuple(args, "y*ii:bias",
+    if (!_PyArg_ParseStack(args, nargs, "y*ii:bias",
         &fragment, &width, &bias)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("bias", kwnames)) {
         goto exit;
     }
     return_value = audioop_bias_impl(module, &fragment, width, bias);
@@ -583,20 +645,24 @@ PyDoc_STRVAR(audioop_reverse__doc__,
 "Reverse the samples in a fragment and returns the modified fragment.");
 
 #define AUDIOOP_REVERSE_METHODDEF    \
-    {"reverse", (PyCFunction)audioop_reverse, METH_VARARGS, audioop_reverse__doc__},
+    {"reverse", (PyCFunction)audioop_reverse, METH_FASTCALL, audioop_reverse__doc__},
 
 static PyObject *
 audioop_reverse_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_reverse(PyObject *module, PyObject *args)
+audioop_reverse(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!PyArg_ParseTuple(args, "y*i:reverse",
+    if (!_PyArg_ParseStack(args, nargs, "y*i:reverse",
         &fragment, &width)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("reverse", kwnames)) {
         goto exit;
     }
     return_value = audioop_reverse_impl(module, &fragment, width);
@@ -617,20 +683,24 @@ PyDoc_STRVAR(audioop_byteswap__doc__,
 "Convert big-endian samples to little-endian and vice versa.");
 
 #define AUDIOOP_BYTESWAP_METHODDEF    \
-    {"byteswap", (PyCFunction)audioop_byteswap, METH_VARARGS, audioop_byteswap__doc__},
+    {"byteswap", (PyCFunction)audioop_byteswap, METH_FASTCALL, audioop_byteswap__doc__},
 
 static PyObject *
 audioop_byteswap_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_byteswap(PyObject *module, PyObject *args)
+audioop_byteswap(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!PyArg_ParseTuple(args, "y*i:byteswap",
+    if (!_PyArg_ParseStack(args, nargs, "y*i:byteswap",
         &fragment, &width)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("byteswap", kwnames)) {
         goto exit;
     }
     return_value = audioop_byteswap_impl(module, &fragment, width);
@@ -651,22 +721,26 @@ PyDoc_STRVAR(audioop_lin2lin__doc__,
 "Convert samples between 1-, 2-, 3- and 4-byte formats.");
 
 #define AUDIOOP_LIN2LIN_METHODDEF    \
-    {"lin2lin", (PyCFunction)audioop_lin2lin, METH_VARARGS, audioop_lin2lin__doc__},
+    {"lin2lin", (PyCFunction)audioop_lin2lin, METH_FASTCALL, audioop_lin2lin__doc__},
 
 static PyObject *
 audioop_lin2lin_impl(PyObject *module, Py_buffer *fragment, int width,
                      int newwidth);
 
 static PyObject *
-audioop_lin2lin(PyObject *module, PyObject *args)
+audioop_lin2lin(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
     int newwidth;
 
-    if (!PyArg_ParseTuple(args, "y*ii:lin2lin",
+    if (!_PyArg_ParseStack(args, nargs, "y*ii:lin2lin",
         &fragment, &width, &newwidth)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("lin2lin", kwnames)) {
         goto exit;
     }
     return_value = audioop_lin2lin_impl(module, &fragment, width, newwidth);
@@ -688,7 +762,7 @@ PyDoc_STRVAR(audioop_ratecv__doc__,
 "Convert the frame rate of the input fragment.");
 
 #define AUDIOOP_RATECV_METHODDEF    \
-    {"ratecv", (PyCFunction)audioop_ratecv, METH_VARARGS, audioop_ratecv__doc__},
+    {"ratecv", (PyCFunction)audioop_ratecv, METH_FASTCALL, audioop_ratecv__doc__},
 
 static PyObject *
 audioop_ratecv_impl(PyObject *module, Py_buffer *fragment, int width,
@@ -696,7 +770,7 @@ audioop_ratecv_impl(PyObject *module, Py_buffer *fragment, int width,
                     int weightA, int weightB);
 
 static PyObject *
-audioop_ratecv(PyObject *module, PyObject *args)
+audioop_ratecv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
@@ -708,8 +782,12 @@ audioop_ratecv(PyObject *module, PyObject *args)
     int weightA = 1;
     int weightB = 0;
 
-    if (!PyArg_ParseTuple(args, "y*iiiiO|ii:ratecv",
+    if (!_PyArg_ParseStack(args, nargs, "y*iiiiO|ii:ratecv",
         &fragment, &width, &nchannels, &inrate, &outrate, &state, &weightA, &weightB)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("ratecv", kwnames)) {
         goto exit;
     }
     return_value = audioop_ratecv_impl(module, &fragment, width, nchannels, inrate, outrate, state, weightA, weightB);
@@ -730,20 +808,24 @@ PyDoc_STRVAR(audioop_lin2ulaw__doc__,
 "Convert samples in the audio fragment to u-LAW encoding.");
 
 #define AUDIOOP_LIN2ULAW_METHODDEF    \
-    {"lin2ulaw", (PyCFunction)audioop_lin2ulaw, METH_VARARGS, audioop_lin2ulaw__doc__},
+    {"lin2ulaw", (PyCFunction)audioop_lin2ulaw, METH_FASTCALL, audioop_lin2ulaw__doc__},
 
 static PyObject *
 audioop_lin2ulaw_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_lin2ulaw(PyObject *module, PyObject *args)
+audioop_lin2ulaw(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!PyArg_ParseTuple(args, "y*i:lin2ulaw",
+    if (!_PyArg_ParseStack(args, nargs, "y*i:lin2ulaw",
         &fragment, &width)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("lin2ulaw", kwnames)) {
         goto exit;
     }
     return_value = audioop_lin2ulaw_impl(module, &fragment, width);
@@ -764,20 +846,24 @@ PyDoc_STRVAR(audioop_ulaw2lin__doc__,
 "Convert sound fragments in u-LAW encoding to linearly encoded sound fragments.");
 
 #define AUDIOOP_ULAW2LIN_METHODDEF    \
-    {"ulaw2lin", (PyCFunction)audioop_ulaw2lin, METH_VARARGS, audioop_ulaw2lin__doc__},
+    {"ulaw2lin", (PyCFunction)audioop_ulaw2lin, METH_FASTCALL, audioop_ulaw2lin__doc__},
 
 static PyObject *
 audioop_ulaw2lin_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_ulaw2lin(PyObject *module, PyObject *args)
+audioop_ulaw2lin(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!PyArg_ParseTuple(args, "y*i:ulaw2lin",
+    if (!_PyArg_ParseStack(args, nargs, "y*i:ulaw2lin",
         &fragment, &width)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("ulaw2lin", kwnames)) {
         goto exit;
     }
     return_value = audioop_ulaw2lin_impl(module, &fragment, width);
@@ -798,20 +884,24 @@ PyDoc_STRVAR(audioop_lin2alaw__doc__,
 "Convert samples in the audio fragment to a-LAW encoding.");
 
 #define AUDIOOP_LIN2ALAW_METHODDEF    \
-    {"lin2alaw", (PyCFunction)audioop_lin2alaw, METH_VARARGS, audioop_lin2alaw__doc__},
+    {"lin2alaw", (PyCFunction)audioop_lin2alaw, METH_FASTCALL, audioop_lin2alaw__doc__},
 
 static PyObject *
 audioop_lin2alaw_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_lin2alaw(PyObject *module, PyObject *args)
+audioop_lin2alaw(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!PyArg_ParseTuple(args, "y*i:lin2alaw",
+    if (!_PyArg_ParseStack(args, nargs, "y*i:lin2alaw",
         &fragment, &width)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("lin2alaw", kwnames)) {
         goto exit;
     }
     return_value = audioop_lin2alaw_impl(module, &fragment, width);
@@ -832,26 +922,34 @@ PyDoc_STRVAR(audioop_alaw2lin__doc__,
 "Convert sound fragments in a-LAW encoding to linearly encoded sound fragments.");
 
 #define AUDIOOP_ALAW2LIN_METHODDEF    \
-    {"alaw2lin", (PyCFunction)audioop_alaw2lin, METH_VARARGS, audioop_alaw2lin__doc__},
+    {"alaw2lin", (PyCFunction)audioop_alaw2lin, METH_FASTCALL, audioop_alaw2lin__doc__},
 
 static PyObject *
 audioop_alaw2lin_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_alaw2lin(PyObject *module, PyObject *args)
+audioop_alaw2lin(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
-    if (!PyArg_ParseTuple(args, "y*i:alaw2lin", &fragment, &width)) {
+
+    if (!_PyArg_ParseStack(args, nargs, "y*i:alaw2lin",
+        &fragment, &width)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("alaw2lin", kwnames)) {
         goto exit;
     }
     return_value = audioop_alaw2lin_impl(module, &fragment, width);
+
 exit:
     /* Cleanup for fragment */
     if (fragment.obj) {
        PyBuffer_Release(&fragment);
     }
+
     return return_value;
 }
 
@@ -862,22 +960,26 @@ PyDoc_STRVAR(audioop_lin2adpcm__doc__,
 "Convert samples to 4 bit Intel/DVI ADPCM encoding.");
 
 #define AUDIOOP_LIN2ADPCM_METHODDEF    \
-    {"lin2adpcm", (PyCFunction)audioop_lin2adpcm, METH_VARARGS, audioop_lin2adpcm__doc__},
+    {"lin2adpcm", (PyCFunction)audioop_lin2adpcm, METH_FASTCALL, audioop_lin2adpcm__doc__},
 
 static PyObject *
 audioop_lin2adpcm_impl(PyObject *module, Py_buffer *fragment, int width,
                        PyObject *state);
 
 static PyObject *
-audioop_lin2adpcm(PyObject *module, PyObject *args)
+audioop_lin2adpcm(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
     PyObject *state;
 
-    if (!PyArg_ParseTuple(args, "y*iO:lin2adpcm",
+    if (!_PyArg_ParseStack(args, nargs, "y*iO:lin2adpcm",
         &fragment, &width, &state)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("lin2adpcm", kwnames)) {
         goto exit;
     }
     return_value = audioop_lin2adpcm_impl(module, &fragment, width, state);
@@ -898,22 +1000,26 @@ PyDoc_STRVAR(audioop_adpcm2lin__doc__,
 "Decode an Intel/DVI ADPCM coded fragment to a linear fragment.");
 
 #define AUDIOOP_ADPCM2LIN_METHODDEF    \
-    {"adpcm2lin", (PyCFunction)audioop_adpcm2lin, METH_VARARGS, audioop_adpcm2lin__doc__},
+    {"adpcm2lin", (PyCFunction)audioop_adpcm2lin, METH_FASTCALL, audioop_adpcm2lin__doc__},
 
 static PyObject *
 audioop_adpcm2lin_impl(PyObject *module, Py_buffer *fragment, int width,
                        PyObject *state);
 
 static PyObject *
-audioop_adpcm2lin(PyObject *module, PyObject *args)
+audioop_adpcm2lin(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
     PyObject *state;
 
-    if (!PyArg_ParseTuple(args, "y*iO:adpcm2lin",
+    if (!_PyArg_ParseStack(args, nargs, "y*iO:adpcm2lin",
         &fragment, &width, &state)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("adpcm2lin", kwnames)) {
         goto exit;
     }
     return_value = audioop_adpcm2lin_impl(module, &fragment, width, state);
@@ -926,4 +1032,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=e0ab74c3fa57c39c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ee7c63ec28a11b78 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/binascii.inc
+++ b/third_party/python/Modules/clinic/binascii.inc
@@ -267,21 +267,25 @@ PyDoc_STRVAR(binascii_crc_hqx__doc__,
 "Compute CRC-CCITT incrementally.");
 
 #define BINASCII_CRC_HQX_METHODDEF    \
-    {"crc_hqx", (PyCFunction)binascii_crc_hqx, METH_VARARGS, binascii_crc_hqx__doc__},
+    {"crc_hqx", (PyCFunction)binascii_crc_hqx, METH_FASTCALL, binascii_crc_hqx__doc__},
 
 static unsigned int
 binascii_crc_hqx_impl(PyObject *module, Py_buffer *data, unsigned int crc);
 
 static PyObject *
-binascii_crc_hqx(PyObject *module, PyObject *args)
+binascii_crc_hqx(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     unsigned int crc;
     unsigned int _return_value;
 
-    if (!PyArg_ParseTuple(args, "y*I:crc_hqx",
+    if (!_PyArg_ParseStack(args, nargs, "y*I:crc_hqx",
         &data, &crc)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("crc_hqx", kwnames)) {
         goto exit;
     }
     _return_value = binascii_crc_hqx_impl(module, &data, crc);
@@ -306,21 +310,25 @@ PyDoc_STRVAR(binascii_crc32__doc__,
 "Compute CRC-32 incrementally.");
 
 #define BINASCII_CRC32_METHODDEF    \
-    {"crc32", (PyCFunction)binascii_crc32, METH_VARARGS, binascii_crc32__doc__},
+    {"crc32", (PyCFunction)binascii_crc32, METH_FASTCALL, binascii_crc32__doc__},
 
 static unsigned int
 binascii_crc32_impl(PyObject *module, Py_buffer *data, unsigned int crc);
 
 static PyObject *
-binascii_crc32(PyObject *module, PyObject *args)
+binascii_crc32(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     unsigned int crc = 0;
     unsigned int _return_value;
 
-    if (!PyArg_ParseTuple(args, "y*|I:crc32",
+    if (!_PyArg_ParseStack(args, nargs, "y*|I:crc32",
         &data, &crc)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("crc32", kwnames)) {
         goto exit;
     }
     _return_value = binascii_crc32_impl(module, &data, crc);
@@ -551,4 +559,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=458eb09731cb7877 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4a418f883ccc79fe input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/binascii.inc
+++ b/third_party/python/Modules/clinic/binascii.inc
@@ -118,7 +118,7 @@ binascii_b2a_base64(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObjec
     Py_buffer data = {NULL, NULL};
     int newline = 1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &data, &newline)) {
         goto exit;
     }
@@ -495,7 +495,7 @@ binascii_a2b_qp(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *k
     Py_buffer data = {NULL, NULL};
     int header = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         ascii_buffer_converter, &data, &header)) {
         goto exit;
     }
@@ -537,7 +537,7 @@ binascii_b2a_qp(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *k
     int istext = 1;
     int header = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &data, &quotetabs, &istext, &header)) {
         goto exit;
     }

--- a/third_party/python/Modules/clinic/cmathmodule.inc
+++ b/third_party/python/Modules/clinic/cmathmodule.inc
@@ -870,7 +870,7 @@ cmath_isclose(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     double abs_tol = 0.0;
     int _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &a, &b, &rel_tol, &abs_tol)) {
         goto exit;
     }

--- a/third_party/python/Modules/clinic/cmathmodule.inc
+++ b/third_party/python/Modules/clinic/cmathmodule.inc
@@ -642,20 +642,24 @@ PyDoc_STRVAR(cmath_log__doc__,
 "If the base not specified, returns the natural logarithm (base e) of z.");
 
 #define CMATH_LOG_METHODDEF    \
-    {"log", (PyCFunction)cmath_log, METH_VARARGS, cmath_log__doc__},
+    {"log", (PyCFunction)cmath_log, METH_FASTCALL, cmath_log__doc__},
 
 static PyObject *
 cmath_log_impl(PyObject *module, Py_complex x, PyObject *y_obj);
 
 static PyObject *
-cmath_log(PyObject *module, PyObject *args)
+cmath_log(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_complex x;
     PyObject *y_obj = NULL;
 
-    if (!PyArg_ParseTuple(args, "D|O:log",
+    if (!_PyArg_ParseStack(args, nargs, "D|O:log",
         &x, &y_obj)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("log", kwnames)) {
         goto exit;
     }
     return_value = cmath_log_impl(module, x, y_obj);
@@ -727,20 +731,24 @@ PyDoc_STRVAR(cmath_rect__doc__,
 "Convert from polar coordinates to rectangular coordinates.");
 
 #define CMATH_RECT_METHODDEF    \
-    {"rect", (PyCFunction)cmath_rect, METH_VARARGS, cmath_rect__doc__},
+    {"rect", (PyCFunction)cmath_rect, METH_FASTCALL, cmath_rect__doc__},
 
 static PyObject *
 cmath_rect_impl(PyObject *module, double r, double phi);
 
 static PyObject *
-cmath_rect(PyObject *module, PyObject *args)
+cmath_rect(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     double r;
     double phi;
 
-    if (!PyArg_ParseTuple(args, "dd:rect",
+    if (!_PyArg_ParseStack(args, nargs, "dd:rect",
         &r, &phi)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("rect", kwnames)) {
         goto exit;
     }
     return_value = cmath_rect_impl(module, r, phi);
@@ -883,4 +891,4 @@ cmath_isclose(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=978f59702b41655f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=93eff5d4c242ee57 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/fcntlmodule.inc
+++ b/third_party/python/Modules/clinic/fcntlmodule.inc
@@ -20,21 +20,25 @@ PyDoc_STRVAR(fcntl_fcntl__doc__,
 "corresponding to the return value of the fcntl call in the C code.");
 
 #define FCNTL_FCNTL_METHODDEF    \
-    {"fcntl", (PyCFunction)fcntl_fcntl, METH_VARARGS, fcntl_fcntl__doc__},
+    {"fcntl", (PyCFunction)fcntl_fcntl, METH_FASTCALL, fcntl_fcntl__doc__},
 
 static PyObject *
 fcntl_fcntl_impl(PyObject *module, int fd, int code, PyObject *arg);
 
 static PyObject *
-fcntl_fcntl(PyObject *module, PyObject *args)
+fcntl_fcntl(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int fd;
     int code;
     PyObject *arg = NULL;
 
-    if (!PyArg_ParseTuple(args, "O&i|O:fcntl",
+    if (!_PyArg_ParseStack(args, nargs, "O&i|O:fcntl",
         conv_descriptor, &fd, &code, &arg)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("fcntl", kwnames)) {
         goto exit;
     }
     return_value = fcntl_fcntl_impl(module, fd, code, arg);
@@ -77,14 +81,14 @@ PyDoc_STRVAR(fcntl_ioctl__doc__,
 "code.");
 
 #define FCNTL_IOCTL_METHODDEF    \
-    {"ioctl", (PyCFunction)fcntl_ioctl, METH_VARARGS, fcntl_ioctl__doc__},
+    {"ioctl", (PyCFunction)fcntl_ioctl, METH_FASTCALL, fcntl_ioctl__doc__},
 
 static PyObject *
 fcntl_ioctl_impl(PyObject *module, int fd, unsigned int code,
                  PyObject *ob_arg, int mutate_arg);
 
 static PyObject *
-fcntl_ioctl(PyObject *module, PyObject *args)
+fcntl_ioctl(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int fd;
@@ -92,8 +96,12 @@ fcntl_ioctl(PyObject *module, PyObject *args)
     PyObject *ob_arg = NULL;
     int mutate_arg = 1;
 
-    if (!PyArg_ParseTuple(args, "O&I|Op:ioctl",
+    if (!_PyArg_ParseStack(args, nargs, "O&I|Op:ioctl",
         conv_descriptor, &fd, &code, &ob_arg, &mutate_arg)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("ioctl", kwnames)) {
         goto exit;
     }
     return_value = fcntl_ioctl_impl(module, fd, code, ob_arg, mutate_arg);
@@ -112,20 +120,24 @@ PyDoc_STRVAR(fcntl_flock__doc__,
 "function is emulated using fcntl()).");
 
 #define FCNTL_FLOCK_METHODDEF    \
-    {"flock", (PyCFunction)fcntl_flock, METH_VARARGS, fcntl_flock__doc__},
+    {"flock", (PyCFunction)fcntl_flock, METH_FASTCALL, fcntl_flock__doc__},
 
 static PyObject *
 fcntl_flock_impl(PyObject *module, int fd, int code);
 
 static PyObject *
-fcntl_flock(PyObject *module, PyObject *args)
+fcntl_flock(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int fd;
     int code;
 
-    if (!PyArg_ParseTuple(args, "O&i:flock",
+    if (!_PyArg_ParseStack(args, nargs, "O&i:flock",
         conv_descriptor, &fd, &code)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("flock", kwnames)) {
         goto exit;
     }
     return_value = fcntl_flock_impl(module, fd, code);
@@ -162,14 +174,14 @@ PyDoc_STRVAR(fcntl_lockf__doc__,
 "    2 - relative to the end of the file (SEEK_END)");
 
 #define FCNTL_LOCKF_METHODDEF    \
-    {"lockf", (PyCFunction)fcntl_lockf, METH_VARARGS, fcntl_lockf__doc__},
+    {"lockf", (PyCFunction)fcntl_lockf, METH_FASTCALL, fcntl_lockf__doc__},
 
 static PyObject *
 fcntl_lockf_impl(PyObject *module, int fd, int code, PyObject *lenobj,
                  PyObject *startobj, int whence);
 
 static PyObject *
-fcntl_lockf(PyObject *module, PyObject *args)
+fcntl_lockf(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int fd;
@@ -178,8 +190,12 @@ fcntl_lockf(PyObject *module, PyObject *args)
     PyObject *startobj = NULL;
     int whence = 0;
 
-    if (!PyArg_ParseTuple(args, "O&i|OOi:lockf",
+    if (!_PyArg_ParseStack(args, nargs, "O&i|OOi:lockf",
         conv_descriptor, &fd, &code, &lenobj, &startobj, &whence)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("lockf", kwnames)) {
         goto exit;
     }
     return_value = fcntl_lockf_impl(module, fd, code, lenobj, startobj, whence);
@@ -187,4 +203,4 @@ fcntl_lockf(PyObject *module, PyObject *args)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=36cff76a8fb2c9a6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b67e9579722e6d4f input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/grpmodule.inc
+++ b/third_party/python/Modules/clinic/grpmodule.inc
@@ -87,4 +87,4 @@ grp_getgrall(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return grp_getgrall_impl(module);
 }
-/*[clinic end generated code: output=d6417ae0a7298e0e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=fb690db5e676d378 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/grpmodule.inc
+++ b/third_party/python/Modules/clinic/grpmodule.inc
@@ -25,7 +25,7 @@ grp_getgrgid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     static _PyArg_Parser _parser = {"O:getgrgid", _keywords, 0};
     PyObject *id;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &id)) {
         goto exit;
     }
@@ -57,7 +57,7 @@ grp_getgrnam(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     static _PyArg_Parser _parser = {"U:getgrnam", _keywords, 0};
     PyObject *name;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &name)) {
         goto exit;
     }

--- a/third_party/python/Modules/clinic/posixmodule.inc
+++ b/third_party/python/Modules/clinic/posixmodule.inc
@@ -50,7 +50,7 @@ os_stat(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     int dir_fd = DEFAULT_DIR_FD;
     int follow_symlinks = 1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, FSTATAT_DIR_FD_CONVERTER, &dir_fd, &follow_symlinks)) {
         goto exit;
     }
@@ -87,7 +87,7 @@ os_lstat(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     path_t path = PATH_T_INITIALIZE("lstat", "path", 0, 0);
     int dir_fd = DEFAULT_DIR_FD;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, FSTATAT_DIR_FD_CONVERTER, &dir_fd)) {
         goto exit;
     }
@@ -152,7 +152,7 @@ os_access(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     int follow_symlinks = 1;
     int _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, &mode, FACCESSAT_DIR_FD_CONVERTER, &dir_fd, &effective_ids, &follow_symlinks)) {
         goto exit;
     }
@@ -254,7 +254,7 @@ os_chdir(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     static _PyArg_Parser _parser = {"O&:chdir", _keywords, 0};
     path_t path = PATH_T_INITIALIZE("chdir", "path", 0, PATH_HAVE_FCHDIR);
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path)) {
         goto exit;
     }
@@ -292,7 +292,7 @@ os_fchdir(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     static _PyArg_Parser _parser = {"O&:fchdir", _keywords, 0};
     int fd;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         fildes_converter, &fd)) {
         goto exit;
     }
@@ -348,7 +348,7 @@ os_chmod(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     int dir_fd = DEFAULT_DIR_FD;
     int follow_symlinks = 1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, &mode, FCHMODAT_DIR_FD_CONVERTER, &dir_fd, &follow_symlinks)) {
         goto exit;
     }
@@ -386,7 +386,7 @@ os_fchmod(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     int fd;
     int mode;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &fd, &mode)) {
         goto exit;
     }
@@ -424,7 +424,7 @@ os_lchmod(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     path_t path = PATH_T_INITIALIZE("lchmod", "path", 0, 0);
     int mode;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, &mode)) {
         goto exit;
     }
@@ -470,7 +470,7 @@ os_chflags(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwname
     unsigned long flags;
     int follow_symlinks = 1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, &flags, &follow_symlinks)) {
         goto exit;
     }
@@ -511,7 +511,7 @@ os_lchflags(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     path_t path = PATH_T_INITIALIZE("lchflags", "path", 0, 0);
     unsigned long flags;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, &flags)) {
         goto exit;
     }
@@ -548,7 +548,7 @@ os_chroot(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     static _PyArg_Parser _parser = {"O&:chroot", _keywords, 0};
     path_t path = PATH_T_INITIALIZE("chroot", "path", 0, 0);
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path)) {
         goto exit;
     }
@@ -585,7 +585,7 @@ os_fsync(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     static _PyArg_Parser _parser = {"O&:fsync", _keywords, 0};
     int fd;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         fildes_converter, &fd)) {
         goto exit;
     }
@@ -641,7 +641,7 @@ os_fdatasync(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     static _PyArg_Parser _parser = {"O&:fdatasync", _keywords, 0};
     int fd;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         fildes_converter, &fd)) {
         goto exit;
     }
@@ -704,7 +704,7 @@ os_chown(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     int dir_fd = DEFAULT_DIR_FD;
     int follow_symlinks = 1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, _Py_Uid_Converter, &uid, _Py_Gid_Converter, &gid, FCHOWNAT_DIR_FD_CONVERTER, &dir_fd, &follow_symlinks)) {
         goto exit;
     }
@@ -745,7 +745,7 @@ os_fchown(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     uid_t uid;
     gid_t gid;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &fd, _Py_Uid_Converter, &uid, _Py_Gid_Converter, &gid)) {
         goto exit;
     }
@@ -784,7 +784,7 @@ os_lchown(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     uid_t uid;
     gid_t gid;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, _Py_Uid_Converter, &uid, _Py_Gid_Converter, &gid)) {
         goto exit;
     }
@@ -873,7 +873,7 @@ os_link(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     int dst_dir_fd = DEFAULT_DIR_FD;
     int follow_symlinks = 1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &src, path_converter, &dst, dir_fd_converter, &src_dir_fd, dir_fd_converter, &dst_dir_fd, &follow_symlinks)) {
         goto exit;
     }
@@ -921,7 +921,7 @@ os_listdir(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwname
     static _PyArg_Parser _parser = {"|O&:listdir", _keywords, 0};
     path_t path = PATH_T_INITIALIZE("listdir", "path", 1, PATH_HAVE_FDOPENDIR);
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path)) {
         goto exit;
     }
@@ -1042,7 +1042,7 @@ os__getvolumepathname(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObj
     static const char * const _keywords[] = {"path", NULL};
     static _PyArg_Parser _parser = {"U:_getvolumepathname", _keywords, 0};
     PyObject *path;
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &path)) {
         goto exit;
     }
@@ -1080,7 +1080,7 @@ os_mkdir(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     int mode = 511;
     int dir_fd = DEFAULT_DIR_FD;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, &mode, MKDIRAT_DIR_FD_CONVERTER, &dir_fd)) {
         goto exit;
     }
@@ -1147,7 +1147,7 @@ os_getpriority(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     int which;
     int who;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &which, &who)) {
         goto exit;
     }
@@ -1183,7 +1183,7 @@ os_setpriority(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     int who;
     int priority;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &which, &who, &priority)) {
         goto exit;
     }
@@ -1225,7 +1225,7 @@ os_rename(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     int src_dir_fd = DEFAULT_DIR_FD;
     int dst_dir_fd = DEFAULT_DIR_FD;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &src, path_converter, &dst, dir_fd_converter, &src_dir_fd, dir_fd_converter, &dst_dir_fd)) {
         goto exit;
     }
@@ -1270,7 +1270,7 @@ os_replace(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwname
     int src_dir_fd = DEFAULT_DIR_FD;
     int dst_dir_fd = DEFAULT_DIR_FD;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &src, path_converter, &dst, dir_fd_converter, &src_dir_fd, dir_fd_converter, &dst_dir_fd)) {
         goto exit;
     }
@@ -1311,7 +1311,7 @@ os_rmdir(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     path_t path = PATH_T_INITIALIZE("rmdir", "path", 0, 0);
     int dir_fd = DEFAULT_DIR_FD;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, UNLINKAT_DIR_FD_CONVERTER, &dir_fd)) {
         goto exit;
     }
@@ -1347,7 +1347,7 @@ os_system(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     Py_UNICODE *command;
     long _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &command)) {
         goto exit;
     }
@@ -1386,7 +1386,7 @@ os_system(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     PyObject *command = NULL;
     long _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         PyUnicode_FSConverter, &command)) {
         goto exit;
     }
@@ -1458,7 +1458,7 @@ os_unlink(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     path_t path = PATH_T_INITIALIZE("unlink", "path", 0, 0);
     int dir_fd = DEFAULT_DIR_FD;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, UNLINKAT_DIR_FD_CONVERTER, &dir_fd)) {
         goto exit;
     }
@@ -1497,7 +1497,7 @@ os_remove(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     path_t path = PATH_T_INITIALIZE("remove", "path", 0, 0);
     int dir_fd = DEFAULT_DIR_FD;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, UNLINKAT_DIR_FD_CONVERTER, &dir_fd)) {
         goto exit;
     }
@@ -1583,7 +1583,7 @@ os_utime(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     int dir_fd = DEFAULT_DIR_FD;
     int follow_symlinks = 1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, &times, &ns, FUTIMENSAT_DIR_FD_CONVERTER, &dir_fd, &follow_symlinks)) {
         goto exit;
     }
@@ -1616,7 +1616,7 @@ os__exit(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     static _PyArg_Parser _parser = {"i:_exit", _keywords, 0};
     int status;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &status)) {
         goto exit;
     }
@@ -1698,7 +1698,7 @@ os_execve(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     PyObject *argv;
     PyObject *env;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, &argv, &env)) {
         goto exit;
     }
@@ -1875,7 +1875,7 @@ os_sched_get_priority_max(PyObject *module, PyObject **args, Py_ssize_t nargs, P
     static _PyArg_Parser _parser = {"i:sched_get_priority_max", _keywords, 0};
     int policy;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &policy)) {
         goto exit;
     }
@@ -1909,7 +1909,7 @@ os_sched_get_priority_min(PyObject *module, PyObject **args, Py_ssize_t nargs, P
     static _PyArg_Parser _parser = {"i:sched_get_priority_min", _keywords, 0};
     int policy;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &policy)) {
         goto exit;
     }
@@ -2405,7 +2405,7 @@ os_getpgid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwname
     static _PyArg_Parser _parser = {"" _Py_PARSE_PID ":getpgid", _keywords, 0};
     pid_t pid;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &pid)) {
         goto exit;
     }
@@ -2855,7 +2855,7 @@ os_wait3(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     static _PyArg_Parser _parser = {"i:wait3", _keywords, 0};
     int options;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &options)) {
         goto exit;
     }
@@ -2893,7 +2893,7 @@ os_wait4(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     pid_t pid;
     int options;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &pid, &options)) {
         goto exit;
     }
@@ -3087,7 +3087,7 @@ os_symlink(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwname
     int target_is_directory = 0;
     int dir_fd = DEFAULT_DIR_FD;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &src, path_converter, &dst, &target_is_directory, SYMLINKAT_DIR_FD_CONVERTER, &dir_fd)) {
         goto exit;
     }
@@ -3309,7 +3309,7 @@ os_open(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     int dir_fd = DEFAULT_DIR_FD;
     int _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, &flags, &mode, OPENAT_DIR_FD_CONVERTER, &dir_fd)) {
         goto exit;
     }
@@ -3346,7 +3346,7 @@ os_close(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     static _PyArg_Parser _parser = {"i:close", _keywords, 0};
     int fd;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &fd)) {
         goto exit;
     }
@@ -3439,7 +3439,7 @@ os_dup2(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     int fd2;
     int inheritable = 1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &fd, &fd2, &inheritable)) {
         goto exit;
     }
@@ -3702,7 +3702,7 @@ os_fstat(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     static _PyArg_Parser _parser = {"i:fstat", _keywords, 0};
     int fd;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &fd)) {
         goto exit;
     }
@@ -3927,7 +3927,7 @@ os_mkfifo(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     int mode = 438;
     int dir_fd = DEFAULT_DIR_FD;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, &mode, MKFIFOAT_DIR_FD_CONVERTER, &dir_fd)) {
         goto exit;
     }
@@ -3980,7 +3980,7 @@ os_mknod(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     dev_t device = 0;
     int dir_fd = DEFAULT_DIR_FD;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, &mode, _Py_Dev_Converter, &device, MKNODAT_DIR_FD_CONVERTER, &dir_fd)) {
         goto exit;
     }
@@ -4164,7 +4164,7 @@ os_truncate(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     path_t path = PATH_T_INITIALIZE("truncate", "path", 0, PATH_HAVE_FTRUNCATE);
     Py_off_t length;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, Py_off_t_converter, &length)) {
         goto exit;
     }
@@ -4455,7 +4455,7 @@ os_WIFCONTINUED(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *k
     int status;
     int _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &status)) {
         goto exit;
     }
@@ -4494,7 +4494,7 @@ os_WIFSTOPPED(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     int status;
     int _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &status)) {
         goto exit;
     }
@@ -4533,7 +4533,7 @@ os_WIFSIGNALED(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     int status;
     int _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &status)) {
         goto exit;
     }
@@ -4572,7 +4572,7 @@ os_WIFEXITED(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     int status;
     int _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &status)) {
         goto exit;
     }
@@ -4611,7 +4611,7 @@ os_WEXITSTATUS(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     int status;
     int _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &status)) {
         goto exit;
     }
@@ -4650,7 +4650,7 @@ os_WTERMSIG(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     int status;
     int _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &status)) {
         goto exit;
     }
@@ -4689,7 +4689,7 @@ os_WSTOPSIG(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     int status;
     int _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &status)) {
         goto exit;
     }
@@ -4764,7 +4764,7 @@ os_statvfs(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwname
     static _PyArg_Parser _parser = {"O&:statvfs", _keywords, 0};
     path_t path = PATH_T_INITIALIZE("statvfs", "path", 0, PATH_HAVE_FSTATVFS);
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path)) {
         goto exit;
     }
@@ -4801,7 +4801,7 @@ os__getdiskusage(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     static _PyArg_Parser _parser = {"u:_getdiskusage", _keywords, 0};
     Py_UNICODE *path;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &path)) {
         goto exit;
     }
@@ -4881,7 +4881,7 @@ os_pathconf(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     int name;
     long _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, conv_path_confname, &name)) {
         goto exit;
     }
@@ -5028,7 +5028,7 @@ os_startfile(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     path_t filepath = PATH_T_INITIALIZE("startfile", "filepath", 0, 0);
     Py_UNICODE *operation = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &filepath, &operation)) {
         goto exit;
     }
@@ -5092,7 +5092,7 @@ os_device_encoding(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
     static _PyArg_Parser _parser = {"i:device_encoding", _keywords, 0};
     int fd;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &fd)) {
         goto exit;
     }
@@ -5244,7 +5244,7 @@ os_getxattr(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     path_t attribute = PATH_T_INITIALIZE("getxattr", "attribute", 0, 0);
     int follow_symlinks = 1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, path_converter, &attribute, &follow_symlinks)) {
         goto exit;
     }
@@ -5294,7 +5294,7 @@ os_setxattr(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     int flags = 0;
     int follow_symlinks = 1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, path_converter, &attribute, &value, &flags, &follow_symlinks)) {
         goto exit;
     }
@@ -5345,7 +5345,7 @@ os_removexattr(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     path_t attribute = PATH_T_INITIALIZE("removexattr", "attribute", 0, 0);
     int follow_symlinks = 1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, path_converter, &attribute, &follow_symlinks)) {
         goto exit;
     }
@@ -5391,7 +5391,7 @@ os_listxattr(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     path_t path = PATH_T_INITIALIZE("listxattr", "path", 1, 1);
     int follow_symlinks = 1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         path_converter, &path, &follow_symlinks)) {
         goto exit;
     }
@@ -5610,7 +5610,7 @@ os_fspath(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     static _PyArg_Parser _parser = {"O:fspath", _keywords, 0};
     PyObject *path;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &path)) {
         goto exit;
     }
@@ -5643,7 +5643,7 @@ os_getrandom(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     Py_ssize_t size;
     int flags = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &size, &flags)) {
         goto exit;
     }

--- a/third_party/python/Modules/clinic/posixmodule.inc
+++ b/third_party/python/Modules/clinic/posixmodule.inc
@@ -2,12 +2,6 @@
 /*[clinic input]
 preserve
 [clinic start generated code]*/
-#include "third_party/python/pyconfig.h"
-#include "third_party/python/pyconfig.h"
-#include "third_party/python/pyconfig.h"
-#include "third_party/python/pyconfig.h"
-#include "third_party/python/pyconfig.h"
-#include "third_party/python/pyconfig.h"
 
 PyDoc_STRVAR(os_stat__doc__,
 "stat($module, /, path, *, dir_fd=None, follow_symlinks=True)\n"
@@ -144,7 +138,7 @@ os_access(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
 {
     PyObject *return_value = NULL;
     static const char * const _keywords[] = {"path", "mode", "dir_fd", "effective_ids", "follow_symlinks", NULL};
-    static _PyArg_Parser _parser = {"O&I|$O&pp:access", _keywords, 0};
+    static _PyArg_Parser _parser = {"O&i|$O&pp:access", _keywords, 0};
     path_t path = PATH_T_INITIALIZE("access", "path", 0, 0);
     int mode;
     int dir_fd = DEFAULT_DIR_FD;
@@ -934,6 +928,33 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(os__getfinalpathname__doc__,
+"_getfinalpathname($module, path, /)\n"
+"--\n"
+"\n"
+"A helper function for samepath on windows.");
+
+#define OS__GETFINALPATHNAME_METHODDEF    \
+    {"_getfinalpathname", (PyCFunction)os__getfinalpathname, METH_O, os__getfinalpathname__doc__},
+
+static PyObject *
+os__getfinalpathname_impl(PyObject *module, PyObject *path);
+
+static PyObject *
+os__getfinalpathname(PyObject *module, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    PyObject *path;
+
+    if (!PyArg_Parse(arg, "U:_getfinalpathname", &path)) {
+        goto exit;
+    }
+    return_value = os__getfinalpathname_impl(module, path);
+
+exit:
+    return return_value;
+}
+
 #if defined(MS_WINDOWS)
 
 PyDoc_STRVAR(os__getfullpathname__doc__,
@@ -967,31 +988,6 @@ exit:
 
 #endif /* defined(MS_WINDOWS) */
 
-PyDoc_STRVAR(os__getfinalpathname__doc__,
-"_getfinalpathname($module, path, /)\n"
-"--\n"
-"\n"
-"A helper function for samepath on windows.");
-
-#define OS__GETFINALPATHNAME_METHODDEF    \
-    {"_getfinalpathname", (PyCFunction)os__getfinalpathname, METH_O, os__getfinalpathname__doc__},
-
-static PyObject *
-os__getfinalpathname_impl(PyObject *module, PyObject *path);
-
-static PyObject *
-os__getfinalpathname(PyObject *module, PyObject *arg)
-{
-    PyObject *return_value = NULL;
-    PyObject *path;
-    if (!PyArg_Parse(arg, "U:_getfinalpathname", &path)) {
-        goto exit;
-    }
-    return_value = os__getfinalpathname_impl(module, path);
-exit:
-    return return_value;
-}
-
 #if defined(MS_WINDOWS)
 
 PyDoc_STRVAR(os__isdir__doc__,
@@ -1011,13 +1007,16 @@ os__isdir(PyObject *module, PyObject *arg)
 {
     PyObject *return_value = NULL;
     path_t path = PATH_T_INITIALIZE("_isdir", "path", 0, 0);
+
     if (!PyArg_Parse(arg, "O&:_isdir", path_converter, &path)) {
         goto exit;
     }
     return_value = os__isdir_impl(module, &path);
+
 exit:
     /* Cleanup for path */
     path_cleanup(&path);
+
     return return_value;
 }
 
@@ -1042,11 +1041,13 @@ os__getvolumepathname(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObj
     static const char * const _keywords[] = {"path", NULL};
     static _PyArg_Parser _parser = {"U:_getvolumepathname", _keywords, 0};
     PyObject *path;
+
     if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &path)) {
         goto exit;
     }
     return_value = os__getvolumepathname_impl(module, path);
+
 exit:
     return return_value;
 }
@@ -1640,20 +1641,24 @@ PyDoc_STRVAR(os_execv__doc__,
 "    Tuple or list of strings.");
 
 #define OS_EXECV_METHODDEF    \
-    {"execv", (PyCFunction)os_execv, METH_VARARGS, os_execv__doc__},
+    {"execv", (PyCFunction)os_execv, METH_FASTCALL, os_execv__doc__},
 
 static PyObject *
 os_execv_impl(PyObject *module, path_t *path, PyObject *argv);
 
 static PyObject *
-os_execv(PyObject *module, PyObject *args)
+os_execv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     path_t path = PATH_T_INITIALIZE("execv", "path", 0, 0);
     PyObject *argv;
 
-    if (!PyArg_ParseTuple(args, "O&O:execv",
+    if (!_PyArg_ParseStack(args, nargs, "O&O:execv",
         path_converter, &path, &argv)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("execv", kwnames)) {
         goto exit;
     }
     return_value = os_execv_impl(module, &path, argv);
@@ -1729,21 +1734,25 @@ PyDoc_STRVAR(os_spawnv__doc__,
 "    Tuple or list of strings.");
 
 #define OS_SPAWNV_METHODDEF    \
-    {"spawnv", (PyCFunction)os_spawnv, METH_VARARGS, os_spawnv__doc__},
+    {"spawnv", (PyCFunction)os_spawnv, METH_FASTCALL, os_spawnv__doc__},
 
 static PyObject *
 os_spawnv_impl(PyObject *module, int mode, path_t *path, PyObject *argv);
 
 static PyObject *
-os_spawnv(PyObject *module, PyObject *args)
+os_spawnv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int mode;
     path_t path = PATH_T_INITIALIZE("spawnv", "path", 0, 0);
     PyObject *argv;
 
-    if (!PyArg_ParseTuple(args, "iO&O:spawnv",
+    if (!_PyArg_ParseStack(args, nargs, "iO&O:spawnv",
         &mode, path_converter, &path, &argv)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("spawnv", kwnames)) {
         goto exit;
     }
     return_value = os_spawnv_impl(module, mode, &path, argv);
@@ -1775,14 +1784,14 @@ PyDoc_STRVAR(os_spawnve__doc__,
 "    Dictionary of strings mapping to strings.");
 
 #define OS_SPAWNVE_METHODDEF    \
-    {"spawnve", (PyCFunction)os_spawnve, METH_VARARGS, os_spawnve__doc__},
+    {"spawnve", (PyCFunction)os_spawnve, METH_FASTCALL, os_spawnve__doc__},
 
 static PyObject *
 os_spawnve_impl(PyObject *module, int mode, path_t *path, PyObject *argv,
                 PyObject *env);
 
 static PyObject *
-os_spawnve(PyObject *module, PyObject *args)
+os_spawnve(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int mode;
@@ -1790,8 +1799,12 @@ os_spawnve(PyObject *module, PyObject *args)
     PyObject *argv;
     PyObject *env;
 
-    if (!PyArg_ParseTuple(args, "iO&OO:spawnve",
+    if (!_PyArg_ParseStack(args, nargs, "iO&OO:spawnve",
         &mode, path_converter, &path, &argv, &env)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("spawnve", kwnames)) {
         goto exit;
     }
     return_value = os_spawnve_impl(module, mode, &path, argv, env);
@@ -2000,22 +2013,26 @@ PyDoc_STRVAR(os_sched_setscheduler__doc__,
 "param is an instance of sched_param.");
 
 #define OS_SCHED_SETSCHEDULER_METHODDEF    \
-    {"sched_setscheduler", (PyCFunction)os_sched_setscheduler, METH_VARARGS, os_sched_setscheduler__doc__},
+    {"sched_setscheduler", (PyCFunction)os_sched_setscheduler, METH_FASTCALL, os_sched_setscheduler__doc__},
 
 static PyObject *
 os_sched_setscheduler_impl(PyObject *module, pid_t pid, int policy,
                            struct sched_param *param);
 
 static PyObject *
-os_sched_setscheduler(PyObject *module, PyObject *args)
+os_sched_setscheduler(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     pid_t pid;
     int policy;
     struct sched_param param;
 
-    if (!PyArg_ParseTuple(args, "" _Py_PARSE_PID "iO&:sched_setscheduler",
+    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "iO&:sched_setscheduler",
         &pid, &policy, convert_sched_param, &param)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("sched_setscheduler", kwnames)) {
         goto exit;
     }
     return_value = os_sched_setscheduler_impl(module, pid, policy, &param);
@@ -2072,21 +2089,25 @@ PyDoc_STRVAR(os_sched_setparam__doc__,
 "param should be an instance of sched_param.");
 
 #define OS_SCHED_SETPARAM_METHODDEF    \
-    {"sched_setparam", (PyCFunction)os_sched_setparam, METH_VARARGS, os_sched_setparam__doc__},
+    {"sched_setparam", (PyCFunction)os_sched_setparam, METH_FASTCALL, os_sched_setparam__doc__},
 
 static PyObject *
 os_sched_setparam_impl(PyObject *module, pid_t pid,
                        struct sched_param *param);
 
 static PyObject *
-os_sched_setparam(PyObject *module, PyObject *args)
+os_sched_setparam(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     pid_t pid;
     struct sched_param param;
 
-    if (!PyArg_ParseTuple(args, "" _Py_PARSE_PID "O&:sched_setparam",
+    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "O&:sched_setparam",
         &pid, convert_sched_param, &param)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("sched_setparam", kwnames)) {
         goto exit;
     }
     return_value = os_sched_setparam_impl(module, pid, &param);
@@ -2164,20 +2185,24 @@ PyDoc_STRVAR(os_sched_setaffinity__doc__,
 "mask should be an iterable of integers identifying CPUs.");
 
 #define OS_SCHED_SETAFFINITY_METHODDEF    \
-    {"sched_setaffinity", (PyCFunction)os_sched_setaffinity, METH_VARARGS, os_sched_setaffinity__doc__},
+    {"sched_setaffinity", (PyCFunction)os_sched_setaffinity, METH_FASTCALL, os_sched_setaffinity__doc__},
 
 static PyObject *
 os_sched_setaffinity_impl(PyObject *module, pid_t pid, PyObject *mask);
 
 static PyObject *
-os_sched_setaffinity(PyObject *module, PyObject *args)
+os_sched_setaffinity(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     pid_t pid;
     PyObject *mask;
 
-    if (!PyArg_ParseTuple(args, "" _Py_PARSE_PID "O:sched_setaffinity",
+    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "O:sched_setaffinity",
         &pid, &mask)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("sched_setaffinity", kwnames)) {
         goto exit;
     }
     return_value = os_sched_setaffinity_impl(module, pid, mask);
@@ -2246,7 +2271,7 @@ os_openpty(PyObject *module, PyObject *Py_UNUSED(ignored))
 
 #endif /* (defined(HAVE_OPENPTY) || defined(HAVE__GETPTY) || defined(HAVE_DEV_PTMX)) */
 
-#if defined(HAVE_FORKPTY)
+#if (HAVE_FORKPTY)
 
 PyDoc_STRVAR(os_forkpty__doc__,
 "forkpty($module, /)\n"
@@ -2271,7 +2296,7 @@ os_forkpty(PyObject *module, PyObject *Py_UNUSED(ignored))
     return os_forkpty_impl(module);
 }
 
-#endif /* defined(HAVE_FORKPTY) */
+#endif /* (HAVE_FORKPTY) */
 
 #if defined(HAVE_GETEGID)
 
@@ -2539,20 +2564,24 @@ PyDoc_STRVAR(os_kill__doc__,
 "Kill a process with a signal.");
 
 #define OS_KILL_METHODDEF    \
-    {"kill", (PyCFunction)os_kill, METH_VARARGS, os_kill__doc__},
+    {"kill", (PyCFunction)os_kill, METH_FASTCALL, os_kill__doc__},
 
 static PyObject *
 os_kill_impl(PyObject *module, pid_t pid, Py_ssize_t signal);
 
 static PyObject *
-os_kill(PyObject *module, PyObject *args)
+os_kill(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     pid_t pid;
     Py_ssize_t signal;
 
-    if (!PyArg_ParseTuple(args, "" _Py_PARSE_PID "n:kill",
+    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "n:kill",
         &pid, &signal)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("kill", kwnames)) {
         goto exit;
     }
     return_value = os_kill_impl(module, pid, signal);
@@ -2572,20 +2601,24 @@ PyDoc_STRVAR(os_killpg__doc__,
 "Kill a process group with a signal.");
 
 #define OS_KILLPG_METHODDEF    \
-    {"killpg", (PyCFunction)os_killpg, METH_VARARGS, os_killpg__doc__},
+    {"killpg", (PyCFunction)os_killpg, METH_FASTCALL, os_killpg__doc__},
 
 static PyObject *
 os_killpg_impl(PyObject *module, pid_t pgid, int signal);
 
 static PyObject *
-os_killpg(PyObject *module, PyObject *args)
+os_killpg(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     pid_t pgid;
     int signal;
 
-    if (!PyArg_ParseTuple(args, "" _Py_PARSE_PID "i:killpg",
+    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "i:killpg",
         &pgid, &signal)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("killpg", kwnames)) {
         goto exit;
     }
     return_value = os_killpg_impl(module, pgid, signal);
@@ -2729,20 +2762,24 @@ PyDoc_STRVAR(os_setreuid__doc__,
 "Set the current process\'s real and effective user ids.");
 
 #define OS_SETREUID_METHODDEF    \
-    {"setreuid", (PyCFunction)os_setreuid, METH_VARARGS, os_setreuid__doc__},
+    {"setreuid", (PyCFunction)os_setreuid, METH_FASTCALL, os_setreuid__doc__},
 
 static PyObject *
 os_setreuid_impl(PyObject *module, uid_t ruid, uid_t euid);
 
 static PyObject *
-os_setreuid(PyObject *module, PyObject *args)
+os_setreuid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     uid_t ruid;
     uid_t euid;
 
-    if (!PyArg_ParseTuple(args, "O&O&:setreuid",
+    if (!_PyArg_ParseStack(args, nargs, "O&O&:setreuid",
         _Py_Uid_Converter, &ruid, _Py_Uid_Converter, &euid)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("setreuid", kwnames)) {
         goto exit;
     }
     return_value = os_setreuid_impl(module, ruid, euid);
@@ -2762,20 +2799,24 @@ PyDoc_STRVAR(os_setregid__doc__,
 "Set the current process\'s real and effective group ids.");
 
 #define OS_SETREGID_METHODDEF    \
-    {"setregid", (PyCFunction)os_setregid, METH_VARARGS, os_setregid__doc__},
+    {"setregid", (PyCFunction)os_setregid, METH_FASTCALL, os_setregid__doc__},
 
 static PyObject *
 os_setregid_impl(PyObject *module, gid_t rgid, gid_t egid);
 
 static PyObject *
-os_setregid(PyObject *module, PyObject *args)
+os_setregid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     gid_t rgid;
     gid_t egid;
 
-    if (!PyArg_ParseTuple(args, "O&O&:setregid",
+    if (!_PyArg_ParseStack(args, nargs, "O&O&:setregid",
         _Py_Gid_Converter, &rgid, _Py_Gid_Converter, &egid)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("setregid", kwnames)) {
         goto exit;
     }
     return_value = os_setregid_impl(module, rgid, egid);
@@ -2817,7 +2858,7 @@ exit:
 
 #endif /* defined(HAVE_SETGID) */
 
-#if defined(HAVE_SETGROUPS)
+#if (HAVE_SETGROUPS)
 
 PyDoc_STRVAR(os_setgroups__doc__,
 "setgroups($module, groups, /)\n"
@@ -2828,7 +2869,7 @@ PyDoc_STRVAR(os_setgroups__doc__,
 #define OS_SETGROUPS_METHODDEF    \
     {"setgroups", (PyCFunction)os_setgroups, METH_O, os_setgroups__doc__},
 
-#endif /* defined(HAVE_SETGROUPS) */
+#endif /* (HAVE_SETGROUPS) */
 
 #if defined(HAVE_WAIT3)
 
@@ -2925,21 +2966,25 @@ PyDoc_STRVAR(os_waitid__doc__,
 "no children in a waitable state.");
 
 #define OS_WAITID_METHODDEF    \
-    {"waitid", (PyCFunction)os_waitid, METH_VARARGS, os_waitid__doc__},
+    {"waitid", (PyCFunction)os_waitid, METH_FASTCALL, os_waitid__doc__},
 
 static PyObject *
 os_waitid_impl(PyObject *module, idtype_t idtype, id_t id, int options);
 
 static PyObject *
-os_waitid(PyObject *module, PyObject *args)
+os_waitid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     idtype_t idtype;
     id_t id;
     int options;
 
-    if (!PyArg_ParseTuple(args, "i" _Py_PARSE_PID "i:waitid",
+    if (!_PyArg_ParseStack(args, nargs, "i" _Py_PARSE_PID "i:waitid",
         &idtype, &id, &options)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("waitid", kwnames)) {
         goto exit;
     }
     return_value = os_waitid_impl(module, idtype, id, options);
@@ -2964,20 +3009,24 @@ PyDoc_STRVAR(os_waitpid__doc__,
 "The options argument is ignored on Windows.");
 
 #define OS_WAITPID_METHODDEF    \
-    {"waitpid", (PyCFunction)os_waitpid, METH_VARARGS, os_waitpid__doc__},
+    {"waitpid", (PyCFunction)os_waitpid, METH_FASTCALL, os_waitpid__doc__},
 
 static PyObject *
 os_waitpid_impl(PyObject *module, pid_t pid, int options);
 
 static PyObject *
-os_waitpid(PyObject *module, PyObject *args)
+os_waitpid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     pid_t pid;
     int options;
 
-    if (!PyArg_ParseTuple(args, "" _Py_PARSE_PID "i:waitpid",
+    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "i:waitpid",
         &pid, &options)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("waitpid", kwnames)) {
         goto exit;
     }
     return_value = os_waitpid_impl(module, pid, options);
@@ -3002,20 +3051,24 @@ PyDoc_STRVAR(os_waitpid__doc__,
 "The options argument is ignored on Windows.");
 
 #define OS_WAITPID_METHODDEF    \
-    {"waitpid", (PyCFunction)os_waitpid, METH_VARARGS, os_waitpid__doc__},
+    {"waitpid", (PyCFunction)os_waitpid, METH_FASTCALL, os_waitpid__doc__},
 
 static PyObject *
 os_waitpid_impl(PyObject *module, intptr_t pid, int options);
 
 static PyObject *
-os_waitpid(PyObject *module, PyObject *args)
+os_waitpid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     intptr_t pid;
     int options;
 
-    if (!PyArg_ParseTuple(args, "" _Py_PARSE_INTPTR "i:waitpid",
+    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_INTPTR "i:waitpid",
         &pid, &options)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("waitpid", kwnames)) {
         goto exit;
     }
     return_value = os_waitpid_impl(module, pid, options);
@@ -3192,20 +3245,24 @@ PyDoc_STRVAR(os_setpgid__doc__,
 "Call the system call setpgid(pid, pgrp).");
 
 #define OS_SETPGID_METHODDEF    \
-    {"setpgid", (PyCFunction)os_setpgid, METH_VARARGS, os_setpgid__doc__},
+    {"setpgid", (PyCFunction)os_setpgid, METH_FASTCALL, os_setpgid__doc__},
 
 static PyObject *
 os_setpgid_impl(PyObject *module, pid_t pid, pid_t pgrp);
 
 static PyObject *
-os_setpgid(PyObject *module, PyObject *args)
+os_setpgid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     pid_t pid;
     pid_t pgrp;
 
-    if (!PyArg_ParseTuple(args, "" _Py_PARSE_PID "" _Py_PARSE_PID ":setpgid",
+    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "" _Py_PARSE_PID ":setpgid",
         &pid, &pgrp)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("setpgid", kwnames)) {
         goto exit;
     }
     return_value = os_setpgid_impl(module, pid, pgrp);
@@ -3256,20 +3313,24 @@ PyDoc_STRVAR(os_tcsetpgrp__doc__,
 "Set the process group associated with the terminal specified by fd.");
 
 #define OS_TCSETPGRP_METHODDEF    \
-    {"tcsetpgrp", (PyCFunction)os_tcsetpgrp, METH_VARARGS, os_tcsetpgrp__doc__},
+    {"tcsetpgrp", (PyCFunction)os_tcsetpgrp, METH_FASTCALL, os_tcsetpgrp__doc__},
 
 static PyObject *
 os_tcsetpgrp_impl(PyObject *module, int fd, pid_t pgid);
 
 static PyObject *
-os_tcsetpgrp(PyObject *module, PyObject *args)
+os_tcsetpgrp(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int fd;
     pid_t pgid;
 
-    if (!PyArg_ParseTuple(args, "i" _Py_PARSE_PID ":tcsetpgrp",
+    if (!_PyArg_ParseStack(args, nargs, "i" _Py_PARSE_PID ":tcsetpgrp",
         &fd, &pgid)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("tcsetpgrp", kwnames)) {
         goto exit;
     }
     return_value = os_tcsetpgrp_impl(module, fd, pgid);
@@ -3302,9 +3363,9 @@ os_open(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     static const char * const _keywords[] = {"path", "flags", "mode", "dir_fd", NULL};
-    static _PyArg_Parser _parser = {"O&I|i$O&:open", _keywords, 0};
+    static _PyArg_Parser _parser = {"O&i|i$O&:open", _keywords, 0};
     path_t path = PATH_T_INITIALIZE("open", "path", 0, 0);
-    unsigned flags;
+    int flags;
     int mode = 511;
     int dir_fd = DEFAULT_DIR_FD;
     int _return_value;
@@ -3363,20 +3424,24 @@ PyDoc_STRVAR(os_closerange__doc__,
 "Closes all file descriptors in [fd_low, fd_high), ignoring errors.");
 
 #define OS_CLOSERANGE_METHODDEF    \
-    {"closerange", (PyCFunction)os_closerange, METH_VARARGS, os_closerange__doc__},
+    {"closerange", (PyCFunction)os_closerange, METH_FASTCALL, os_closerange__doc__},
 
 static PyObject *
 os_closerange_impl(PyObject *module, int fd_low, int fd_high);
 
 static PyObject *
-os_closerange(PyObject *module, PyObject *args)
+os_closerange(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int fd_low;
     int fd_high;
 
-    if (!PyArg_ParseTuple(args, "ii:closerange",
+    if (!_PyArg_ParseStack(args, nargs, "ii:closerange",
         &fd_low, &fd_high)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("closerange", kwnames)) {
         goto exit;
     }
     return_value = os_closerange_impl(module, fd_low, fd_high);
@@ -3465,21 +3530,25 @@ PyDoc_STRVAR(os_lockf__doc__,
 "    The number of bytes to lock, starting at the current position.");
 
 #define OS_LOCKF_METHODDEF    \
-    {"lockf", (PyCFunction)os_lockf, METH_VARARGS, os_lockf__doc__},
+    {"lockf", (PyCFunction)os_lockf, METH_FASTCALL, os_lockf__doc__},
 
 static PyObject *
 os_lockf_impl(PyObject *module, int fd, int command, Py_off_t length);
 
 static PyObject *
-os_lockf(PyObject *module, PyObject *args)
+os_lockf(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int fd;
     int command;
     Py_off_t length;
 
-    if (!PyArg_ParseTuple(args, "iiO&:lockf",
+    if (!_PyArg_ParseStack(args, nargs, "iiO&:lockf",
         &fd, &command, Py_off_t_converter, &length)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("lockf", kwnames)) {
         goto exit;
     }
     return_value = os_lockf_impl(module, fd, command, length);
@@ -3500,13 +3569,13 @@ PyDoc_STRVAR(os_lseek__doc__,
 "relative to the beginning of the file.");
 
 #define OS_LSEEK_METHODDEF    \
-    {"lseek", (PyCFunction)os_lseek, METH_VARARGS, os_lseek__doc__},
+    {"lseek", (PyCFunction)os_lseek, METH_FASTCALL, os_lseek__doc__},
 
 static Py_off_t
 os_lseek_impl(PyObject *module, int fd, Py_off_t position, int how);
 
 static PyObject *
-os_lseek(PyObject *module, PyObject *args)
+os_lseek(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int fd;
@@ -3514,8 +3583,12 @@ os_lseek(PyObject *module, PyObject *args)
     int how;
     Py_off_t _return_value;
 
-    if (!PyArg_ParseTuple(args, "iO&i:lseek",
+    if (!_PyArg_ParseStack(args, nargs, "iO&i:lseek",
         &fd, Py_off_t_converter, &position, &how)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("lseek", kwnames)) {
         goto exit;
     }
     _return_value = os_lseek_impl(module, fd, position, how);
@@ -3535,20 +3608,24 @@ PyDoc_STRVAR(os_read__doc__,
 "Read from a file descriptor.  Returns a bytes object.");
 
 #define OS_READ_METHODDEF    \
-    {"read", (PyCFunction)os_read, METH_VARARGS, os_read__doc__},
+    {"read", (PyCFunction)os_read, METH_FASTCALL, os_read__doc__},
 
 static PyObject *
 os_read_impl(PyObject *module, int fd, Py_ssize_t length);
 
 static PyObject *
-os_read(PyObject *module, PyObject *args)
+os_read(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int fd;
     Py_ssize_t length;
 
-    if (!PyArg_ParseTuple(args, "in:read",
+    if (!_PyArg_ParseStack(args, nargs, "in:read",
         &fd, &length)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("read", kwnames)) {
         goto exit;
     }
     return_value = os_read_impl(module, fd, length);
@@ -3574,21 +3651,25 @@ PyDoc_STRVAR(os_readv__doc__,
 "which may be less than the total capacity of all the buffers.");
 
 #define OS_READV_METHODDEF    \
-    {"readv", (PyCFunction)os_readv, METH_VARARGS, os_readv__doc__},
+    {"readv", (PyCFunction)os_readv, METH_FASTCALL, os_readv__doc__},
 
 static Py_ssize_t
 os_readv_impl(PyObject *module, int fd, PyObject *buffers);
 
 static PyObject *
-os_readv(PyObject *module, PyObject *args)
+os_readv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int fd;
     PyObject *buffers;
     Py_ssize_t _return_value;
 
-    if (!PyArg_ParseTuple(args, "iO:readv",
+    if (!_PyArg_ParseStack(args, nargs, "iO:readv",
         &fd, &buffers)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("readv", kwnames)) {
         goto exit;
     }
     _return_value = os_readv_impl(module, fd, buffers);
@@ -3615,21 +3696,25 @@ PyDoc_STRVAR(os_pread__doc__,
 "the beginning of the file.  The file offset remains unchanged.");
 
 #define OS_PREAD_METHODDEF    \
-    {"pread", (PyCFunction)os_pread, METH_VARARGS, os_pread__doc__},
+    {"pread", (PyCFunction)os_pread, METH_FASTCALL, os_pread__doc__},
 
 static PyObject *
 os_pread_impl(PyObject *module, int fd, int length, Py_off_t offset);
 
 static PyObject *
-os_pread(PyObject *module, PyObject *args)
+os_pread(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int fd;
     int length;
     Py_off_t offset;
 
-    if (!PyArg_ParseTuple(args, "iiO&:pread",
+    if (!_PyArg_ParseStack(args, nargs, "iiO&:pread",
         &fd, &length, Py_off_t_converter, &offset)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("pread", kwnames)) {
         goto exit;
     }
     return_value = os_pread_impl(module, fd, length, offset);
@@ -3647,21 +3732,25 @@ PyDoc_STRVAR(os_write__doc__,
 "Write a bytes object to a file descriptor.");
 
 #define OS_WRITE_METHODDEF    \
-    {"write", (PyCFunction)os_write, METH_VARARGS, os_write__doc__},
+    {"write", (PyCFunction)os_write, METH_FASTCALL, os_write__doc__},
 
 static Py_ssize_t
 os_write_impl(PyObject *module, int fd, Py_buffer *data);
 
 static PyObject *
-os_write(PyObject *module, PyObject *args)
+os_write(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int fd;
     Py_buffer data = {NULL, NULL};
     Py_ssize_t _return_value;
 
-    if (!PyArg_ParseTuple(args, "iy*:write",
+    if (!_PyArg_ParseStack(args, nargs, "iy*:write",
         &fd, &data)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("write", kwnames)) {
         goto exit;
     }
     _return_value = os_write_impl(module, fd, &data);
@@ -3821,21 +3910,25 @@ PyDoc_STRVAR(os_writev__doc__,
 "buffers must be a sequence of bytes-like objects.");
 
 #define OS_WRITEV_METHODDEF    \
-    {"writev", (PyCFunction)os_writev, METH_VARARGS, os_writev__doc__},
+    {"writev", (PyCFunction)os_writev, METH_FASTCALL, os_writev__doc__},
 
 static Py_ssize_t
 os_writev_impl(PyObject *module, int fd, PyObject *buffers);
 
 static PyObject *
-os_writev(PyObject *module, PyObject *args)
+os_writev(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int fd;
     PyObject *buffers;
     Py_ssize_t _return_value;
 
-    if (!PyArg_ParseTuple(args, "iO:writev",
+    if (!_PyArg_ParseStack(args, nargs, "iO:writev",
         &fd, &buffers)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("writev", kwnames)) {
         goto exit;
     }
     _return_value = os_writev_impl(module, fd, buffers);
@@ -3863,13 +3956,13 @@ PyDoc_STRVAR(os_pwrite__doc__,
 "current file offset.");
 
 #define OS_PWRITE_METHODDEF    \
-    {"pwrite", (PyCFunction)os_pwrite, METH_VARARGS, os_pwrite__doc__},
+    {"pwrite", (PyCFunction)os_pwrite, METH_FASTCALL, os_pwrite__doc__},
 
 static Py_ssize_t
 os_pwrite_impl(PyObject *module, int fd, Py_buffer *buffer, Py_off_t offset);
 
 static PyObject *
-os_pwrite(PyObject *module, PyObject *args)
+os_pwrite(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int fd;
@@ -3877,8 +3970,12 @@ os_pwrite(PyObject *module, PyObject *args)
     Py_off_t offset;
     Py_ssize_t _return_value;
 
-    if (!PyArg_ParseTuple(args, "iy*O&:pwrite",
+    if (!_PyArg_ParseStack(args, nargs, "iy*O&:pwrite",
         &fd, &buffer, Py_off_t_converter, &offset)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("pwrite", kwnames)) {
         goto exit;
     }
     _return_value = os_pwrite_impl(module, fd, &buffer, offset);
@@ -4076,21 +4173,25 @@ PyDoc_STRVAR(os_makedev__doc__,
 "Composes a raw device number from the major and minor device numbers.");
 
 #define OS_MAKEDEV_METHODDEF    \
-    {"makedev", (PyCFunction)os_makedev, METH_VARARGS, os_makedev__doc__},
+    {"makedev", (PyCFunction)os_makedev, METH_FASTCALL, os_makedev__doc__},
 
 static dev_t
 os_makedev_impl(PyObject *module, int major, int minor);
 
 static PyObject *
-os_makedev(PyObject *module, PyObject *args)
+os_makedev(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int major;
     int minor;
     dev_t _return_value;
 
-    if (!PyArg_ParseTuple(args, "ii:makedev",
+    if (!_PyArg_ParseStack(args, nargs, "ii:makedev",
         &major, &minor)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("makedev", kwnames)) {
         goto exit;
     }
     _return_value = os_makedev_impl(module, major, minor);
@@ -4114,20 +4215,24 @@ PyDoc_STRVAR(os_ftruncate__doc__,
 "Truncate a file, specified by file descriptor, to a specific length.");
 
 #define OS_FTRUNCATE_METHODDEF    \
-    {"ftruncate", (PyCFunction)os_ftruncate, METH_VARARGS, os_ftruncate__doc__},
+    {"ftruncate", (PyCFunction)os_ftruncate, METH_FASTCALL, os_ftruncate__doc__},
 
 static PyObject *
 os_ftruncate_impl(PyObject *module, int fd, Py_off_t length);
 
 static PyObject *
-os_ftruncate(PyObject *module, PyObject *args)
+os_ftruncate(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int fd;
     Py_off_t length;
 
-    if (!PyArg_ParseTuple(args, "iO&:ftruncate",
+    if (!_PyArg_ParseStack(args, nargs, "iO&:ftruncate",
         &fd, Py_off_t_converter, &length)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("ftruncate", kwnames)) {
         goto exit;
     }
     return_value = os_ftruncate_impl(module, fd, length);
@@ -4191,22 +4296,26 @@ PyDoc_STRVAR(os_posix_fallocate__doc__,
 "starting at offset bytes from the beginning and continuing for length bytes.");
 
 #define OS_POSIX_FALLOCATE_METHODDEF    \
-    {"posix_fallocate", (PyCFunction)os_posix_fallocate, METH_VARARGS, os_posix_fallocate__doc__},
+    {"posix_fallocate", (PyCFunction)os_posix_fallocate, METH_FASTCALL, os_posix_fallocate__doc__},
 
 static PyObject *
 os_posix_fallocate_impl(PyObject *module, int fd, Py_off_t offset,
                         Py_off_t length);
 
 static PyObject *
-os_posix_fallocate(PyObject *module, PyObject *args)
+os_posix_fallocate(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int fd;
     Py_off_t offset;
     Py_off_t length;
 
-    if (!PyArg_ParseTuple(args, "iO&O&:posix_fallocate",
+    if (!_PyArg_ParseStack(args, nargs, "iO&O&:posix_fallocate",
         &fd, Py_off_t_converter, &offset, Py_off_t_converter, &length)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("posix_fallocate", kwnames)) {
         goto exit;
     }
     return_value = os_posix_fallocate_impl(module, fd, offset, length);
@@ -4234,14 +4343,14 @@ PyDoc_STRVAR(os_posix_fadvise__doc__,
 "POSIX_FADV_DONTNEED.");
 
 #define OS_POSIX_FADVISE_METHODDEF    \
-    {"posix_fadvise", (PyCFunction)os_posix_fadvise, METH_VARARGS, os_posix_fadvise__doc__},
+    {"posix_fadvise", (PyCFunction)os_posix_fadvise, METH_FASTCALL, os_posix_fadvise__doc__},
 
 static PyObject *
 os_posix_fadvise_impl(PyObject *module, int fd, Py_off_t offset,
                       Py_off_t length, int advice);
 
 static PyObject *
-os_posix_fadvise(PyObject *module, PyObject *args)
+os_posix_fadvise(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int fd;
@@ -4249,8 +4358,12 @@ os_posix_fadvise(PyObject *module, PyObject *args)
     Py_off_t length;
     int advice;
 
-    if (!PyArg_ParseTuple(args, "iO&O&i:posix_fadvise",
+    if (!_PyArg_ParseStack(args, nargs, "iO&O&i:posix_fadvise",
         &fd, Py_off_t_converter, &offset, Py_off_t_converter, &length, &advice)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("posix_fadvise", kwnames)) {
         goto exit;
     }
     return_value = os_posix_fadvise_impl(module, fd, offset, length, advice);
@@ -4270,20 +4383,24 @@ PyDoc_STRVAR(os_putenv__doc__,
 "Change or add an environment variable.");
 
 #define OS_PUTENV_METHODDEF    \
-    {"putenv", (PyCFunction)os_putenv, METH_VARARGS, os_putenv__doc__},
+    {"putenv", (PyCFunction)os_putenv, METH_FASTCALL, os_putenv__doc__},
 
 static PyObject *
 os_putenv_impl(PyObject *module, PyObject *name, PyObject *value);
 
 static PyObject *
-os_putenv(PyObject *module, PyObject *args)
+os_putenv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *name;
     PyObject *value;
 
-    if (!PyArg_ParseTuple(args, "UU:putenv",
+    if (!_PyArg_ParseStack(args, nargs, "UU:putenv",
         &name, &value)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("putenv", kwnames)) {
         goto exit;
     }
     return_value = os_putenv_impl(module, name, value);
@@ -4303,20 +4420,24 @@ PyDoc_STRVAR(os_putenv__doc__,
 "Change or add an environment variable.");
 
 #define OS_PUTENV_METHODDEF    \
-    {"putenv", (PyCFunction)os_putenv, METH_VARARGS, os_putenv__doc__},
+    {"putenv", (PyCFunction)os_putenv, METH_FASTCALL, os_putenv__doc__},
 
 static PyObject *
 os_putenv_impl(PyObject *module, PyObject *name, PyObject *value);
 
 static PyObject *
-os_putenv(PyObject *module, PyObject *args)
+os_putenv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *name = NULL;
     PyObject *value = NULL;
 
-    if (!PyArg_ParseTuple(args, "O&O&:putenv",
+    if (!_PyArg_ParseStack(args, nargs, "O&O&:putenv",
         PyUnicode_FSConverter, &name, PyUnicode_FSConverter, &value)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("putenv", kwnames)) {
         goto exit;
     }
     return_value = os_putenv_impl(module, name, value);
@@ -4705,7 +4826,7 @@ exit:
 
 #endif /* defined(WSTOPSIG) */
 
-#if (defined(HAVE_FSTATVFS))
+#if defined(HAVE_FSTATVFS)
 
 PyDoc_STRVAR(os_fstatvfs__doc__,
 "fstatvfs($module, fd, /)\n"
@@ -4736,9 +4857,9 @@ exit:
     return return_value;
 }
 
-#endif /* (defined(HAVE_FSTATVFS)) */
+#endif /* defined(HAVE_FSTATVFS) */
 
-#if (defined(HAVE_STATVFS))
+#if defined(HAVE_STATVFS)
 
 PyDoc_STRVAR(os_statvfs__doc__,
 "statvfs($module, /, path)\n"
@@ -4777,7 +4898,7 @@ exit:
     return return_value;
 }
 
-#endif /* (defined(HAVE_STATVFS)) */
+#endif /* defined(HAVE_STATVFS) */
 
 #if defined(MS_WINDOWS)
 
@@ -4824,21 +4945,25 @@ PyDoc_STRVAR(os_fpathconf__doc__,
 "If there is no limit, return -1.");
 
 #define OS_FPATHCONF_METHODDEF    \
-    {"fpathconf", (PyCFunction)os_fpathconf, METH_VARARGS, os_fpathconf__doc__},
+    {"fpathconf", (PyCFunction)os_fpathconf, METH_FASTCALL, os_fpathconf__doc__},
 
 static long
 os_fpathconf_impl(PyObject *module, int fd, int name);
 
 static PyObject *
-os_fpathconf(PyObject *module, PyObject *args)
+os_fpathconf(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int fd;
     int name;
     long _return_value;
 
-    if (!PyArg_ParseTuple(args, "iO&:fpathconf",
+    if (!_PyArg_ParseStack(args, nargs, "iO&:fpathconf",
         &fd, conv_path_confname, &name)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("fpathconf", kwnames)) {
         goto exit;
     }
     _return_value = os_fpathconf_impl(module, fd, name);
@@ -5111,21 +5236,25 @@ PyDoc_STRVAR(os_setresuid__doc__,
 "Set the current process\'s real, effective, and saved user ids.");
 
 #define OS_SETRESUID_METHODDEF    \
-    {"setresuid", (PyCFunction)os_setresuid, METH_VARARGS, os_setresuid__doc__},
+    {"setresuid", (PyCFunction)os_setresuid, METH_FASTCALL, os_setresuid__doc__},
 
 static PyObject *
 os_setresuid_impl(PyObject *module, uid_t ruid, uid_t euid, uid_t suid);
 
 static PyObject *
-os_setresuid(PyObject *module, PyObject *args)
+os_setresuid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     uid_t ruid;
     uid_t euid;
     uid_t suid;
 
-    if (!PyArg_ParseTuple(args, "O&O&O&:setresuid",
+    if (!_PyArg_ParseStack(args, nargs, "O&O&O&:setresuid",
         _Py_Uid_Converter, &ruid, _Py_Uid_Converter, &euid, _Py_Uid_Converter, &suid)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("setresuid", kwnames)) {
         goto exit;
     }
     return_value = os_setresuid_impl(module, ruid, euid, suid);
@@ -5145,21 +5274,25 @@ PyDoc_STRVAR(os_setresgid__doc__,
 "Set the current process\'s real, effective, and saved group ids.");
 
 #define OS_SETRESGID_METHODDEF    \
-    {"setresgid", (PyCFunction)os_setresgid, METH_VARARGS, os_setresgid__doc__},
+    {"setresgid", (PyCFunction)os_setresgid, METH_FASTCALL, os_setresgid__doc__},
 
 static PyObject *
 os_setresgid_impl(PyObject *module, gid_t rgid, gid_t egid, gid_t sgid);
 
 static PyObject *
-os_setresgid(PyObject *module, PyObject *args)
+os_setresgid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     gid_t rgid;
     gid_t egid;
     gid_t sgid;
 
-    if (!PyArg_ParseTuple(args, "O&O&O&:setresgid",
+    if (!_PyArg_ParseStack(args, nargs, "O&O&O&:setresgid",
         _Py_Gid_Converter, &rgid, _Py_Gid_Converter, &egid, _Py_Gid_Converter, &sgid)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("setresgid", kwnames)) {
         goto exit;
     }
     return_value = os_setresgid_impl(module, rgid, egid, sgid);
@@ -5494,20 +5627,24 @@ PyDoc_STRVAR(os_set_inheritable__doc__,
 "Set the inheritable flag of the specified file descriptor.");
 
 #define OS_SET_INHERITABLE_METHODDEF    \
-    {"set_inheritable", (PyCFunction)os_set_inheritable, METH_VARARGS, os_set_inheritable__doc__},
+    {"set_inheritable", (PyCFunction)os_set_inheritable, METH_FASTCALL, os_set_inheritable__doc__},
 
 static PyObject *
 os_set_inheritable_impl(PyObject *module, int fd, int inheritable);
 
 static PyObject *
-os_set_inheritable(PyObject *module, PyObject *args)
+os_set_inheritable(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int fd;
     int inheritable;
 
-    if (!PyArg_ParseTuple(args, "ii:set_inheritable",
+    if (!_PyArg_ParseStack(args, nargs, "ii:set_inheritable",
         &fd, &inheritable)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("set_inheritable", kwnames)) {
         goto exit;
     }
     return_value = os_set_inheritable_impl(module, fd, inheritable);
@@ -5561,21 +5698,25 @@ PyDoc_STRVAR(os_set_handle_inheritable__doc__,
 "Set the inheritable flag of the specified handle.");
 
 #define OS_SET_HANDLE_INHERITABLE_METHODDEF    \
-    {"set_handle_inheritable", (PyCFunction)os_set_handle_inheritable, METH_VARARGS, os_set_handle_inheritable__doc__},
+    {"set_handle_inheritable", (PyCFunction)os_set_handle_inheritable, METH_FASTCALL, os_set_handle_inheritable__doc__},
 
 static PyObject *
 os_set_handle_inheritable_impl(PyObject *module, intptr_t handle,
                                int inheritable);
 
 static PyObject *
-os_set_handle_inheritable(PyObject *module, PyObject *args)
+os_set_handle_inheritable(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     intptr_t handle;
     int inheritable;
 
-    if (!PyArg_ParseTuple(args, "" _Py_PARSE_INTPTR "p:set_handle_inheritable",
+    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_INTPTR "p:set_handle_inheritable",
         &handle, &inheritable)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("set_handle_inheritable", kwnames)) {
         goto exit;
     }
     return_value = os_set_handle_inheritable_impl(module, handle, inheritable);
@@ -5719,17 +5860,9 @@ exit:
     #define OS__GETFULLPATHNAME_METHODDEF
 #endif /* !defined(OS__GETFULLPATHNAME_METHODDEF) */
 
-#ifndef OS__GETFINALPATHNAME_METHODDEF
-    #define OS__GETFINALPATHNAME_METHODDEF
-#endif /* !defined(OS__GETFINALPATHNAME_METHODDEF) */
-
 #ifndef OS__ISDIR_METHODDEF
     #define OS__ISDIR_METHODDEF
 #endif /* !defined(OS__ISDIR_METHODDEF) */
-
-#ifndef OS__GETVOLUMEPATHNAME_METHODDEF
-    #define OS__GETVOLUMEPATHNAME_METHODDEF
-#endif /* !defined(OS__GETVOLUMEPATHNAME_METHODDEF) */
 
 #ifndef OS_NICE_METHODDEF
     #define OS_NICE_METHODDEF
@@ -5802,10 +5935,6 @@ exit:
 #ifndef OS_SCHED_RR_GET_INTERVAL_METHODDEF
     #define OS_SCHED_RR_GET_INTERVAL_METHODDEF
 #endif /* !defined(OS_SCHED_RR_GET_INTERVAL_METHODDEF) */
-
-#ifndef OS_SCHED_YIELD_METHODDEF
-    #define OS_SCHED_YIELD_METHODDEF
-#endif /* !defined(OS_SCHED_YIELD_METHODDEF) */
 
 #ifndef OS_SCHED_SETAFFINITY_METHODDEF
     #define OS_SCHED_SETAFFINITY_METHODDEF
@@ -6138,4 +6267,4 @@ exit:
 #ifndef OS_GETRANDOM_METHODDEF
     #define OS_GETRANDOM_METHODDEF
 #endif /* !defined(OS_GETRANDOM_METHODDEF) */
-/*[clinic end generated code: output=92026f29ec925950 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f222503f1d1fd002 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/pyexpat.inc
+++ b/third_party/python/Modules/clinic/pyexpat.inc
@@ -12,21 +12,25 @@ PyDoc_STRVAR(pyexpat_xmlparser_Parse__doc__,
 "`isfinal\' should be true at end of input.");
 
 #define PYEXPAT_XMLPARSER_PARSE_METHODDEF    \
-    {"Parse", (PyCFunction)pyexpat_xmlparser_Parse, METH_VARARGS, pyexpat_xmlparser_Parse__doc__},
+    {"Parse", (PyCFunction)pyexpat_xmlparser_Parse, METH_FASTCALL, pyexpat_xmlparser_Parse__doc__},
 
 static PyObject *
 pyexpat_xmlparser_Parse_impl(xmlparseobject *self, PyObject *data,
                              int isfinal);
 
 static PyObject *
-pyexpat_xmlparser_Parse(xmlparseobject *self, PyObject *args)
+pyexpat_xmlparser_Parse(xmlparseobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *data;
     int isfinal = 0;
 
-    if (!PyArg_ParseTuple(args, "O|i:Parse",
+    if (!_PyArg_ParseStack(args, nargs, "O|i:Parse",
         &data, &isfinal)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("Parse", kwnames)) {
         goto exit;
     }
     return_value = pyexpat_xmlparser_Parse_impl(self, data, isfinal);
@@ -117,7 +121,7 @@ PyDoc_STRVAR(pyexpat_xmlparser_ExternalEntityParserCreate__doc__,
 "Create a parser for parsing an external entity based on the information passed to the ExternalEntityRefHandler.");
 
 #define PYEXPAT_XMLPARSER_EXTERNALENTITYPARSERCREATE_METHODDEF    \
-    {"ExternalEntityParserCreate", (PyCFunction)pyexpat_xmlparser_ExternalEntityParserCreate, METH_VARARGS, pyexpat_xmlparser_ExternalEntityParserCreate__doc__},
+    {"ExternalEntityParserCreate", (PyCFunction)pyexpat_xmlparser_ExternalEntityParserCreate, METH_FASTCALL, pyexpat_xmlparser_ExternalEntityParserCreate__doc__},
 
 static PyObject *
 pyexpat_xmlparser_ExternalEntityParserCreate_impl(xmlparseobject *self,
@@ -125,14 +129,18 @@ pyexpat_xmlparser_ExternalEntityParserCreate_impl(xmlparseobject *self,
                                                   const char *encoding);
 
 static PyObject *
-pyexpat_xmlparser_ExternalEntityParserCreate(xmlparseobject *self, PyObject *args)
+pyexpat_xmlparser_ExternalEntityParserCreate(xmlparseobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     const char *context;
     const char *encoding = NULL;
 
-    if (!PyArg_ParseTuple(args, "z|s:ExternalEntityParserCreate",
+    if (!_PyArg_ParseStack(args, nargs, "z|s:ExternalEntityParserCreate",
         &context, &encoding)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("ExternalEntityParserCreate", kwnames)) {
         goto exit;
     }
     return_value = pyexpat_xmlparser_ExternalEntityParserCreate_impl(self, context, encoding);
@@ -186,19 +194,23 @@ PyDoc_STRVAR(pyexpat_xmlparser_UseForeignDTD__doc__,
 "information to the parser. \'flag\' defaults to True if not provided.");
 
 #define PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF    \
-    {"UseForeignDTD", (PyCFunction)pyexpat_xmlparser_UseForeignDTD, METH_VARARGS, pyexpat_xmlparser_UseForeignDTD__doc__},
+    {"UseForeignDTD", (PyCFunction)pyexpat_xmlparser_UseForeignDTD, METH_FASTCALL, pyexpat_xmlparser_UseForeignDTD__doc__},
 
 static PyObject *
 pyexpat_xmlparser_UseForeignDTD_impl(xmlparseobject *self, int flag);
 
 static PyObject *
-pyexpat_xmlparser_UseForeignDTD(xmlparseobject *self, PyObject *args)
+pyexpat_xmlparser_UseForeignDTD(xmlparseobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int flag = 1;
 
-    if (!PyArg_ParseTuple(args, "|p:UseForeignDTD",
+    if (!_PyArg_ParseStack(args, nargs, "|p:UseForeignDTD",
         &flag)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("UseForeignDTD", kwnames)) {
         goto exit;
     }
     return_value = pyexpat_xmlparser_UseForeignDTD_impl(self, flag);
@@ -290,4 +302,4 @@ exit:
 #ifndef PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF
     #define PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF
 #endif /* !defined(PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF) */
-/*[clinic end generated code: output=e889f7c6af6cc42f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=0548a6b12157e29b input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/pyexpat.inc
+++ b/third_party/python/Modules/clinic/pyexpat.inc
@@ -250,7 +250,7 @@ pyexpat_ParserCreate(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObje
     const char *namespace_separator = NULL;
     PyObject *intern = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &encoding, &namespace_separator, &intern)) {
         goto exit;
     }

--- a/third_party/python/Modules/clinic/signalmodule.inc
+++ b/third_party/python/Modules/clinic/signalmodule.inc
@@ -354,22 +354,26 @@ PyDoc_STRVAR(signal_sigtimedwait__doc__,
 "The timeout is specified in seconds, with floating point numbers allowed.");
 
 #define SIGNAL_SIGTIMEDWAIT_METHODDEF    \
-    {"sigtimedwait", (PyCFunction)signal_sigtimedwait, METH_VARARGS, signal_sigtimedwait__doc__},
+    {"sigtimedwait", (PyCFunction)signal_sigtimedwait, METH_FASTCALL, signal_sigtimedwait__doc__},
 
 static PyObject *
 signal_sigtimedwait_impl(PyObject *module, PyObject *sigset,
                          PyObject *timeout_obj);
 
 static PyObject *
-signal_sigtimedwait(PyObject *module, PyObject *args)
+signal_sigtimedwait(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *sigset;
     PyObject *timeout_obj;
 
-    if (!PyArg_UnpackTuple(args, "sigtimedwait",
+    if (!_PyArg_UnpackStack(args, nargs, "sigtimedwait",
         2, 2,
         &sigset, &timeout_obj)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("sigtimedwait", kwnames)) {
         goto exit;
     }
     return_value = signal_sigtimedwait_impl(module, sigset, timeout_obj);
@@ -460,4 +464,4 @@ exit:
 #ifndef SIGNAL_PTHREAD_KILL_METHODDEF
     #define SIGNAL_PTHREAD_KILL_METHODDEF
 #endif /* !defined(SIGNAL_PTHREAD_KILL_METHODDEF) */
-/*[clinic end generated code: output=b49f7bfff44d1256 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=fab3dba32c058588 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/signalmodule.inc
+++ b/third_party/python/Modules/clinic/signalmodule.inc
@@ -75,20 +75,24 @@ PyDoc_STRVAR(signal_signal__doc__,
 "the first is the signal number, the second is the interrupted stack frame.");
 
 #define SIGNAL_SIGNAL_METHODDEF    \
-    {"signal", (PyCFunction)signal_signal, METH_VARARGS, signal_signal__doc__},
+    {"signal", (PyCFunction)signal_signal, METH_FASTCALL, signal_signal__doc__},
 
 static PyObject *
 signal_signal_impl(PyObject *module, int signalnum, PyObject *handler);
 
 static PyObject *
-signal_signal(PyObject *module, PyObject *args)
+signal_signal(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int signalnum;
     PyObject *handler;
 
-    if (!PyArg_ParseTuple(args, "iO:signal",
+    if (!_PyArg_ParseStack(args, nargs, "iO:signal",
         &signalnum, &handler)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("signal", kwnames)) {
         goto exit;
     }
     return_value = signal_signal_impl(module, signalnum, handler);
@@ -142,20 +146,24 @@ PyDoc_STRVAR(signal_siginterrupt__doc__,
 "signal sig, else system calls will be interrupted.");
 
 #define SIGNAL_SIGINTERRUPT_METHODDEF    \
-    {"siginterrupt", (PyCFunction)signal_siginterrupt, METH_VARARGS, signal_siginterrupt__doc__},
+    {"siginterrupt", (PyCFunction)signal_siginterrupt, METH_FASTCALL, signal_siginterrupt__doc__},
 
 static PyObject *
 signal_siginterrupt_impl(PyObject *module, int signalnum, int flag);
 
 static PyObject *
-signal_siginterrupt(PyObject *module, PyObject *args)
+signal_siginterrupt(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int signalnum;
     int flag;
 
-    if (!PyArg_ParseTuple(args, "ii:siginterrupt",
+    if (!_PyArg_ParseStack(args, nargs, "ii:siginterrupt",
         &signalnum, &flag)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("siginterrupt", kwnames)) {
         goto exit;
     }
     return_value = signal_siginterrupt_impl(module, signalnum, flag);
@@ -180,22 +188,26 @@ PyDoc_STRVAR(signal_setitimer__doc__,
 "Returns old values as a tuple: (delay, interval).");
 
 #define SIGNAL_SETITIMER_METHODDEF    \
-    {"setitimer", (PyCFunction)signal_setitimer, METH_VARARGS, signal_setitimer__doc__},
+    {"setitimer", (PyCFunction)signal_setitimer, METH_FASTCALL, signal_setitimer__doc__},
 
 static PyObject *
 signal_setitimer_impl(PyObject *module, int which, double seconds,
                       double interval);
 
 static PyObject *
-signal_setitimer(PyObject *module, PyObject *args)
+signal_setitimer(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int which;
     double seconds;
     double interval = 0.0;
 
-    if (!PyArg_ParseTuple(args, "id|d:setitimer",
+    if (!_PyArg_ParseStack(args, nargs, "id|d:setitimer",
         &which, &seconds, &interval)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("setitimer", kwnames)) {
         goto exit;
     }
     return_value = signal_setitimer_impl(module, which, seconds, interval);
@@ -246,20 +258,24 @@ PyDoc_STRVAR(signal_pthread_sigmask__doc__,
 "Fetch and/or change the signal mask of the calling thread.");
 
 #define SIGNAL_PTHREAD_SIGMASK_METHODDEF    \
-    {"pthread_sigmask", (PyCFunction)signal_pthread_sigmask, METH_VARARGS, signal_pthread_sigmask__doc__},
+    {"pthread_sigmask", (PyCFunction)signal_pthread_sigmask, METH_FASTCALL, signal_pthread_sigmask__doc__},
 
 static PyObject *
 signal_pthread_sigmask_impl(PyObject *module, int how, PyObject *mask);
 
 static PyObject *
-signal_pthread_sigmask(PyObject *module, PyObject *args)
+signal_pthread_sigmask(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int how;
     PyObject *mask;
 
-    if (!PyArg_ParseTuple(args, "iO:pthread_sigmask",
+    if (!_PyArg_ParseStack(args, nargs, "iO:pthread_sigmask",
         &how, &mask)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("pthread_sigmask", kwnames)) {
         goto exit;
     }
     return_value = signal_pthread_sigmask_impl(module, how, mask);
@@ -373,20 +389,24 @@ PyDoc_STRVAR(signal_pthread_kill__doc__,
 "Send a signal to a thread.");
 
 #define SIGNAL_PTHREAD_KILL_METHODDEF    \
-    {"pthread_kill", (PyCFunction)signal_pthread_kill, METH_VARARGS, signal_pthread_kill__doc__},
+    {"pthread_kill", (PyCFunction)signal_pthread_kill, METH_FASTCALL, signal_pthread_kill__doc__},
 
 static PyObject *
 signal_pthread_kill_impl(PyObject *module, long thread_id, int signalnum);
 
 static PyObject *
-signal_pthread_kill(PyObject *module, PyObject *args)
+signal_pthread_kill(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     long thread_id;
     int signalnum;
 
-    if (!PyArg_ParseTuple(args, "li:pthread_kill",
+    if (!_PyArg_ParseStack(args, nargs, "li:pthread_kill",
         &thread_id, &signalnum)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("pthread_kill", kwnames)) {
         goto exit;
     }
     return_value = signal_pthread_kill_impl(module, thread_id, signalnum);
@@ -440,4 +460,4 @@ exit:
 #ifndef SIGNAL_PTHREAD_KILL_METHODDEF
     #define SIGNAL_PTHREAD_KILL_METHODDEF
 #endif /* !defined(SIGNAL_PTHREAD_KILL_METHODDEF) */
-/*[clinic end generated code: output=c6990ef0d0ba72b6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b49f7bfff44d1256 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/unicodedata.inc
+++ b/third_party/python/Modules/clinic/unicodedata.inc
@@ -14,21 +14,25 @@ PyDoc_STRVAR(unicodedata_UCD_decimal__doc__,
 "ValueError is raised.");
 
 #define UNICODEDATA_UCD_DECIMAL_METHODDEF    \
-    {"decimal", (PyCFunction)unicodedata_UCD_decimal, METH_VARARGS, unicodedata_UCD_decimal__doc__},
+    {"decimal", (PyCFunction)unicodedata_UCD_decimal, METH_FASTCALL, unicodedata_UCD_decimal__doc__},
 
 static PyObject *
 unicodedata_UCD_decimal_impl(PyObject *self, int chr,
                              PyObject *default_value);
 
 static PyObject *
-unicodedata_UCD_decimal(PyObject *self, PyObject *args)
+unicodedata_UCD_decimal(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int chr;
     PyObject *default_value = NULL;
 
-    if (!PyArg_ParseTuple(args, "C|O:decimal",
+    if (!_PyArg_ParseStack(args, nargs, "C|O:decimal",
         &chr, &default_value)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("decimal", kwnames)) {
         goto exit;
     }
     return_value = unicodedata_UCD_decimal_impl(self, chr, default_value);
@@ -48,20 +52,24 @@ PyDoc_STRVAR(unicodedata_UCD_digit__doc__,
 "ValueError is raised.");
 
 #define UNICODEDATA_UCD_DIGIT_METHODDEF    \
-    {"digit", (PyCFunction)unicodedata_UCD_digit, METH_VARARGS, unicodedata_UCD_digit__doc__},
+    {"digit", (PyCFunction)unicodedata_UCD_digit, METH_FASTCALL, unicodedata_UCD_digit__doc__},
 
 static PyObject *
 unicodedata_UCD_digit_impl(PyObject *self, int chr, PyObject *default_value);
 
 static PyObject *
-unicodedata_UCD_digit(PyObject *self, PyObject *args)
+unicodedata_UCD_digit(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int chr;
     PyObject *default_value = NULL;
 
-    if (!PyArg_ParseTuple(args, "C|O:digit",
+    if (!_PyArg_ParseStack(args, nargs, "C|O:digit",
         &chr, &default_value)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("digit", kwnames)) {
         goto exit;
     }
     return_value = unicodedata_UCD_digit_impl(self, chr, default_value);
@@ -81,21 +89,25 @@ PyDoc_STRVAR(unicodedata_UCD_numeric__doc__,
 "ValueError is raised.");
 
 #define UNICODEDATA_UCD_NUMERIC_METHODDEF    \
-    {"numeric", (PyCFunction)unicodedata_UCD_numeric, METH_VARARGS, unicodedata_UCD_numeric__doc__},
+    {"numeric", (PyCFunction)unicodedata_UCD_numeric, METH_FASTCALL, unicodedata_UCD_numeric__doc__},
 
 static PyObject *
 unicodedata_UCD_numeric_impl(PyObject *self, int chr,
                              PyObject *default_value);
 
 static PyObject *
-unicodedata_UCD_numeric(PyObject *self, PyObject *args)
+unicodedata_UCD_numeric(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int chr;
     PyObject *default_value = NULL;
 
-    if (!PyArg_ParseTuple(args, "C|O:numeric",
+    if (!_PyArg_ParseStack(args, nargs, "C|O:numeric",
         &chr, &default_value)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("numeric", kwnames)) {
         goto exit;
     }
     return_value = unicodedata_UCD_numeric_impl(self, chr, default_value);
@@ -294,21 +306,25 @@ PyDoc_STRVAR(unicodedata_UCD_normalize__doc__,
 "Valid values for form are \'NFC\', \'NFKC\', \'NFD\', and \'NFKD\'.");
 
 #define UNICODEDATA_UCD_NORMALIZE_METHODDEF    \
-    {"normalize", (PyCFunction)unicodedata_UCD_normalize, METH_VARARGS, unicodedata_UCD_normalize__doc__},
+    {"normalize", (PyCFunction)unicodedata_UCD_normalize, METH_FASTCALL, unicodedata_UCD_normalize__doc__},
 
 static PyObject *
 unicodedata_UCD_normalize_impl(PyObject *self, const char *form,
                                PyObject *input);
 
 static PyObject *
-unicodedata_UCD_normalize(PyObject *self, PyObject *args)
+unicodedata_UCD_normalize(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     const char *form;
     PyObject *input;
 
-    if (!PyArg_ParseTuple(args, "sO!:normalize",
+    if (!_PyArg_ParseStack(args, nargs, "sO!:normalize",
         &form, &PyUnicode_Type, &input)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("normalize", kwnames)) {
         goto exit;
     }
     return_value = unicodedata_UCD_normalize_impl(self, form, input);
@@ -327,20 +343,24 @@ PyDoc_STRVAR(unicodedata_UCD_name__doc__,
 "ValueError is raised.");
 
 #define UNICODEDATA_UCD_NAME_METHODDEF    \
-    {"name", (PyCFunction)unicodedata_UCD_name, METH_VARARGS, unicodedata_UCD_name__doc__},
+    {"name", (PyCFunction)unicodedata_UCD_name, METH_FASTCALL, unicodedata_UCD_name__doc__},
 
 static PyObject *
 unicodedata_UCD_name_impl(PyObject *self, int chr, PyObject *default_value);
 
 static PyObject *
-unicodedata_UCD_name(PyObject *self, PyObject *args)
+unicodedata_UCD_name(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int chr;
     PyObject *default_value = NULL;
 
-    if (!PyArg_ParseTuple(args, "C|O:name",
+    if (!_PyArg_ParseStack(args, nargs, "C|O:name",
         &chr, &default_value)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("name", kwnames)) {
         goto exit;
     }
     return_value = unicodedata_UCD_name_impl(self, chr, default_value);
@@ -380,4 +400,4 @@ unicodedata_UCD_lookup(PyObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=5313ce129da87b2f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=badeb811d1caec40 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/zlibmodule.inc
+++ b/third_party/python/Modules/clinic/zlibmodule.inc
@@ -18,6 +18,9 @@ PyDoc_STRVAR(zlib_compress__doc__,
     {"compress", (PyCFunction)zlib_compress, METH_FASTCALL, zlib_compress__doc__},
 
 static PyObject *
+zlib_compress_impl(PyObject *module, Py_buffer *data, int level);
+
+static PyObject *
 zlib_compress(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
@@ -110,7 +113,7 @@ PyDoc_STRVAR(zlib_compressobj__doc__,
 "    Valid values range from 1 to 9.  Higher values result in higher memory\n"
 "    usage, faster compression, and smaller output.\n"
 "  strategy\n"
-"    Used to tune the compression algorithm.  Possible values are\n"
+"    Used to tune the compression algorithm. Possible values are\n"
 "    Z_DEFAULT_STRATEGY, Z_RLE, Z_HUFFMAN_ONLY, Z_FILTERED, and\n"
 "    Z_FIXED.\n"
 "  zdict\n"
@@ -289,19 +292,23 @@ PyDoc_STRVAR(zlib_Compress_flush__doc__,
 "    can still be compressed.");
 
 #define ZLIB_COMPRESS_FLUSH_METHODDEF    \
-    {"flush", (PyCFunction)zlib_Compress_flush, METH_VARARGS, zlib_Compress_flush__doc__},
+    {"flush", (PyCFunction)zlib_Compress_flush, METH_FASTCALL, zlib_Compress_flush__doc__},
 
 static PyObject *
 zlib_Compress_flush_impl(compobject *self, int mode);
 
 static PyObject *
-zlib_Compress_flush(compobject *self, PyObject *args)
+zlib_Compress_flush(compobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int mode = Z_FINISH;
 
-    if (!PyArg_ParseTuple(args, "|i:flush",
+    if (!_PyArg_ParseStack(args, nargs, "|i:flush",
         &mode)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("flush", kwnames)) {
         goto exit;
     }
     return_value = zlib_Compress_flush_impl(self, mode);
@@ -364,19 +371,23 @@ PyDoc_STRVAR(zlib_Decompress_flush__doc__,
 "    the initial size of the output buffer.");
 
 #define ZLIB_DECOMPRESS_FLUSH_METHODDEF    \
-    {"flush", (PyCFunction)zlib_Decompress_flush, METH_VARARGS, zlib_Decompress_flush__doc__},
+    {"flush", (PyCFunction)zlib_Decompress_flush, METH_FASTCALL, zlib_Decompress_flush__doc__},
 
 static PyObject *
 zlib_Decompress_flush_impl(compobject *self, Py_ssize_t length);
 
 static PyObject *
-zlib_Decompress_flush(compobject *self, PyObject *args)
+zlib_Decompress_flush(compobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_ssize_t length = DEF_BUF_SIZE;
 
-    if (!PyArg_ParseTuple(args, "|O&:flush",
+    if (!_PyArg_ParseStack(args, nargs, "|O&:flush",
         ssize_t_converter, &length)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("flush", kwnames)) {
         goto exit;
     }
     return_value = zlib_Decompress_flush_impl(self, length);
@@ -397,20 +408,24 @@ PyDoc_STRVAR(zlib_adler32__doc__,
 "The returned checksum is an integer.");
 
 #define ZLIB_ADLER32_METHODDEF    \
-    {"adler32", (PyCFunction)zlib_adler32, METH_VARARGS, zlib_adler32__doc__},
+    {"adler32", (PyCFunction)zlib_adler32, METH_FASTCALL, zlib_adler32__doc__},
 
 static PyObject *
 zlib_adler32_impl(PyObject *module, Py_buffer *data, unsigned int value);
 
 static PyObject *
-zlib_adler32(PyObject *module, PyObject *args)
+zlib_adler32(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     unsigned int value = 1;
 
-    if (!PyArg_ParseTuple(args, "y*|I:adler32",
+    if (!_PyArg_ParseStack(args, nargs, "y*|I:adler32",
         &data, &value)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("adler32", kwnames)) {
         goto exit;
     }
     return_value = zlib_adler32_impl(module, &data, value);
@@ -436,20 +451,24 @@ PyDoc_STRVAR(zlib_crc32__doc__,
 "The returned checksum is an integer.");
 
 #define ZLIB_CRC32_METHODDEF    \
-    {"crc32", (PyCFunction)zlib_crc32, METH_VARARGS, zlib_crc32__doc__},
+    {"crc32", (PyCFunction)zlib_crc32, METH_FASTCALL, zlib_crc32__doc__},
 
 static PyObject *
 zlib_crc32_impl(PyObject *module, Py_buffer *data, unsigned int value);
 
 static PyObject *
-zlib_crc32(PyObject *module, PyObject *args)
+zlib_crc32(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     unsigned int value = 0;
 
-    if (!PyArg_ParseTuple(args, "y*|I:crc32",
+    if (!_PyArg_ParseStack(args, nargs, "y*|I:crc32",
         &data, &value)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("crc32", kwnames)) {
         goto exit;
     }
     return_value = zlib_crc32_impl(module, &data, value);
@@ -466,8 +485,4 @@ exit:
 #ifndef ZLIB_COMPRESS_COPY_METHODDEF
     #define ZLIB_COMPRESS_COPY_METHODDEF
 #endif /* !defined(ZLIB_COMPRESS_COPY_METHODDEF) */
-
-#ifndef ZLIB_DECOMPRESS_COPY_METHODDEF
-    #define ZLIB_DECOMPRESS_COPY_METHODDEF
-#endif /* !defined(ZLIB_DECOMPRESS_COPY_METHODDEF) */
-/*[clinic end generated code: output=497dad1132c962e2 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c6cb10ed66f226b2 input=a9049054013a1b77]*/

--- a/third_party/python/Modules/clinic/zlibmodule.inc
+++ b/third_party/python/Modules/clinic/zlibmodule.inc
@@ -26,7 +26,7 @@ zlib_compress(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     Py_buffer data = {NULL, NULL};
     int level = Z_DEFAULT_COMPRESSION;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &data, &level)) {
         goto exit;
     }
@@ -71,7 +71,7 @@ zlib_decompress(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *k
     int wbits = MAX_WBITS;
     Py_ssize_t bufsize = DEF_BUF_SIZE;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &data, &wbits, ssize_t_converter, &bufsize)) {
         goto exit;
     }
@@ -137,7 +137,7 @@ zlib_compressobj(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     int strategy = Z_DEFAULT_STRATEGY;
     Py_buffer zdict = {NULL, NULL};
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &level, &method, &wbits, &memLevel, &strategy, &zdict)) {
         goto exit;
     }
@@ -179,7 +179,7 @@ zlib_decompressobj(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
     int wbits = MAX_WBITS;
     PyObject *zdict = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &wbits, &zdict)) {
         goto exit;
     }
@@ -261,7 +261,7 @@ zlib_Decompress_decompress(compobject *self, PyObject **args, Py_ssize_t nargs, 
     Py_buffer data = {NULL, NULL};
     Py_ssize_t max_length = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &data, ssize_t_converter, &max_length)) {
         goto exit;
     }

--- a/third_party/python/Modules/socketmodule.c
+++ b/third_party/python/Modules/socketmodule.c
@@ -3867,11 +3867,15 @@ sock_sendto(PySocketSockObject *s, PyObject *args)
     arglen = PyTuple_Size(args);
     switch (arglen) {
         case 2:
-            PyArg_ParseTuple(args, "y*O:sendto", &pbuf, &addro);
+            if (!PyArg_ParseTuple(args, "y*O:sendto", &pbuf, &addro)) {
+                return NULL;
+            }
             break;
         case 3:
-            PyArg_ParseTuple(args, "y*iO:sendto",
-                             &pbuf, &flags, &addro);
+            if (!PyArg_ParseTuple(args, "y*iO:sendto",
+                                  &pbuf, &flags, &addro)) {
+                return NULL;
+            }
             break;
         default:
             PyErr_Format(PyExc_TypeError,
@@ -3879,8 +3883,6 @@ sock_sendto(PySocketSockObject *s, PyObject *args)
                          arglen);
             return NULL;
     }
-    if (PyErr_Occurred())
-        return NULL;
 
     if (!IS_SELECTABLE(s)) {
         PyBuffer_Release(&pbuf);

--- a/third_party/python/Modules/zlibmodule.c
+++ b/third_party/python/Modules/zlibmodule.c
@@ -503,7 +503,7 @@ Return a compressor object.
 static PyObject *
 zlib_compressobj_impl(PyObject *module, int level, int method, int wbits,
                       int memLevel, int strategy, Py_buffer *zdict)
-/*[clinic end generated code: output=8b5bed9c8fc3814d input=2fa3d026f90ab8d5]*/
+/*[clinic end generated code: output=8b5bed9c8fc3814d input=b5a08c304c3bae52]*/
 {
     compobject *self = NULL;
     int err;

--- a/third_party/python/Objects/abstract.c
+++ b/third_party/python/Objects/abstract.c
@@ -2508,7 +2508,7 @@ _PyObject_FastCallKeywords(PyObject *callable, PyObject **stack, Py_ssize_t narg
 
     /* kwnames must only contains str strings, no subclass, and all keys must
        be unique: these checks are implemented in Python/ceval.c and
-       _PyArg_ParseStack(). */
+       _PyArg_ParseStackAndKeywords(). */
 
     if (PyFunction_Check(callable)) {
         return _PyFunction_FastCallKeywords(callable, stack, nargs, kwnames);

--- a/third_party/python/Objects/abstract.c
+++ b/third_party/python/Objects/abstract.c
@@ -2255,7 +2255,7 @@ PyObject_Call(PyObject *callable, PyObject *args, PyObject *kwargs)
     PyObject *result;
 
     /* PyObject_Call() must not be called with an exception set,
-       because it may clear it (directly or indirectly) and so the
+       because it can clear it (directly or indirectly) and so the
        caller loses its exception */
     assert(!PyErr_Occurred());
     assert(PyTuple_Check(args));
@@ -2332,7 +2332,7 @@ _PyObject_FastCallDict(PyObject *callable, PyObject **args, Py_ssize_t nargs,
     PyObject *result = NULL;
 
     /* _PyObject_FastCallDict() must not be called with an exception set,
-       because it may clear it (directly or indirectly) and so the
+       because it can clear it (directly or indirectly) and so the
        caller loses its exception */
     assert(!PyErr_Occurred());
 
@@ -2505,6 +2505,11 @@ PyObject *
 _PyObject_FastCallKeywords(PyObject *callable, PyObject **stack, Py_ssize_t nargs,
                            PyObject *kwnames)
 {
+    /* _PyObject_FastCallKeywords() must not be called with an exception set,
+       because it can clear it (directly or indirectly) and so the
+       caller loses its exception */
+    assert(!PyErr_Occurred());
+
     assert(nargs >= 0);
     assert(kwnames == NULL || PyTuple_CheckExact(kwnames));
 
@@ -2561,6 +2566,8 @@ _PyObject_FastCallKeywords(PyObject *callable, PyObject **stack, Py_ssize_t narg
         result = (*call)(callable, argtuple, kwdict);
         Py_DECREF(argtuple);
         Py_XDECREF(kwdict);
+
+        result = _Py_CheckFunctionResult(callable, result, NULL);
 
     exit:
         Py_LeaveRecursiveCall();

--- a/third_party/python/Objects/abstract.c
+++ b/third_party/python/Objects/abstract.c
@@ -2261,21 +2261,32 @@ PyObject_Call(PyObject *callable, PyObject *args, PyObject *kwargs)
     assert(PyTuple_Check(args));
     assert(kwargs == NULL || PyDict_Check(kwargs));
 
-    call = callable->ob_type->tp_call;
-    if (call == NULL) {
-        PyErr_Format(PyExc_TypeError, "'%.200s' object is not callable",
-                     callable->ob_type->tp_name);
-        return NULL;
+    if (PyFunction_Check(callable)) {
+        return _PyFunction_FastCallDict(callable,
+                                        &PyTuple_GET_ITEM(args, 0),
+                                        PyTuple_GET_SIZE(args),
+                                        kwargs);
     }
+    else if (PyCFunction_Check(callable)) {
+        return PyCFunction_Call(callable, args, kwargs);
+    }
+    else {
+        call = callable->ob_type->tp_call;
+        if (call == NULL) {
+            PyErr_Format(PyExc_TypeError, "'%.200s' object is not callable",
+                         callable->ob_type->tp_name);
+            return NULL;
+        }
 
-    if (Py_EnterRecursiveCall(" while calling a Python object"))
-        return NULL;
+        if (Py_EnterRecursiveCall(" while calling a Python object"))
+            return NULL;
 
-    result = (*call)(callable, args, kwargs);
+        result = (*call)(callable, args, kwargs);
 
-    Py_LeaveRecursiveCall();
+        Py_LeaveRecursiveCall();
 
-    return _Py_CheckFunctionResult(callable, result, NULL);
+        return _Py_CheckFunctionResult(callable, result, NULL);
+    }
 }
 
 /* Issue #29234: Inlining _PyStack_AsTuple() into callers increases their
@@ -2328,9 +2339,6 @@ PyObject *
 _PyObject_FastCallDict(PyObject *callable, PyObject **args, Py_ssize_t nargs,
                        PyObject *kwargs)
 {
-    ternaryfunc call;
-    PyObject *result = NULL;
-
     /* _PyObject_FastCallDict() must not be called with an exception set,
        because it can clear it (directly or indirectly) and so the
        caller loses its exception */
@@ -2341,42 +2349,41 @@ _PyObject_FastCallDict(PyObject *callable, PyObject **args, Py_ssize_t nargs,
     assert(nargs == 0 || args != NULL);
     assert(kwargs == NULL || PyDict_Check(kwargs));
 
-    if (Py_EnterRecursiveCall(" while calling a Python object")) {
-        return NULL;
-    }
-
     if (PyFunction_Check(callable)) {
-        result = _PyFunction_FastCallDict(callable, args, nargs, kwargs);
+        return _PyFunction_FastCallDict(callable, args, nargs, kwargs);
     }
     else if (PyCFunction_Check(callable)) {
-        result = _PyCFunction_FastCallDict(callable, args, nargs, kwargs);
+        return _PyCFunction_FastCallDict(callable, args, nargs, kwargs);
     }
     else {
-        PyObject *tuple;
+        PyObject *argstuple, *result;
+        ternaryfunc call;
 
         /* Slow-path: build a temporary tuple */
         call = callable->ob_type->tp_call;
         if (call == NULL) {
             PyErr_Format(PyExc_TypeError, "'%.200s' object is not callable",
                          callable->ob_type->tp_name);
-            goto exit;
+            return NULL;
         }
 
-        tuple = _PyStack_AsTuple(args, nargs);
-        if (tuple == NULL) {
-            goto exit;
+        argstuple = _PyStack_AsTuple(args, nargs);
+        if (argstuple == NULL) {
+            return NULL;
         }
 
-        result = (*call)(callable, tuple, kwargs);
-        Py_DECREF(tuple);
+        if (Py_EnterRecursiveCall(" while calling a Python object")) {
+            return NULL;
+        }
 
+        result = (*call)(callable, argstuple, kwargs);
+
+        Py_LeaveRecursiveCall();
+
+        Py_DECREF(argstuple);
         result = _Py_CheckFunctionResult(callable, result, NULL);
+        return result;
     }
-
-exit:
-    Py_LeaveRecursiveCall();
-
-    return result;
 }
 
 /* Positional arguments are obj followed by args:
@@ -2528,49 +2535,48 @@ _PyObject_FastCallKeywords(PyObject *callable, PyObject **stack, Py_ssize_t narg
            temporary dictionary for keyword arguments (if any) */
 
         ternaryfunc call;
-        PyObject *argtuple;
+        PyObject *argstuple;
         PyObject *kwdict, *result;
         Py_ssize_t nkwargs;
 
-        result = NULL;
         nkwargs = (kwnames == NULL) ? 0 : PyTuple_GET_SIZE(kwnames);
         assert((nargs == 0 && nkwargs == 0) || stack != NULL);
-
-        if (Py_EnterRecursiveCall(" while calling a Python object")) {
-            return NULL;
-        }
 
         call = callable->ob_type->tp_call;
         if (call == NULL) {
             PyErr_Format(PyExc_TypeError, "'%.200s' object is not callable",
                          callable->ob_type->tp_name);
-            goto exit;
+            return NULL;
         }
 
-        argtuple = _PyStack_AsTuple(stack, nargs);
-        if (argtuple == NULL) {
-            goto exit;
+        argstuple = _PyStack_AsTuple(stack, nargs);
+        if (argstuple == NULL) {
+            return NULL;
         }
 
         if (nkwargs > 0) {
             kwdict = _PyStack_AsDict(stack + nargs, kwnames);
             if (kwdict == NULL) {
-                Py_DECREF(argtuple);
-                goto exit;
+                Py_DECREF(argstuple);
+                return NULL;
             }
         }
         else {
             kwdict = NULL;
         }
 
-        result = (*call)(callable, argtuple, kwdict);
-        Py_DECREF(argtuple);
+        if (Py_EnterRecursiveCall(" while calling a Python object")) {
+            return NULL;
+        }
+
+        result = (*call)(callable, argstuple, kwdict);
+
+        Py_LeaveRecursiveCall();
+
+        Py_DECREF(argstuple);
         Py_XDECREF(kwdict);
 
         result = _Py_CheckFunctionResult(callable, result, NULL);
-
-    exit:
-        Py_LeaveRecursiveCall();
         return result;
     }
 }

--- a/third_party/python/Objects/abstract.c
+++ b/third_party/python/Objects/abstract.c
@@ -2444,9 +2444,9 @@ _PyStack_AsDict(PyObject **values, PyObject *kwnames)
     return kwdict;
 }
 
-PyObject **
+int
 _PyStack_UnpackDict(PyObject **args, Py_ssize_t nargs, PyObject *kwargs,
-                    PyObject **p_kwnames, PyObject *func)
+                    PyObject ***p_stack, PyObject **p_kwnames, PyObject *func)
 {
     PyObject **stack, **kwstack;
     Py_ssize_t nkwargs;
@@ -2458,25 +2458,26 @@ _PyStack_UnpackDict(PyObject **args, Py_ssize_t nargs, PyObject *kwargs,
     assert(kwargs == NULL || PyDict_CheckExact(kwargs));
 
     if (kwargs == NULL || (nkwargs = PyDict_GET_SIZE(kwargs)) == 0) {
+        *p_stack = args;
         *p_kwnames = NULL;
-        return args;
+        return 0;
     }
 
     if ((size_t)nargs > PY_SSIZE_T_MAX / sizeof(stack[0]) - (size_t)nkwargs) {
         PyErr_NoMemory();
-        return NULL;
+        return -1;
     }
 
     stack = PyMem_Malloc((nargs + nkwargs) * sizeof(stack[0]));
     if (stack == NULL) {
         PyErr_NoMemory();
-        return NULL;
+        return -1;
     }
 
     kwnames = PyTuple_New(nkwargs);
     if (kwnames == NULL) {
         PyMem_Free(stack);
-        return NULL;
+        return -1;
     }
 
     /* Copy position arguments (borrowed references) */
@@ -2495,8 +2496,9 @@ _PyStack_UnpackDict(PyObject **args, Py_ssize_t nargs, PyObject *kwargs,
         i++;
     }
 
+    *p_stack = stack;
     *p_kwnames = kwnames;
-    return stack;
+    return 0;
 }
 
 PyObject *

--- a/third_party/python/Objects/abstract.c
+++ b/third_party/python/Objects/abstract.c
@@ -2300,6 +2300,30 @@ _PyStack_AsTuple(PyObject **stack, Py_ssize_t nargs)
     return args;
 }
 
+PyObject*
+_PyStack_AsTupleSlice(PyObject **stack, Py_ssize_t nargs,
+                      Py_ssize_t start, Py_ssize_t end)
+{
+    PyObject *args;
+    Py_ssize_t i;
+
+    assert(0 <= start);
+    assert(end <= nargs);
+    assert(start <= end);
+
+    args = PyTuple_New(end - start);
+    if (args == NULL) {
+        return NULL;
+    }
+
+    for (i=start; i < end; i++) {
+        PyObject *item = stack[i];
+        Py_INCREF(item);
+        PyTuple_SET_ITEM(args, i - start, item);
+    }
+    return args;
+}
+
 PyObject *
 _PyObject_FastCallDict(PyObject *callable, PyObject **args, Py_ssize_t nargs,
                        PyObject *kwargs)

--- a/third_party/python/Objects/abstract.c
+++ b/third_party/python/Objects/abstract.c
@@ -2389,10 +2389,44 @@ _PyObject_FastCallDict(PyObject *callable, PyObject **args, Py_ssize_t nargs,
 /* Positional arguments are obj followed by args:
    call callable(obj, *args, **kwargs) */
 PyObject *
+_PyObject_FastCall_Prepend(PyObject *callable,
+                           PyObject *obj, PyObject **args, Py_ssize_t nargs)
+{
+    PyObject *small_stack[_PY_FASTCALL_SMALL_STACK];
+    PyObject **args2;
+    PyObject *result;
+
+    nargs++;
+    if (nargs <= (Py_ssize_t)Py_ARRAY_LENGTH(small_stack)) {
+        args2 = small_stack;
+    }
+    else {
+        args2 = PyMem_Malloc(nargs * sizeof(PyObject *));
+        if (args2 == NULL) {
+            PyErr_NoMemory();
+            return NULL;
+        }
+    }
+
+    /* use borrowed references */
+    args2[0] = obj;
+    memcpy(&args2[1],
+           args,
+           (nargs - 1)* sizeof(PyObject *));
+
+    result = _PyObject_FastCall(callable, args2, nargs);
+    if (args2 != small_stack) {
+        PyMem_Free(args2);
+    }
+    return result;
+}
+
+/* Call callable(obj, *args, **kwargs). */
+PyObject *
 _PyObject_Call_Prepend(PyObject *callable,
                        PyObject *obj, PyObject *args, PyObject *kwargs)
 {
-    PyObject *small_stack[5];
+    PyObject *small_stack[_PY_FASTCALL_SMALL_STACK];
     PyObject **stack;
     Py_ssize_t argcount;
     PyObject *result;
@@ -2600,10 +2634,10 @@ _PyObject_CallFunctionVa(PyObject *callable, const char *format,
     }
 
     if (is_size_t) {
-        stack = _Py_VaBuildStack(small_stack, small_stack_len, format, va, &nargs);
+        stack = _Py_VaBuildStack_SizeT(small_stack, small_stack_len, format, va, &nargs);
     }
     else {
-        stack = _Py_VaBuildStack_SizeT(small_stack, small_stack_len, format, va, &nargs);
+        stack = _Py_VaBuildStack(small_stack, small_stack_len, format, va, &nargs);
     }
     if (stack == NULL) {
         return NULL;

--- a/third_party/python/Objects/abstract.c
+++ b/third_party/python/Objects/abstract.c
@@ -2422,10 +2422,12 @@ _PyObject_Call_Prepend(PyObject *callable,
 PyObject *
 _PyStack_AsDict(PyObject **values, PyObject *kwnames)
 {
-    Py_ssize_t nkwargs = PyTuple_GET_SIZE(kwnames);
+    Py_ssize_t nkwargs;
     PyObject *kwdict;
     Py_ssize_t i;
 
+    assert(kwnames != NULL);
+    nkwargs = PyTuple_GET_SIZE(kwnames);
     kwdict = _PyDict_NewPresized(nkwargs);
     if (kwdict == NULL) {
         return NULL;
@@ -2434,8 +2436,6 @@ _PyStack_AsDict(PyObject **values, PyObject *kwnames)
     for (i = 0; i < nkwargs; i++) {
         PyObject *key = PyTuple_GET_ITEM(kwnames, i);
         PyObject *value = *values++;
-        assert(PyUnicode_CheckExact(key));
-        assert(PyDict_GetItem(kwdict, key) == NULL);
         if (PyDict_SetItem(kwdict, key, value)) {
             Py_DECREF(kwdict);
             return NULL;

--- a/third_party/python/Objects/abstract.c
+++ b/third_party/python/Objects/abstract.c
@@ -2446,7 +2446,7 @@ _PyStack_AsDict(PyObject **values, PyObject *kwnames)
 
 int
 _PyStack_UnpackDict(PyObject **args, Py_ssize_t nargs, PyObject *kwargs,
-                    PyObject ***p_stack, PyObject **p_kwnames, PyObject *func)
+                    PyObject ***p_stack, PyObject **p_kwnames)
 {
     PyObject **stack, **kwstack;
     Py_ssize_t nkwargs;

--- a/third_party/python/Objects/clinic/bytearrayobject.inc
+++ b/third_party/python/Objects/clinic/bytearrayobject.inc
@@ -223,10 +223,10 @@ PyDoc_STRVAR(bytearray_partition__doc__,
 "\n"
 "This will search for the separator sep in the bytearray. If the separator is\n"
 "found, returns a 3-tuple containing the part before the separator, the\n"
-"separator itself, and the part after it.\n"
+"separator itself, and the part after it as new bytearray objects.\n"
 "\n"
-"If the separator is not found, returns a 3-tuple containing the original\n"
-"bytearray object and two empty bytearray objects.");
+"If the separator is not found, returns a 3-tuple containing the copy of the\n"
+"original bytearray object and two empty bytearray objects.");
 
 #define BYTEARRAY_PARTITION_METHODDEF    \
     {"partition", (PyCFunction)bytearray_partition, METH_O, bytearray_partition__doc__},
@@ -235,14 +235,15 @@ PyDoc_STRVAR(bytearray_rpartition__doc__,
 "rpartition($self, sep, /)\n"
 "--\n"
 "\n"
-"Partition the bytes into three parts using the given separator.\n"
+"Partition the bytearray into three parts using the given separator.\n"
 "\n"
-"This will search for the separator sep in the bytearray, starting and the end.\n"
+"This will search for the separator sep in the bytearray, starting at the end.\n"
 "If the separator is found, returns a 3-tuple containing the part before the\n"
-"separator, the separator itself, and the part after it.\n"
+"separator, the separator itself, and the part after it as new bytearray\n"
+"objects.\n"
 "\n"
 "If the separator is not found, returns a 3-tuple containing two empty bytearray\n"
-"objects and the original bytearray object.");
+"objects and the copy of the original bytearray object.");
 
 #define BYTEARRAY_RPARTITION_METHODDEF    \
     {"rpartition", (PyCFunction)bytearray_rpartition, METH_O, bytearray_rpartition__doc__},
@@ -464,20 +465,24 @@ PyDoc_STRVAR(bytearray_strip__doc__,
 "If the argument is omitted or None, strip leading and trailing ASCII whitespace.");
 
 #define BYTEARRAY_STRIP_METHODDEF    \
-    {"strip", (PyCFunction)bytearray_strip, METH_VARARGS, bytearray_strip__doc__},
+    {"strip", (PyCFunction)bytearray_strip, METH_FASTCALL, bytearray_strip__doc__},
 
 static PyObject *
 bytearray_strip_impl(PyByteArrayObject *self, PyObject *bytes);
 
 static PyObject *
-bytearray_strip(PyByteArrayObject *self, PyObject *args)
+bytearray_strip(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "strip",
+    if (!_PyArg_UnpackStack(args, nargs, "strip",
         0, 1,
         &bytes)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("strip", kwnames)) {
         goto exit;
     }
     return_value = bytearray_strip_impl(self, bytes);
@@ -495,20 +500,24 @@ PyDoc_STRVAR(bytearray_lstrip__doc__,
 "If the argument is omitted or None, strip leading ASCII whitespace.");
 
 #define BYTEARRAY_LSTRIP_METHODDEF    \
-    {"lstrip", (PyCFunction)bytearray_lstrip, METH_VARARGS, bytearray_lstrip__doc__},
+    {"lstrip", (PyCFunction)bytearray_lstrip, METH_FASTCALL, bytearray_lstrip__doc__},
 
 static PyObject *
 bytearray_lstrip_impl(PyByteArrayObject *self, PyObject *bytes);
 
 static PyObject *
-bytearray_lstrip(PyByteArrayObject *self, PyObject *args)
+bytearray_lstrip(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "lstrip",
+    if (!_PyArg_UnpackStack(args, nargs, "lstrip",
         0, 1,
         &bytes)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("lstrip", kwnames)) {
         goto exit;
     }
     return_value = bytearray_lstrip_impl(self, bytes);
@@ -526,20 +535,24 @@ PyDoc_STRVAR(bytearray_rstrip__doc__,
 "If the argument is omitted or None, strip trailing ASCII whitespace.");
 
 #define BYTEARRAY_RSTRIP_METHODDEF    \
-    {"rstrip", (PyCFunction)bytearray_rstrip, METH_VARARGS, bytearray_rstrip__doc__},
+    {"rstrip", (PyCFunction)bytearray_rstrip, METH_FASTCALL, bytearray_rstrip__doc__},
 
 static PyObject *
 bytearray_rstrip_impl(PyByteArrayObject *self, PyObject *bytes);
 
 static PyObject *
-bytearray_rstrip(PyByteArrayObject *self, PyObject *args)
+bytearray_rstrip(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "rstrip",
+    if (!_PyArg_UnpackStack(args, nargs, "rstrip",
         0, 1,
         &bytes)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("rstrip", kwnames)) {
         goto exit;
     }
     return_value = bytearray_rstrip_impl(self, bytes);
@@ -732,4 +745,4 @@ bytearray_sizeof(PyByteArrayObject *self, PyObject *Py_UNUSED(ignored))
 {
     return bytearray_sizeof_impl(self);
 }
-/*[clinic end generated code: output=e6c057d1cd7c2496 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c1b1b83b0e19df74 input=a9049054013a1b77]*/

--- a/third_party/python/Objects/clinic/bytearrayobject.inc
+++ b/third_party/python/Objects/clinic/bytearrayobject.inc
@@ -74,7 +74,7 @@ bytearray_translate(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, 
     PyObject *table;
     PyObject *deletechars = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &table, &deletechars)) {
         goto exit;
     }
@@ -204,7 +204,7 @@ bytearray_split(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyOb
     PyObject *sep = Py_None;
     Py_ssize_t maxsplit = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &sep, &maxsplit)) {
         goto exit;
     }
@@ -279,7 +279,7 @@ bytearray_rsplit(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyO
     PyObject *sep = Py_None;
     Py_ssize_t maxsplit = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &sep, &maxsplit)) {
         goto exit;
     }
@@ -571,7 +571,7 @@ bytearray_decode(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyO
     const char *encoding = NULL;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &encoding, &errors)) {
         goto exit;
     }
@@ -617,7 +617,7 @@ bytearray_splitlines(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs,
     static _PyArg_Parser _parser = {"|i:splitlines", _keywords, 0};
     int keepends = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &keepends)) {
         goto exit;
     }

--- a/third_party/python/Objects/clinic/bytearrayobject.inc
+++ b/third_party/python/Objects/clinic/bytearrayobject.inc
@@ -1,11 +1,4 @@
-/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:4;tab-width:8;coding:utf-8 -*-│
-│vi: set net ft=c ts=4 sts=4 sw=4 fenc=utf-8                                :vi│
-╞══════════════════════════════════════════════════════════════════════════════╡
-│ Python 3                                                                     │
-│ https://docs.python.org/3/license.html                                       │
-╚─────────────────────────────────────────────────────────────────────────────*/
 /* clang-format off */
-
 /*[clinic input]
 preserve
 [clinic start generated code]*/
@@ -96,20 +89,24 @@ PyDoc_STRVAR(bytearray_maketrans__doc__,
 "The bytes objects frm and to must be of the same length.");
 
 #define BYTEARRAY_MAKETRANS_METHODDEF    \
-    {"maketrans", (PyCFunction)bytearray_maketrans, METH_VARARGS|METH_STATIC, bytearray_maketrans__doc__},
+    {"maketrans", (PyCFunction)bytearray_maketrans, METH_FASTCALL|METH_STATIC, bytearray_maketrans__doc__},
 
 static PyObject *
 bytearray_maketrans_impl(Py_buffer *frm, Py_buffer *to);
 
 static PyObject *
-bytearray_maketrans(void *null, PyObject *args)
+bytearray_maketrans(void *null, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer frm = {NULL, NULL};
     Py_buffer to = {NULL, NULL};
 
-    if (!PyArg_ParseTuple(args, "y*y*:maketrans",
+    if (!_PyArg_ParseStack(args, nargs, "y*y*:maketrans",
         &frm, &to)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("maketrans", kwnames)) {
         goto exit;
     }
     return_value = bytearray_maketrans_impl(&frm, &to);
@@ -141,22 +138,26 @@ PyDoc_STRVAR(bytearray_replace__doc__,
 "replaced.");
 
 #define BYTEARRAY_REPLACE_METHODDEF    \
-    {"replace", (PyCFunction)bytearray_replace, METH_VARARGS, bytearray_replace__doc__},
+    {"replace", (PyCFunction)bytearray_replace, METH_FASTCALL, bytearray_replace__doc__},
 
 static PyObject *
 bytearray_replace_impl(PyByteArrayObject *self, Py_buffer *old,
                        Py_buffer *new, Py_ssize_t count);
 
 static PyObject *
-bytearray_replace(PyByteArrayObject *self, PyObject *args)
+bytearray_replace(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer old = {NULL, NULL};
     Py_buffer new = {NULL, NULL};
     Py_ssize_t count = -1;
 
-    if (!PyArg_ParseTuple(args, "y*y*|n:replace",
+    if (!_PyArg_ParseStack(args, nargs, "y*y*|n:replace",
         &old, &new, &count)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("replace", kwnames)) {
         goto exit;
     }
     return_value = bytearray_replace_impl(self, &old, &new, count);
@@ -222,10 +223,10 @@ PyDoc_STRVAR(bytearray_partition__doc__,
 "\n"
 "This will search for the separator sep in the bytearray. If the separator is\n"
 "found, returns a 3-tuple containing the part before the separator, the\n"
-"separator itself, and the part after it as new bytearray objects.\n"
+"separator itself, and the part after it.\n"
 "\n"
-"If the separator is not found, returns a 3-tuple containing the copy of the\n"
-"original bytearray object and two empty bytearray objects.");
+"If the separator is not found, returns a 3-tuple containing the original\n"
+"bytearray object and two empty bytearray objects.");
 
 #define BYTEARRAY_PARTITION_METHODDEF    \
     {"partition", (PyCFunction)bytearray_partition, METH_O, bytearray_partition__doc__},
@@ -234,15 +235,14 @@ PyDoc_STRVAR(bytearray_rpartition__doc__,
 "rpartition($self, sep, /)\n"
 "--\n"
 "\n"
-"Partition the bytearray into three parts using the given separator.\n"
+"Partition the bytes into three parts using the given separator.\n"
 "\n"
-"This will search for the separator sep in the bytearray, starting at the end.\n"
+"This will search for the separator sep in the bytearray, starting and the end.\n"
 "If the separator is found, returns a 3-tuple containing the part before the\n"
-"separator, the separator itself, and the part after it as new bytearray\n"
-"objects.\n"
+"separator, the separator itself, and the part after it.\n"
 "\n"
 "If the separator is not found, returns a 3-tuple containing two empty bytearray\n"
-"objects and the copy of the original bytearray object.");
+"objects and the original bytearray object.");
 
 #define BYTEARRAY_RPARTITION_METHODDEF    \
     {"rpartition", (PyCFunction)bytearray_rpartition, METH_O, bytearray_rpartition__doc__},
@@ -319,20 +319,24 @@ PyDoc_STRVAR(bytearray_insert__doc__,
 "    The item to be inserted.");
 
 #define BYTEARRAY_INSERT_METHODDEF    \
-    {"insert", (PyCFunction)bytearray_insert, METH_VARARGS, bytearray_insert__doc__},
+    {"insert", (PyCFunction)bytearray_insert, METH_FASTCALL, bytearray_insert__doc__},
 
 static PyObject *
 bytearray_insert_impl(PyByteArrayObject *self, Py_ssize_t index, int item);
 
 static PyObject *
-bytearray_insert(PyByteArrayObject *self, PyObject *args)
+bytearray_insert(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_ssize_t index;
     int item;
 
-    if (!PyArg_ParseTuple(args, "nO&:insert",
+    if (!_PyArg_ParseStack(args, nargs, "nO&:insert",
         &index, _getbytevalue, &item)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("insert", kwnames)) {
         goto exit;
     }
     return_value = bytearray_insert_impl(self, index, item);
@@ -396,19 +400,23 @@ PyDoc_STRVAR(bytearray_pop__doc__,
 "If no index argument is given, will pop the last item.");
 
 #define BYTEARRAY_POP_METHODDEF    \
-    {"pop", (PyCFunction)bytearray_pop, METH_VARARGS, bytearray_pop__doc__},
+    {"pop", (PyCFunction)bytearray_pop, METH_FASTCALL, bytearray_pop__doc__},
 
 static PyObject *
 bytearray_pop_impl(PyByteArrayObject *self, Py_ssize_t index);
 
 static PyObject *
-bytearray_pop(PyByteArrayObject *self, PyObject *args)
+bytearray_pop(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_ssize_t index = -1;
 
-    if (!PyArg_ParseTuple(args, "|n:pop",
+    if (!_PyArg_ParseStack(args, nargs, "|n:pop",
         &index)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("pop", kwnames)) {
         goto exit;
     }
     return_value = bytearray_pop_impl(self, index);
@@ -682,19 +690,23 @@ PyDoc_STRVAR(bytearray_reduce_ex__doc__,
 "Return state information for pickling.");
 
 #define BYTEARRAY_REDUCE_EX_METHODDEF    \
-    {"__reduce_ex__", (PyCFunction)bytearray_reduce_ex, METH_VARARGS, bytearray_reduce_ex__doc__},
+    {"__reduce_ex__", (PyCFunction)bytearray_reduce_ex, METH_FASTCALL, bytearray_reduce_ex__doc__},
 
 static PyObject *
 bytearray_reduce_ex_impl(PyByteArrayObject *self, int proto);
 
 static PyObject *
-bytearray_reduce_ex(PyByteArrayObject *self, PyObject *args)
+bytearray_reduce_ex(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     int proto = 0;
 
-    if (!PyArg_ParseTuple(args, "|i:__reduce_ex__",
+    if (!_PyArg_ParseStack(args, nargs, "|i:__reduce_ex__",
         &proto)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("__reduce_ex__", kwnames)) {
         goto exit;
     }
     return_value = bytearray_reduce_ex_impl(self, proto);
@@ -720,4 +732,4 @@ bytearray_sizeof(PyByteArrayObject *self, PyObject *Py_UNUSED(ignored))
 {
     return bytearray_sizeof_impl(self);
 }
-/*[clinic end generated code: output=8f022100f059226c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e6c057d1cd7c2496 input=a9049054013a1b77]*/

--- a/third_party/python/Objects/clinic/bytesobject.inc
+++ b/third_party/python/Objects/clinic/bytesobject.inc
@@ -87,7 +87,7 @@ PyDoc_STRVAR(bytes_rpartition__doc__,
 "\n"
 "Partition the bytes into three parts using the given separator.\n"
 "\n"
-"This will search for the separator sep in the bytes, starting and the end. If\n"
+"This will search for the separator sep in the bytes, starting at the end. If\n"
 "the separator is found, returns a 3-tuple containing the part before the\n"
 "separator, the separator itself, and the part after it.\n"
 "\n"
@@ -185,20 +185,24 @@ PyDoc_STRVAR(bytes_strip__doc__,
 "If the argument is omitted or None, strip leading and trailing ASCII whitespace.");
 
 #define BYTES_STRIP_METHODDEF    \
-    {"strip", (PyCFunction)bytes_strip, METH_VARARGS, bytes_strip__doc__},
+    {"strip", (PyCFunction)bytes_strip, METH_FASTCALL, bytes_strip__doc__},
 
 static PyObject *
 bytes_strip_impl(PyBytesObject *self, PyObject *bytes);
 
 static PyObject *
-bytes_strip(PyBytesObject *self, PyObject *args)
+bytes_strip(PyBytesObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "strip",
+    if (!_PyArg_UnpackStack(args, nargs, "strip",
         0, 1,
         &bytes)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("strip", kwnames)) {
         goto exit;
     }
     return_value = bytes_strip_impl(self, bytes);
@@ -216,20 +220,24 @@ PyDoc_STRVAR(bytes_lstrip__doc__,
 "If the argument is omitted or None, strip leading  ASCII whitespace.");
 
 #define BYTES_LSTRIP_METHODDEF    \
-    {"lstrip", (PyCFunction)bytes_lstrip, METH_VARARGS, bytes_lstrip__doc__},
+    {"lstrip", (PyCFunction)bytes_lstrip, METH_FASTCALL, bytes_lstrip__doc__},
 
 static PyObject *
 bytes_lstrip_impl(PyBytesObject *self, PyObject *bytes);
 
 static PyObject *
-bytes_lstrip(PyBytesObject *self, PyObject *args)
+bytes_lstrip(PyBytesObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "lstrip",
+    if (!_PyArg_UnpackStack(args, nargs, "lstrip",
         0, 1,
         &bytes)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("lstrip", kwnames)) {
         goto exit;
     }
     return_value = bytes_lstrip_impl(self, bytes);
@@ -247,20 +255,24 @@ PyDoc_STRVAR(bytes_rstrip__doc__,
 "If the argument is omitted or None, strip trailing ASCII whitespace.");
 
 #define BYTES_RSTRIP_METHODDEF    \
-    {"rstrip", (PyCFunction)bytes_rstrip, METH_VARARGS, bytes_rstrip__doc__},
+    {"rstrip", (PyCFunction)bytes_rstrip, METH_FASTCALL, bytes_rstrip__doc__},
 
 static PyObject *
 bytes_rstrip_impl(PyBytesObject *self, PyObject *bytes);
 
 static PyObject *
-bytes_rstrip(PyBytesObject *self, PyObject *args)
+bytes_rstrip(PyBytesObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "rstrip",
+    if (!_PyArg_UnpackStack(args, nargs, "rstrip",
         0, 1,
         &bytes)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("rstrip", kwnames)) {
         goto exit;
     }
     return_value = bytes_rstrip_impl(self, bytes);
@@ -508,4 +520,4 @@ bytes_fromhex(PyTypeObject *type, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=2b8d3cff7e11045e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=debf785947e0eec2 input=a9049054013a1b77]*/

--- a/third_party/python/Objects/clinic/bytesobject.inc
+++ b/third_party/python/Objects/clinic/bytesobject.inc
@@ -39,7 +39,7 @@ bytes_split(PyBytesObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kw
     PyObject *sep = Py_None;
     Py_ssize_t maxsplit = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &sep, &maxsplit)) {
         goto exit;
     }
@@ -158,7 +158,7 @@ bytes_rsplit(PyBytesObject *self, PyObject **args, Py_ssize_t nargs, PyObject *k
     PyObject *sep = Py_None;
     Py_ssize_t maxsplit = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &sep, &maxsplit)) {
         goto exit;
     }
@@ -304,7 +304,7 @@ bytes_translate(PyBytesObject *self, PyObject **args, Py_ssize_t nargs, PyObject
     PyObject *table;
     PyObject *deletechars = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &table, &deletechars)) {
         goto exit;
     }
@@ -435,7 +435,7 @@ bytes_decode(PyBytesObject *self, PyObject **args, Py_ssize_t nargs, PyObject *k
     const char *encoding = NULL;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &encoding, &errors)) {
         goto exit;
     }
@@ -468,7 +468,7 @@ bytes_splitlines(PyBytesObject *self, PyObject **args, Py_ssize_t nargs, PyObjec
     static _PyArg_Parser _parser = {"|i:splitlines", _keywords, 0};
     int keepends = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &keepends)) {
         goto exit;
     }

--- a/third_party/python/Objects/clinic/bytesobject.inc
+++ b/third_party/python/Objects/clinic/bytesobject.inc
@@ -1,11 +1,4 @@
-/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:4;tab-width:8;coding:utf-8 -*-│
-│vi: set net ft=c ts=4 sts=4 sw=4 fenc=utf-8                                :vi│
-╞══════════════════════════════════════════════════════════════════════════════╡
-│ Python 3                                                                     │
-│ https://docs.python.org/3/license.html                                       │
-╚─────────────────────────────────────────────────────────────────────────────*/
 /* clang-format off */
-
 /*[clinic input]
 preserve
 [clinic start generated code]*/
@@ -94,7 +87,7 @@ PyDoc_STRVAR(bytes_rpartition__doc__,
 "\n"
 "Partition the bytes into three parts using the given separator.\n"
 "\n"
-"This will search for the separator sep in the bytes, starting at the end. If\n"
+"This will search for the separator sep in the bytes, starting and the end. If\n"
 "the separator is found, returns a 3-tuple containing the part before the\n"
 "separator, the separator itself, and the part after it.\n"
 "\n"
@@ -326,20 +319,24 @@ PyDoc_STRVAR(bytes_maketrans__doc__,
 "The bytes objects frm and to must be of the same length.");
 
 #define BYTES_MAKETRANS_METHODDEF    \
-    {"maketrans", (PyCFunction)bytes_maketrans, METH_VARARGS|METH_STATIC, bytes_maketrans__doc__},
+    {"maketrans", (PyCFunction)bytes_maketrans, METH_FASTCALL|METH_STATIC, bytes_maketrans__doc__},
 
 static PyObject *
 bytes_maketrans_impl(Py_buffer *frm, Py_buffer *to);
 
 static PyObject *
-bytes_maketrans(void *null, PyObject *args)
+bytes_maketrans(void *null, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer frm = {NULL, NULL};
     Py_buffer to = {NULL, NULL};
 
-    if (!PyArg_ParseTuple(args, "y*y*:maketrans",
+    if (!_PyArg_ParseStack(args, nargs, "y*y*:maketrans",
         &frm, &to)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("maketrans", kwnames)) {
         goto exit;
     }
     return_value = bytes_maketrans_impl(&frm, &to);
@@ -371,22 +368,26 @@ PyDoc_STRVAR(bytes_replace__doc__,
 "replaced.");
 
 #define BYTES_REPLACE_METHODDEF    \
-    {"replace", (PyCFunction)bytes_replace, METH_VARARGS, bytes_replace__doc__},
+    {"replace", (PyCFunction)bytes_replace, METH_FASTCALL, bytes_replace__doc__},
 
 static PyObject *
 bytes_replace_impl(PyBytesObject *self, Py_buffer *old, Py_buffer *new,
                    Py_ssize_t count);
 
 static PyObject *
-bytes_replace(PyBytesObject *self, PyObject *args)
+bytes_replace(PyBytesObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     Py_buffer old = {NULL, NULL};
     Py_buffer new = {NULL, NULL};
     Py_ssize_t count = -1;
 
-    if (!PyArg_ParseTuple(args, "y*y*|n:replace",
+    if (!_PyArg_ParseStack(args, nargs, "y*y*|n:replace",
         &old, &new, &count)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("replace", kwnames)) {
         goto exit;
     }
     return_value = bytes_replace_impl(self, &old, &new, count);
@@ -507,4 +508,4 @@ bytes_fromhex(PyTypeObject *type, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=4ac7e35150d47467 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2b8d3cff7e11045e input=a9049054013a1b77]*/

--- a/third_party/python/Objects/clinic/dictobject.inc
+++ b/third_party/python/Objects/clinic/dictobject.inc
@@ -10,21 +10,25 @@ PyDoc_STRVAR(dict_fromkeys__doc__,
 "Returns a new dict with keys from iterable and values equal to value.");
 
 #define DICT_FROMKEYS_METHODDEF    \
-    {"fromkeys", (PyCFunction)dict_fromkeys, METH_VARARGS|METH_CLASS, dict_fromkeys__doc__},
+    {"fromkeys", (PyCFunction)dict_fromkeys, METH_FASTCALL|METH_CLASS, dict_fromkeys__doc__},
 
 static PyObject *
 dict_fromkeys_impl(PyTypeObject *type, PyObject *iterable, PyObject *value);
 
 static PyObject *
-dict_fromkeys(PyTypeObject *type, PyObject *args)
+dict_fromkeys(PyTypeObject *type, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *iterable;
     PyObject *value = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "fromkeys",
+    if (!_PyArg_UnpackStack(args, nargs, "fromkeys",
         1, 2,
         &iterable, &value)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("fromkeys", kwnames)) {
         goto exit;
     }
     return_value = dict_fromkeys_impl(type, iterable, value);
@@ -41,4 +45,4 @@ PyDoc_STRVAR(dict___contains____doc__,
 
 #define DICT___CONTAINS___METHODDEF    \
     {"__contains__", (PyCFunction)dict___contains__, METH_O|METH_COEXIST, dict___contains____doc__},
-/*[clinic end generated code: output=926326109e3d9839 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=69f3d767ed44e8ec input=a9049054013a1b77]*/

--- a/third_party/python/Objects/clinic/dictobject.inc
+++ b/third_party/python/Objects/clinic/dictobject.inc
@@ -1,49 +1,44 @@
-/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:4;tab-width:8;coding:utf-8 -*-│
-│vi: set net ft=c ts=4 sts=4 sw=4 fenc=utf-8                                :vi│
-╞══════════════════════════════════════════════════════════════════════════════╡
-│ Python 3                                                                     │
-│ https://docs.python.org/3/license.html                                       │
-╚─────────────────────────────────────────────────────────────────────────────*/
 /* clang-format off */
-
 /*[clinic input]
 preserve
 [clinic start generated code]*/
 
-PyDoc_STRVAR(
-    dict_fromkeys__doc__,
-    "fromkeys($type, iterable, value=None, /)\n"
-    "--\n"
-    "\n"
-    "Returns a new dict with keys from iterable and values equal to value.");
+PyDoc_STRVAR(dict_fromkeys__doc__,
+"fromkeys($type, iterable, value=None, /)\n"
+"--\n"
+"\n"
+"Returns a new dict with keys from iterable and values equal to value.");
 
-#define DICT_FROMKEYS_METHODDEF                                       \
-  {"fromkeys", (PyCFunction)dict_fromkeys, METH_VARARGS | METH_CLASS, \
-   dict_fromkeys__doc__},
+#define DICT_FROMKEYS_METHODDEF    \
+    {"fromkeys", (PyCFunction)dict_fromkeys, METH_VARARGS|METH_CLASS, dict_fromkeys__doc__},
 
-static PyObject *dict_fromkeys_impl(PyTypeObject *type, PyObject *iterable,
-                                    PyObject *value);
+static PyObject *
+dict_fromkeys_impl(PyTypeObject *type, PyObject *iterable, PyObject *value);
 
-static PyObject *dict_fromkeys(PyTypeObject *type, PyObject *args) {
-  PyObject *return_value = NULL;
-  PyObject *iterable;
-  PyObject *value = Py_None;
+static PyObject *
+dict_fromkeys(PyTypeObject *type, PyObject *args)
+{
+    PyObject *return_value = NULL;
+    PyObject *iterable;
+    PyObject *value = Py_None;
 
-  if (!PyArg_UnpackTuple(args, "fromkeys", 1, 2, &iterable, &value)) {
-    goto exit;
-  }
-  return_value = dict_fromkeys_impl(type, iterable, value);
+    if (!PyArg_UnpackTuple(args, "fromkeys",
+        1, 2,
+        &iterable, &value)) {
+        goto exit;
+    }
+    return_value = dict_fromkeys_impl(type, iterable, value);
 
 exit:
-  return return_value;
+    return return_value;
 }
 
-PyDoc_STRVAR(dict___contains____doc__, "__contains__($self, key, /)\n"
-                                       "--\n"
-                                       "\n"
-                                       "True if D has a key k, else False.");
+PyDoc_STRVAR(dict___contains____doc__,
+"__contains__($self, key, /)\n"
+"--\n"
+"\n"
+"True if D has a key k, else False.");
 
-#define DICT___CONTAINS___METHODDEF                                       \
-  {"__contains__", (PyCFunction)dict___contains__, METH_O | METH_COEXIST, \
-   dict___contains____doc__},
+#define DICT___CONTAINS___METHODDEF    \
+    {"__contains__", (PyCFunction)dict___contains__, METH_O|METH_COEXIST, dict___contains____doc__},
 /*[clinic end generated code: output=926326109e3d9839 input=a9049054013a1b77]*/

--- a/third_party/python/Objects/clinic/odictobject.inc
+++ b/third_party/python/Objects/clinic/odictobject.inc
@@ -1,0 +1,136 @@
+/* clang-format off */
+/*[clinic input]
+preserve
+[clinic start generated code]*/
+
+PyDoc_STRVAR(OrderedDict_fromkeys__doc__,
+"fromkeys($type, /, iterable, value=None)\n"
+"--\n"
+"\n"
+"New ordered dictionary with keys from S.\n"
+"\n"
+"If not specified, the value defaults to None.");
+
+#define ORDEREDDICT_FROMKEYS_METHODDEF    \
+    {"fromkeys", (PyCFunction)OrderedDict_fromkeys, METH_FASTCALL|METH_CLASS, OrderedDict_fromkeys__doc__},
+
+static PyObject *
+OrderedDict_fromkeys_impl(PyTypeObject *type, PyObject *seq, PyObject *value);
+
+static PyObject *
+OrderedDict_fromkeys(PyTypeObject *type, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"iterable", "value", NULL};
+    static _PyArg_Parser _parser = {"O|O:fromkeys", _keywords, 0};
+    PyObject *seq;
+    PyObject *value = Py_None;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &seq, &value)) {
+        goto exit;
+    }
+    return_value = OrderedDict_fromkeys_impl(type, seq, value);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(OrderedDict_setdefault__doc__,
+"setdefault($self, /, key, default=None)\n"
+"--\n"
+"\n"
+"od.get(k,d), also set od[k]=d if k not in od.");
+
+#define ORDEREDDICT_SETDEFAULT_METHODDEF    \
+    {"setdefault", (PyCFunction)OrderedDict_setdefault, METH_FASTCALL, OrderedDict_setdefault__doc__},
+
+static PyObject *
+OrderedDict_setdefault_impl(PyODictObject *self, PyObject *key,
+                            PyObject *failobj);
+
+static PyObject *
+OrderedDict_setdefault(PyODictObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"key", "default", NULL};
+    static _PyArg_Parser _parser = {"O|O:setdefault", _keywords, 0};
+    PyObject *key;
+    PyObject *failobj = Py_None;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &key, &failobj)) {
+        goto exit;
+    }
+    return_value = OrderedDict_setdefault_impl(self, key, failobj);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(OrderedDict_popitem__doc__,
+"popitem($self, /, last=True)\n"
+"--\n"
+"\n"
+"Return (k, v) and remove a (key, value) pair.\n"
+"\n"
+"Pairs are returned in LIFO order if last is true or FIFO order if false.");
+
+#define ORDEREDDICT_POPITEM_METHODDEF    \
+    {"popitem", (PyCFunction)OrderedDict_popitem, METH_FASTCALL, OrderedDict_popitem__doc__},
+
+static PyObject *
+OrderedDict_popitem_impl(PyODictObject *self, int last);
+
+static PyObject *
+OrderedDict_popitem(PyODictObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"last", NULL};
+    static _PyArg_Parser _parser = {"|p:popitem", _keywords, 0};
+    int last = 1;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &last)) {
+        goto exit;
+    }
+    return_value = OrderedDict_popitem_impl(self, last);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(OrderedDict_move_to_end__doc__,
+"move_to_end($self, /, key, last=True)\n"
+"--\n"
+"\n"
+"\"Move an existing element to the end (or beginning if last==False).\n"
+"\n"
+"    Raises KeyError if the element does not exist.\n"
+"    When last=True, acts like a fast version of self[key]=self.pop(key).");
+
+#define ORDEREDDICT_MOVE_TO_END_METHODDEF    \
+    {"move_to_end", (PyCFunction)OrderedDict_move_to_end, METH_FASTCALL, OrderedDict_move_to_end__doc__},
+
+static PyObject *
+OrderedDict_move_to_end_impl(PyODictObject *self, PyObject *key, int last);
+
+static PyObject *
+OrderedDict_move_to_end(PyODictObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"key", "last", NULL};
+    static _PyArg_Parser _parser = {"O|p:move_to_end", _keywords, 0};
+    PyObject *key;
+    int last = 1;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &key, &last)) {
+        goto exit;
+    }
+    return_value = OrderedDict_move_to_end_impl(self, key, last);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=f2641e1277045b59 input=a9049054013a1b77]*/

--- a/third_party/python/Objects/clinic/unicodeobject.inc
+++ b/third_party/python/Objects/clinic/unicodeobject.inc
@@ -1,11 +1,4 @@
-/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:4;tab-width:8;coding:utf-8 -*-│
-│vi: set net ft=c ts=4 sts=4 sw=4 fenc=utf-8                                :vi│
-╞══════════════════════════════════════════════════════════════════════════════╡
-│ Python 3                                                                     │
-│ https://docs.python.org/3/license.html                                       │
-╚─────────────────────────────────────────────────────────────────────────────*/
 /* clang-format off */
-
 /*[clinic input]
 preserve
 [clinic start generated code]*/
@@ -25,21 +18,25 @@ PyDoc_STRVAR(unicode_maketrans__doc__,
 "must be a string, whose characters will be mapped to None in the result.");
 
 #define UNICODE_MAKETRANS_METHODDEF    \
-    {"maketrans", (PyCFunction)unicode_maketrans, METH_VARARGS|METH_STATIC, unicode_maketrans__doc__},
+    {"maketrans", (PyCFunction)unicode_maketrans, METH_FASTCALL|METH_STATIC, unicode_maketrans__doc__},
 
 static PyObject *
 unicode_maketrans_impl(PyObject *x, PyObject *y, PyObject *z);
 
 static PyObject *
-unicode_maketrans(void *null, PyObject *args)
+unicode_maketrans(void *null, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *x;
     PyObject *y = NULL;
     PyObject *z = NULL;
 
-    if (!PyArg_ParseTuple(args, "O|UU:maketrans",
+    if (!_PyArg_ParseStack(args, nargs, "O|UU:maketrans",
         &x, &y, &z)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("maketrans", kwnames)) {
         goto exit;
     }
     return_value = unicode_maketrans_impl(x, y, z);
@@ -47,4 +44,4 @@ unicode_maketrans(void *null, PyObject *args)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=4a86dd108d92d104 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=af4804dbf21463b5 input=a9049054013a1b77]*/

--- a/third_party/python/Objects/descrobject.c
+++ b/third_party/python/Objects/descrobject.c
@@ -228,15 +228,15 @@ getset_set(PyGetSetDescrObject *descr, PyObject *obj, PyObject *value)
 }
 
 static PyObject *
-methoddescr_call(PyMethodDescrObject *descr, PyObject *args, PyObject *kwds)
+methoddescr_call(PyMethodDescrObject *descr, PyObject *args, PyObject *kwargs)
 {
-    Py_ssize_t argc;
-    PyObject *self, *func, *result, **stack;
+    Py_ssize_t nargs;
+    PyObject *self, *result;
 
     /* Make sure that the first argument is acceptable as 'self' */
     assert(PyTuple_Check(args));
-    argc = PyTuple_GET_SIZE(args);
-    if (argc < 1) {
+    nargs = PyTuple_GET_SIZE(args);
+    if (nargs < 1) {
         PyErr_Format(PyExc_TypeError,
                      "descriptor '%V' of '%.100s' "
                      "object needs an argument",
@@ -257,12 +257,10 @@ methoddescr_call(PyMethodDescrObject *descr, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
-    func = PyCFunction_NewEx(descr->d_method, self, NULL);
-    if (func == NULL)
-        return NULL;
-    stack = &PyTuple_GET_ITEM(args, 1);
-    result = _PyObject_FastCallDict(func, stack, argc - 1, kwds);
-    Py_DECREF(func);
+    result = _PyMethodDef_RawFastCallDict(descr->d_method, self,
+                                          &PyTuple_GET_ITEM(args, 1), nargs - 1,
+                                          kwargs);
+    result = _Py_CheckFunctionResult((PyObject *)descr, result, NULL);
     return result;
 }
 

--- a/third_party/python/Objects/dictobject.c
+++ b/third_party/python/Objects/dictobject.c
@@ -638,6 +638,51 @@ new_dict_with_shared_keys(PyDictKeysObject *keys)
     return new_dict(keys, values);
 }
 
+static PyObject *
+clone_combined_dict(PyDictObject *orig)
+{
+    assert(PyDict_CheckExact(orig));
+    assert(orig->ma_values == NULL);
+    assert(orig->ma_keys->dk_refcnt == 1);
+
+    Py_ssize_t keys_size = _PyDict_KeysSize(orig->ma_keys);
+    PyDictKeysObject *keys = PyObject_Malloc(keys_size);
+    if (keys == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+
+    memcpy(keys, orig->ma_keys, keys_size);
+
+    /* After copying key/value pairs, we need to incref all
+       keys and values and they are about to be co-owned by a
+       new dict object. */
+    PyDictKeyEntry *ep0 = DK_ENTRIES(keys);
+    Py_ssize_t n = keys->dk_nentries;
+    for (Py_ssize_t i = 0; i < n; i++) {
+        PyDictKeyEntry *entry = &ep0[i];
+        PyObject *value = entry->me_value;
+        if (value != NULL) {
+            Py_INCREF(value);
+            Py_INCREF(entry->me_key);
+        }
+    }
+
+    PyDictObject *new = (PyDictObject *)new_dict(keys, NULL);
+    if (new == NULL) {
+        /* In case of an error, `new_dict()` takes care of
+           cleaning up `keys`. */
+        return NULL;
+    }
+    new->ma_used = orig->ma_used;
+    assert(_PyDict_CheckConsistency(new));
+    if (_PyObject_GC_IS_TRACKED(orig)) {
+        /* Maintain tracking. */
+        _PyObject_GC_TRACK(new);
+    }
+    return (PyObject *)new;
+}
+
 PyObject *
 PyDict_New(void)
 {
@@ -2656,6 +2701,12 @@ PyDict_Copy(PyObject *o)
         return NULL;
     }
     mp = (PyDictObject *)o;
+    if (mp->ma_used == 0) {
+        /* The dict is empty; just return a new dict. */
+        return PyDict_New();
+    }
+
+
     if (_PyDict_HasSplitTable(mp)) {
         PyDictObject *split_copy;
         Py_ssize_t size = USABLE_FRACTION(DK_SIZE(mp->ma_keys));
@@ -2682,6 +2733,27 @@ PyDict_Copy(PyObject *o)
             _PyObject_GC_TRACK(split_copy);
         return (PyObject *)split_copy;
     }
+
+    if (PyDict_CheckExact(mp) && mp->ma_values == NULL &&
+            (mp->ma_used >= (mp->ma_keys->dk_nentries * 2) / 3))
+    {
+        /* Use fast-copy if:
+
+           (1) 'mp' is an instance of a subclassed dict; and
+
+           (2) 'mp' is not a split-dict; and
+
+           (3) if 'mp' is non-compact ('del' operation does not resize dicts),
+               do fast-copy only if it has at most 1/3 non-used keys.
+
+           The last condition (3) is important to guard against a pathalogical
+           case when a large dict is almost emptied with multiple del/pop
+           operations and copied after that.  In cases like this, we defer to
+           PyDict_Merge, which produces a compacted copy.
+        */
+        return clone_combined_dict(mp);
+    }
+
     copy = PyDict_New();
     if (copy == NULL)
         return NULL;

--- a/third_party/python/Objects/dictobject.c
+++ b/third_party/python/Objects/dictobject.c
@@ -2911,7 +2911,7 @@ dict___contains__(PyDictObject *self, PyObject *key)
 }
 
 static PyObject *
-dict_get(PyDictObject *mp, PyObject *args)
+dict_get(PyDictObject *mp, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *key;
     PyObject *failobj = Py_None;
@@ -2920,7 +2920,10 @@ dict_get(PyDictObject *mp, PyObject *args)
     Py_ssize_t ix;
     PyObject **value_addr;
 
-    if (!PyArg_UnpackTuple(args, "get", 1, 2, &key, &failobj))
+    if (!_PyArg_UnpackStack(args, nargs, "get", 1, 2, &key, &failobj))
+        return NULL;
+
+    if (!_PyArg_NoStackKeywords("get", kwnames))
         return NULL;
 
     if (!PyUnicode_CheckExact(key) ||
@@ -3029,14 +3032,17 @@ PyDict_SetDefault(PyObject *d, PyObject *key, PyObject *defaultobj)
 }
 
 static PyObject *
-dict_setdefault(PyDictObject *mp, PyObject *args)
+dict_setdefault(PyDictObject *mp, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *key, *val;
     PyObject *defaultobj = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "setdefault", 1, 2, &key, &defaultobj))
+    if (!_PyArg_UnpackStack(args, nargs, "setdefault", 1, 2, &key, &defaultobj))
         return NULL;
 
+    if(!_PyArg_NoStackKeywords("pop", kwnames))
+        return NULL;
+    
     val = PyDict_SetDefault((PyObject *)mp, key, defaultobj);
     Py_XINCREF(val);
     return val;
@@ -3050,11 +3056,14 @@ dict_clear(PyDictObject *mp)
 }
 
 static PyObject *
-dict_pop(PyDictObject *mp, PyObject *args)
+dict_pop(PyDictObject *mp, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *key, *deflt = NULL;
 
-    if(!PyArg_UnpackTuple(args, "pop", 1, 2, &key, &deflt))
+    if(!_PyArg_UnpackStack(args, nargs, "pop", 1, 2, &key, &deflt))
+        return NULL;
+
+    if(!_PyArg_NoStackKeywords("pop", kwnames))
         return NULL;
 
     return _PyDict_Pop((PyObject*)mp, key, deflt);
@@ -3243,11 +3252,11 @@ static PyMethodDef mapp_methods[] = {
      getitem__doc__},
     {"__sizeof__",      (PyCFunction)dict_sizeof,       METH_NOARGS,
      sizeof__doc__},
-    {"get",         (PyCFunction)dict_get,          METH_VARARGS,
+    {"get",         (PyCFunction)dict_get,          METH_FASTCALL,
      get__doc__},
-    {"setdefault",  (PyCFunction)dict_setdefault,   METH_VARARGS,
+    {"setdefault",  (PyCFunction)dict_setdefault,   METH_FASTCALL,
      setdefault_doc__},
-    {"pop",         (PyCFunction)dict_pop,          METH_VARARGS,
+    {"pop",         (PyCFunction)dict_pop,          METH_FASTCALL,
      pop__doc__},
     {"popitem",         (PyCFunction)dict_popitem,      METH_NOARGS,
      popitem__doc__},

--- a/third_party/python/Objects/fileobject.c
+++ b/third_party/python/Objects/fileobject.c
@@ -364,7 +364,7 @@ PyFile_NewStdPrinter(int fd)
 }
 
 static PyObject *
-stdprinter_write(PyStdPrinter_Object *self, PyObject *args)
+stdprinter_write(PyStdPrinter_Object *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *unicode;
     PyObject *bytes = NULL;
@@ -380,7 +380,10 @@ stdprinter_write(PyStdPrinter_Object *self, PyObject *args)
         Py_RETURN_NONE;
     }
 
-    if (!PyArg_ParseTuple(args, "U", &unicode))
+    if (!_PyArg_UnpackStack(args, nargs, "write", 1, 1, &unicode))
+        return NULL;
+
+    if(!_PyArg_NoStackKeywords("write", kwnames))
         return NULL;
 
     /* encode Unicode to UTF-8 */
@@ -452,7 +455,7 @@ static PyMethodDef stdprinter_methods[] = {
     {"flush",           (PyCFunction)stdprinter_noop, METH_NOARGS, ""},
     {"fileno",          (PyCFunction)stdprinter_fileno, METH_NOARGS, ""},
     {"isatty",          (PyCFunction)stdprinter_isatty, METH_NOARGS, ""},
-    {"write",           (PyCFunction)stdprinter_write, METH_VARARGS, ""},
+    {"write",           (PyCFunction)stdprinter_write, METH_FASTCALL, ""},
     {NULL,              NULL}  /*sentinel */
 };
 

--- a/third_party/python/Objects/floatobject.c
+++ b/third_party/python/Objects/floatobject.c
@@ -1038,15 +1038,19 @@ double_round(double x, int ndigits) {
 /* round a Python float v to the closest multiple of 10**-ndigits */
 
 static PyObject *
-float_round(PyObject *v, PyObject *args)
+float_round(PyObject *v, PyObject **args, Py_ssize_t nargs,  PyObject *kwnames)
 {
     double x, rounded;
     PyObject *o_ndigits = NULL;
     Py_ssize_t ndigits;
 
     x = PyFloat_AsDouble(v);
-    if (!PyArg_ParseTuple(args, "|O", &o_ndigits))
+    if (!_PyArg_UnpackStack(args, nargs, "__round__", 0, 1, &o_ndigits))
         return NULL;
+    
+    if(!_PyArg_NoStackKeywords("__round__", kwnames))
+        return NULL;
+
     if (o_ndigits == NULL || o_ndigits == Py_None) {
         /* single-argument round or with None ndigits:
          * round to nearest integer */
@@ -1762,13 +1766,16 @@ float_getzero(PyObject *v, void *closure)
 }
 
 static PyObject *
-float__format__(PyObject *self, PyObject *args)
+float__format__(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *format_spec;
     _PyUnicodeWriter writer;
     int ret;
 
-    if (!PyArg_ParseTuple(args, "U:__format__", &format_spec))
+    if (!_PyArg_ParseStack(args, nargs, "U:__format__", &format_spec))
+        return NULL;
+
+    if(!_PyArg_NoStackKeywords("__format__", kwnames))
         return NULL;
 
     _PyUnicodeWriter_Init(&writer);
@@ -1794,7 +1801,7 @@ static PyMethodDef float_methods[] = {
      "Return self, the complex conjugate of any float."},
     {"__trunc__",       (PyCFunction)float_trunc, METH_NOARGS,
      "Return the Integral closest to x between 0 and x."},
-    {"__round__",       (PyCFunction)float_round, METH_VARARGS,
+    {"__round__",       (PyCFunction)float_round, METH_FASTCALL,
      "Return the Integral closest to x, rounding half toward even.\n"
      "When an argument is passed, work like built-in round(x, ndigits)."},
     {"as_integer_ratio", (PyCFunction)float_as_integer_ratio, METH_NOARGS,
@@ -1819,7 +1826,7 @@ static PyMethodDef float_methods[] = {
     {"__setformat__",           (PyCFunction)float_setformat,
      METH_VARARGS|METH_CLASS,           float_setformat_doc},
     {"__format__",          (PyCFunction)float__format__,
-     METH_VARARGS,                  float__format__doc},
+     METH_FASTCALL,                  float__format__doc},
     {NULL,              NULL}           /* sentinel */
 };
 

--- a/third_party/python/Objects/listobject.c
+++ b/third_party/python/Objects/listobject.c
@@ -755,11 +755,12 @@ list_ass_item(PyListObject *a, Py_ssize_t i, PyObject *v)
 }
 
 static PyObject *
-listinsert(PyListObject *self, PyObject *args)
+listinsert(PyListObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     Py_ssize_t i;
     PyObject *v;
-    if (!PyArg_ParseTuple(args, "nO:insert", &i, &v))
+    if (!_PyArg_ParseStack(args, nargs, "nO:insert", &i, &v)
+            || !_PyArg_NoStackKeywords("insert", kwnames))
         return NULL;
     if (ins1(self, i, v) == 0)
         Py_RETURN_NONE;
@@ -920,13 +921,14 @@ list_inplace_concat(PyListObject *self, PyObject *other)
 }
 
 static PyObject *
-listpop(PyListObject *self, PyObject *args)
+listpop(PyListObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     Py_ssize_t i = -1;
     PyObject *v;
     int status;
 
-    if (!PyArg_ParseTuple(args, "|n:pop", &i))
+    if (!_PyArg_ParseStack(args, nargs, "|n:pop", &i)
+            || !_PyArg_NoStackKeywords("pop", kwnames))
         return NULL;
 
     if (Py_SIZE(self) == 0) {
@@ -2384,9 +2386,9 @@ static PyMethodDef list_methods[] = {
     {"clear",           (PyCFunction)listclear,   METH_NOARGS, clear_doc},
     {"copy",            (PyCFunction)listcopy,   METH_NOARGS, copy_doc},
     {"append",          (PyCFunction)listappend,  METH_O, append_doc},
-    {"insert",          (PyCFunction)listinsert,  METH_VARARGS, insert_doc},
+    {"insert",          (PyCFunction)listinsert,  METH_FASTCALL, insert_doc},
     {"extend",          (PyCFunction)listextend,  METH_O, extend_doc},
-    {"pop",             (PyCFunction)listpop,     METH_VARARGS, pop_doc},
+    {"pop",             (PyCFunction)listpop,     METH_FASTCALL, pop_doc},
     {"remove",          (PyCFunction)listremove,  METH_O, remove_doc},
     {"index",           (PyCFunction)listindex,   METH_VARARGS, index_doc},
     {"count",           (PyCFunction)listcount,   METH_O, count_doc},

--- a/third_party/python/Objects/longobject.c
+++ b/third_party/python/Objects/longobject.c
@@ -4907,13 +4907,13 @@ long_get1(PyLongObject *v, void *context) {
 }
 
 static PyObject *
-long__format__(PyObject *self, PyObject *args)
+long__format__(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *format_spec;
     _PyUnicodeWriter writer;
     int ret;
 
-    if (!PyArg_ParseTuple(args, "U:__format__", &format_spec))
+    if (!_PyArg_ParseStack(args, nargs, "U:__format__", &format_spec))
         return NULL;
 
     _PyUnicodeWriter_Init(&writer);
@@ -5026,7 +5026,7 @@ _PyLong_DivmodNear(PyObject *a, PyObject *b)
 }
 
 static PyObject *
-long_round(PyObject *self, PyObject *args)
+long_round(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *o_ndigits=NULL, *temp, *result, *ndigits;
 
@@ -5044,7 +5044,7 @@ long_round(PyObject *self, PyObject *args)
      *
      *   m - divmod_near(m, 10**n)[1].
      */
-    if (!PyArg_ParseTuple(args, "|O", &o_ndigits))
+    if (!_PyArg_ParseStack(args, nargs, "|O", &o_ndigits))
         return NULL;
     if (o_ndigits == NULL)
         return long_long(self);
@@ -5368,11 +5368,11 @@ static PyMethodDef long_methods[] = {
      "Flooring an Integral returns itself."},
     {"__ceil__",        (PyCFunction)long_long, METH_NOARGS,
      "Ceiling of an Integral returns itself."},
-    {"__round__",       (PyCFunction)long_round, METH_VARARGS,
+    {"__round__",       (PyCFunction)long_round, METH_FASTCALL,
      "Rounding an Integral returns itself.\n"
      "Rounding with an ndigits argument also returns an integer."},
     {"__getnewargs__",          (PyCFunction)long_getnewargs,   METH_NOARGS},
-    {"__format__", (PyCFunction)long__format__, METH_VARARGS},
+    {"__format__", (PyCFunction)long__format__, METH_FASTCALL},
     {"__sizeof__",      (PyCFunction)long_sizeof, METH_NOARGS,
      "Returns size in memory, in bytes"},
     {NULL,              NULL}           /* sentinel */

--- a/third_party/python/Objects/methodobject.c
+++ b/third_party/python/Objects/methodobject.c
@@ -253,8 +253,8 @@ _PyCFunction_FastCallDict(PyObject *func_obj, PyObject **args, Py_ssize_t nargs,
         PyObject *kwnames;
         _PyCFunctionFast fastmeth = (_PyCFunctionFast)meth;
 
-        stack = _PyStack_UnpackDict(args, nargs, kwargs, &kwnames, func_obj);
-        if (stack == NULL) {
+        if (_PyStack_UnpackDict(args, nargs, kwargs,
+                                &stack, &kwnames, func_obj) < 0) {
             return NULL;
         }
 

--- a/third_party/python/Objects/methodobject.c
+++ b/third_party/python/Objects/methodobject.c
@@ -90,13 +90,59 @@ PyCFunction_GetFlags(PyObject *op)
     return PyCFunction_GET_FLAGS(op);
 }
 
+static PyObject *
+cfunction_call_varargs(PyObject *func, PyObject *args, PyObject *kwargs)
+{
+    assert(!PyErr_Occurred());
+
+    PyCFunction meth = PyCFunction_GET_FUNCTION(func);
+    PyObject *self = PyCFunction_GET_SELF(func);
+    PyObject *result;
+
+    if (PyCFunction_GET_FLAGS(func) & METH_KEYWORDS) {
+        if (Py_EnterRecursiveCall(" while calling a Python object")) {
+            return NULL;
+        }
+
+        result = (*(PyCFunctionWithKeywords)meth)(self, args, kwargs);
+
+        Py_LeaveRecursiveCall();
+    }
+    else {
+        if (kwargs != NULL && PyDict_Size(kwargs) != 0) {
+            PyErr_Format(PyExc_TypeError, "%.200s() takes no keyword arguments",
+                         ((PyCFunctionObject*)func)->m_ml->ml_name);
+            return NULL;
+        }
+
+        if (Py_EnterRecursiveCall(" while calling a Python object")) {
+            return NULL;
+        }
+
+        result = (*meth)(self, args);
+
+        Py_LeaveRecursiveCall();
+    }
+
+    return _Py_CheckFunctionResult(func, result, NULL);
+}
+
+
 PyObject *
 PyCFunction_Call(PyObject *func, PyObject *args, PyObject *kwargs)
 {
-    return _PyCFunction_FastCallDict(func,
-                                     &PyTuple_GET_ITEM(args, 0),
-                                     PyTuple_GET_SIZE(args),
-                                     kwargs);
+    /* first try METH_VARARGS to pass directly args tuple unchanged.
+       _PyMethodDef_RawFastCallDict() creates a new temporary tuple
+       for METH_VARARGS. */
+    if (PyCFunction_GET_FLAGS(func) & METH_VARARGS) {
+        return cfunction_call_varargs(func, args, kwargs);
+    }
+    else {
+        return _PyCFunction_FastCallDict(func,
+                                         &PyTuple_GET_ITEM(args, 0),
+                                         PyTuple_GET_SIZE(args),
+                                         kwargs);
+    }
 }
 
 PyObject *

--- a/third_party/python/Objects/methodobject.c
+++ b/third_party/python/Objects/methodobject.c
@@ -165,17 +165,14 @@ PyCFunction_Call(PyObject *func, PyObject *args, PyObject *kwds)
 }
 
 PyObject *
-_PyCFunction_FastCallDict(PyObject *func_obj, PyObject **args, Py_ssize_t nargs,
-                          PyObject *kwargs)
+_PyMethodDef_RawFastCallDict(PyMethodDef *method, PyObject *self, PyObject **args,
+                             Py_ssize_t nargs, PyObject *kwargs)
 {
-    PyCFunctionObject *func;
     PyCFunction meth;
-    PyObject *self;
     PyObject *result;
     int flags;
 
-    assert(func_obj != NULL);
-    assert(PyCFunction_Check(func_obj));
+    assert(method != NULL);
     assert(nargs >= 0);
     assert(nargs == 0 || args != NULL);
     assert(kwargs == NULL || PyDict_Check(kwargs));
@@ -185,10 +182,8 @@ _PyCFunction_FastCallDict(PyObject *func_obj, PyObject **args, Py_ssize_t nargs,
        caller loses its exception */
     assert(!PyErr_Occurred());
 
-    func = (PyCFunctionObject*)func_obj;
-    meth = PyCFunction_GET_FUNCTION(func);
-    self = PyCFunction_GET_SELF(func);
-    flags = PyCFunction_GET_FLAGS(func) & ~(METH_CLASS | METH_STATIC | METH_COEXIST);
+    meth = method->ml_meth;
+    flags = method->ml_flags & ~(METH_CLASS | METH_STATIC | METH_COEXIST);
 
     switch (flags)
     {
@@ -199,7 +194,7 @@ _PyCFunction_FastCallDict(PyObject *func_obj, PyObject **args, Py_ssize_t nargs,
 
         if (kwargs != NULL && PyDict_GET_SIZE(kwargs) != 0) {
             PyErr_Format(PyExc_TypeError, "%.200s() takes no keyword arguments",
-                         func->m_ml->ml_name);
+                         method->ml_name);
             return NULL;
         }
 
@@ -210,7 +205,7 @@ _PyCFunction_FastCallDict(PyObject *func_obj, PyObject **args, Py_ssize_t nargs,
         if (nargs != 1) {
             PyErr_Format(PyExc_TypeError,
                 "%.200s() takes exactly one argument (%zd given)",
-                func->m_ml->ml_name, nargs);
+                method->ml_name, nargs);
             return NULL;
         }
 
@@ -253,8 +248,7 @@ _PyCFunction_FastCallDict(PyObject *func_obj, PyObject **args, Py_ssize_t nargs,
         PyObject *kwnames;
         _PyCFunctionFast fastmeth = (_PyCFunctionFast)meth;
 
-        if (_PyStack_UnpackDict(args, nargs, kwargs,
-                                &stack, &kwnames, func_obj) < 0) {
+        if (_PyStack_UnpackDict(args, nargs, kwargs, &stack, &kwnames) < 0) {
             return NULL;
         }
 
@@ -273,16 +267,32 @@ _PyCFunction_FastCallDict(PyObject *func_obj, PyObject **args, Py_ssize_t nargs,
         return NULL;
     }
 
-    result = _Py_CheckFunctionResult(func_obj, result, NULL);
-
     return result;
 
 no_keyword_error:
     PyErr_Format(PyExc_TypeError,
             "%.200s() takes no arguments (%zd given)",
-            func->m_ml->ml_name, nargs);
+            method->ml_name, nargs);
     return NULL;
 }
+
+PyObject *
+_PyCFunction_FastCallDict(PyObject *func, PyObject **args, Py_ssize_t nargs,
+                          PyObject *kwargs)
+{
+    PyObject *result;
+
+    assert(func != NULL);
+    assert(PyCFunction_Check(func));
+
+    result = _PyMethodDef_RawFastCallDict(((PyCFunctionObject*)func)->m_ml,
+                                          PyCFunction_GET_SELF(func),
+                                          args, nargs, kwargs);
+    result = _Py_CheckFunctionResult(func, result, NULL);
+    return result;
+}
+
+
 
 PyObject *
 _PyCFunction_FastCallKeywords(PyObject *func_obj, PyObject **args,

--- a/third_party/python/Objects/object.c
+++ b/third_party/python/Objects/object.c
@@ -1255,6 +1255,7 @@ _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
     return res;
 }
 
+
 int
 PyObject_GenericSetAttr(PyObject *obj, PyObject *name, PyObject *value)
 {

--- a/third_party/python/Objects/odictobject.c
+++ b/third_party/python/Objects/odictobject.c
@@ -90,7 +90,7 @@ Linked-List API
 As noted, the linked-list implemented here does not have all the bells and
 whistles.  However, we recognize that the implementation may need to
 change to accommodate performance improvements or extra functionality.  To
-that end, we use a simple API to interact with the linked-list.  Here's a
+that end, We use a simple API to interact with the linked-list.  Here's a
 summary of the methods/macros:
 
 Node info:
@@ -123,6 +123,10 @@ Others:
 * _odict_find_node_hash(od, key, hash)
 * _odict_find_node(od, key)
 * _odict_keys_equal(od1, od2)
+
+Used, but specific to the linked-list implementation:
+
+* _odict_free_fast_nodes(od)
 
 And here's a look at how the linked-list relates to the OrderedDict API:
 
@@ -397,6 +401,7 @@ tp_iter           odict_iter
 tp_dictoffset     (offset)
 tp_init           odict_init
 tp_alloc          (repeated)
+tp_new            odict_new
 ================= ================
 
 ================= ================
@@ -462,7 +467,7 @@ Potential Optimizations
   - Set node->key to NULL to indicate the node is not-in-use.
   - Add _odict_EXISTS()?
   - How to maintain consistency across resizes?  Existing node pointers
-    would be invalidated after a resize, which is particularly problematic
+    would be invalidate after a resize, which is particularly problematic
     for the iterators.
 * Use a more stream-lined implementation of update() and, likely indirectly,
   __init__().
@@ -486,6 +491,14 @@ later:
 - support subclasses better (e.g. in odict_richcompare)
 
 */
+
+#include "third_party/python/Objects/clinic/odictobject.inc"
+
+/*[clinic input]
+class OrderedDict "PyODictObject *" "&PyODict_Type"
+[clinic start generated code]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=ca0641cf6143d4af]*/
+
 
 typedef struct _odictnode _ODictNode;
 
@@ -534,15 +547,24 @@ struct _odictnode {
 #define _odict_FOREACH(od, node) \
     for (node = _odict_FIRST(od); node != NULL; node = _odictnode_NEXT(node))
 
+#define _odict_FAST_SIZE(od) ((PyDictObject *)od)->ma_keys->dk_size
+
+static void
+_odict_free_fast_nodes(PyODictObject *od) {
+    if (od->od_fast_nodes) {
+        PyMem_FREE(od->od_fast_nodes);
+    }
+}
+
 /* Return the index into the hash table, regardless of a valid node. */
 static Py_ssize_t
 _odict_get_index_raw(PyODictObject *od, PyObject *key, Py_hash_t hash)
 {
-    PyObject **value_addr = NULL;
+    PyObject **value = NULL;
     PyDictKeysObject *keys = ((PyDictObject *)od)->ma_keys;
     Py_ssize_t ix;
 
-    ix = (keys->dk_lookup)((PyDictObject *)od, key, hash, &value_addr, NULL);
+    ix = (keys->dk_lookup)((PyDictObject *)od, key, hash, &value, NULL);
     if (ix == DKIX_EMPTY) {
         return keys->dk_nentries;  /* index of new entry */
     }
@@ -554,8 +576,7 @@ _odict_get_index_raw(PyODictObject *od, PyObject *key, Py_hash_t hash)
 
 /* Replace od->od_fast_nodes with a new table matching the size of dict's. */
 static int
-_odict_resize(PyODictObject *od)
-{
+_odict_resize(PyODictObject *od) {
     Py_ssize_t size, i;
     _ODictNode **fast_nodes, *node;
 
@@ -581,7 +602,7 @@ _odict_resize(PyODictObject *od)
     }
 
     /* Replace the old fast nodes table. */
-    PyMem_FREE(od->od_fast_nodes);
+    _odict_free_fast_nodes(od);
     od->od_fast_nodes = fast_nodes;
     od->od_fast_nodes_size = size;
     od->od_resize_sentinel = ((PyDictObject *)od)->ma_keys;
@@ -619,7 +640,6 @@ _odict_find_node_hash(PyODictObject *od, PyObject *key, Py_hash_t hash)
     index = _odict_get_index(od, key, hash);
     if (index < 0)
         return NULL;
-    assert(od->od_fast_nodes != NULL);
     return od->od_fast_nodes[index];
 }
 
@@ -637,7 +657,6 @@ _odict_find_node(PyODictObject *od, PyObject *key)
     index = _odict_get_index(od, key, hash);
     if (index < 0)
         return NULL;
-    assert(od->od_fast_nodes != NULL);
     return od->od_fast_nodes[index];
 }
 
@@ -682,8 +701,7 @@ _odict_add_new_node(PyODictObject *od, PyObject *key, Py_hash_t hash)
         Py_DECREF(key);
         return -1;
     }
-    assert(od->od_fast_nodes != NULL);
-    if (od->od_fast_nodes[i] != NULL) {
+    else if (od->od_fast_nodes[i] != NULL) {
         /* We already have a node for the key so there's no need to add one. */
         Py_DECREF(key);
         return 0;
@@ -762,7 +780,6 @@ _odict_clear_node(PyODictObject *od, _ODictNode *node, PyObject *key,
     if (i < 0)
         return PyErr_Occurred() ? -1 : 0;
 
-    assert(od->od_fast_nodes != NULL);
     if (node == NULL)
         node = od->od_fast_nodes[i];
     assert(node == od->od_fast_nodes[i]);
@@ -783,10 +800,8 @@ _odict_clear_nodes(PyODictObject *od)
 {
     _ODictNode *node, *next;
 
-    PyMem_FREE(od->od_fast_nodes);
+    _odict_free_fast_nodes(od);
     od->od_fast_nodes = NULL;
-    od->od_fast_nodes_size = 0;
-    od->od_resize_sentinel = NULL;
 
     node = _odict_FIRST(od);
     _odict_FIRST(od) = NULL;
@@ -885,7 +900,8 @@ odict_eq(PyObject *a, PyObject *b)
 
 PyDoc_STRVAR(odict_init__doc__,
 "Initialize an ordered dictionary.  The signature is the same as\n\
-        regular dictionaries.  Keyword argument order is preserved.\n\
+        regular dictionaries, but keyword arguments are not recommended because\n\
+        their insertion order is arbitrary.\n\
 \n\
         ");
 
@@ -921,25 +937,23 @@ PyDoc_STRVAR(odict_setitem__doc__, "od.__setitem__(i, y) <==> od[i]=y");
 
 /* fromkeys() */
 
-PyDoc_STRVAR(odict_fromkeys__doc__,
-"OD.fromkeys(S[, v]) -> New ordered dictionary with keys from S.\n\
-        If not specified, the value defaults to None.\n\
-\n\
-        ");
+/*[clinic input]
+@classmethod
+OrderedDict.fromkeys
+
+    iterable as seq: object
+    value: object = None
+
+New ordered dictionary with keys from S.
+
+If not specified, the value defaults to None.
+[clinic start generated code]*/
 
 static PyObject *
-odict_fromkeys(PyObject *cls, PyObject *args, PyObject *kwargs)
+OrderedDict_fromkeys_impl(PyTypeObject *type, PyObject *seq, PyObject *value)
+/*[clinic end generated code: output=c10390d452d78d6d input=33eefc496d5eee7b]*/
 {
-    static char *kwlist[] = {"iterable", "value", 0};
-    PyObject *seq;
-    PyObject *value = Py_None;
-
-    /* both borrowed */
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|O:fromkeys", kwlist,
-                                     &seq, &value)) {
-        return NULL;
-    }
-    return _PyDict_FromKeys(cls, seq, value);
+    return _PyDict_FromKeys((PyObject *)type, seq, value);
 }
 
 /* __sizeof__() */
@@ -951,7 +965,7 @@ static PyObject *
 odict_sizeof(PyODictObject *od)
 {
     Py_ssize_t res = _PyDict_SizeOf((PyDictObject *)od);
-    res += sizeof(_ODictNode *) * od->od_fast_nodes_size;  /* od_fast_nodes */
+    res += sizeof(_ODictNode *) * _odict_FAST_SIZE(od);  /* od_fast_nodes */
     if (!_odict_EMPTY(od)) {
         res += sizeof(_ODictNode) * PyODict_SIZE(od);  /* linked-list */
     }
@@ -1009,32 +1023,32 @@ Done:
     return result;
 }
 
-/* setdefault() */
+/* setdefault(): Skips __missing__() calls. */
 
-PyDoc_STRVAR(odict_setdefault__doc__,
-        "od.setdefault(k[,d]) -> od.get(k,d), also set od[k]=d if k not in od");
 
-/* Skips __missing__() calls. */
+/*[clinic input]
+OrderedDict.setdefault
+
+    key: object
+    default as failobj: object = None
+
+od.get(k,d), also set od[k]=d if k not in od.
+[clinic start generated code]*/
+
 static PyObject *
-odict_setdefault(register PyODictObject *od, PyObject *args, PyObject *kwargs)
+OrderedDict_setdefault_impl(PyODictObject *self, PyObject *key,
+                            PyObject *failobj)
+/*[clinic end generated code: output=605d0f6f61ccb0a6 input=4ee5006f32f5691b]*/
 {
-    static char *kwlist[] = {"key", "default", 0};
-    PyObject *key, *result = NULL;
-    PyObject *failobj = Py_None;
+    PyObject *result = NULL;
 
-    /* both borrowed */
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|O:setdefault", kwlist,
-                                     &key, &failobj)) {
-        return NULL;
-    }
-
-    if (PyODict_CheckExact(od)) {
-        result = PyODict_GetItemWithError(od, key);  /* borrowed */
+    if (PyODict_CheckExact(self)) {
+        result = PyODict_GetItemWithError(self, key);  /* borrowed */
         if (result == NULL) {
             if (PyErr_Occurred())
                 return NULL;
-            assert(_odict_find_node(od, key) == NULL);
-            if (PyODict_SetItem((PyObject *)od, key, failobj) >= 0) {
+            assert(_odict_find_node(self, key) == NULL);
+            if (PyODict_SetItem((PyObject *)self, key, failobj) >= 0) {
                 result = failobj;
                 Py_INCREF(failobj);
             }
@@ -1044,14 +1058,14 @@ odict_setdefault(register PyODictObject *od, PyObject *args, PyObject *kwargs)
         }
     }
     else {
-        int exists = PySequence_Contains((PyObject *)od, key);
+        int exists = PySequence_Contains((PyObject *)self, key);
         if (exists < 0) {
             return NULL;
         }
         else if (exists) {
-            result = PyObject_GetItem((PyObject *)od, key);
+            result = PyObject_GetItem((PyObject *)self, key);
         }
-        else if (PyObject_SetItem((PyObject *)od, key, failobj) >= 0) {
+        else if (PyObject_SetItem((PyObject *)self, key, failobj) >= 0) {
             result = failobj;
             Py_INCREF(failobj);
         }
@@ -1161,41 +1175,37 @@ _odict_popkey(PyObject *od, PyObject *key, PyObject *failobj)
     return _odict_popkey_hash(od, key, failobj, hash);
 }
 
+
 /* popitem() */
 
-PyDoc_STRVAR(odict_popitem__doc__,
-"popitem($self, /, last=True)\n"
-"--\n"
-"\n"
-"Remove and return a (key, value) pair from the dictionary.\n"
-"\n"
-"Pairs are returned in LIFO order if last is true or FIFO order if false.");
+/*[clinic input]
+OrderedDict.popitem
+
+    last: bool = True
+
+Return (k, v) and remove a (key, value) pair.
+
+Pairs are returned in LIFO order if last is true or FIFO order if false.
+[clinic start generated code]*/
 
 static PyObject *
-odict_popitem(PyObject *od, PyObject *args, PyObject *kwargs)
+OrderedDict_popitem_impl(PyODictObject *self, int last)
+/*[clinic end generated code: output=98e7d986690d49eb input=4937da2015939126]*/
 {
-    static char *kwlist[] = {"last", 0};
     PyObject *key, *value, *item = NULL;
     _ODictNode *node;
-    int last = 1;
 
     /* pull the item */
 
-    /* borrowed */
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|p:popitem", kwlist,
-                                     &last)) {
-        return NULL;
-    }
-
-    if (_odict_EMPTY(od)) {
+    if (_odict_EMPTY(self)) {
         PyErr_SetString(PyExc_KeyError, "dictionary is empty");
         return NULL;
     }
 
-    node = last ? _odict_LAST(od) : _odict_FIRST(od);
+    node = last ? _odict_LAST(self) : _odict_FIRST(self);
     key = _odictnode_KEY(node);
     Py_INCREF(key);
-    value = _odict_popkey_hash(od, key, NULL, _odictnode_HASH(node));
+    value = _odict_popkey_hash((PyObject *)self, key, NULL, _odictnode_HASH(node));
     if (value == NULL)
         return NULL;
     item = PyTuple_Pack(2, key, value);
@@ -1241,10 +1251,12 @@ PyDoc_STRVAR(odict_clear__doc__,
              "od.clear() -> None.  Remove all items from od.");
 
 static PyObject *
-odict_clear(register PyODictObject *od, PyObject *Py_UNUSED(ignored))
+odict_clear(register PyODictObject *od)
 {
     PyDict_Clear((PyObject *)od);
     _odict_clear_nodes(od);
+    if (_odict_resize(od) < 0)
+        return NULL;
     Py_RETURN_NONE;
 }
 
@@ -1265,7 +1277,7 @@ odict_copy(register PyODictObject *od)
     if (PyODict_CheckExact(od))
         od_copy = PyODict_New();
     else
-        od_copy = PyObject_CallFunctionObjArgs((PyObject *)Py_TYPE(od), NULL);
+        od_copy = _PyObject_CallNoArg((PyObject *)Py_TYPE(od));
     if (od_copy == NULL)
         return NULL;
 
@@ -1321,36 +1333,34 @@ odict_reversed(PyODictObject *od)
     return odictiter_new(od, _odict_ITER_KEYS|_odict_ITER_REVERSED);
 }
 
+
 /* move_to_end() */
 
-PyDoc_STRVAR(odict_move_to_end__doc__,
-"Move an existing element to the end (or beginning if last==False).\n\
-\n\
-        Raises KeyError if the element does not exist.\n\
-        When last=True, acts like a fast version of self[key]=self.pop(key).\n\
-\n\
-        ");
+/*[clinic input]
+OrderedDict.move_to_end
+
+    key: object
+    last: bool = True
+
+"Move an existing element to the end (or beginning if last==False).
+
+    Raises KeyError if the element does not exist.
+    When last=True, acts like a fast version of self[key]=self.pop(key).
+[clinic start generated code]*/
 
 static PyObject *
-odict_move_to_end(PyODictObject *od, PyObject *args, PyObject *kwargs)
+OrderedDict_move_to_end_impl(PyODictObject *self, PyObject *key, int last)
+/*[clinic end generated code: output=fafa4c5cc9b92f20 input=3b8283f7d0e15e43]*/
 {
-    static char *kwlist[] = {"key", "last", 0};
-    PyObject *key;
-    int last = 1;
     _ODictNode *node;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|p:move_to_end", kwlist,
-                                     &key, &last)) {
-        return NULL;
-    }
-
-    if (_odict_EMPTY(od)) {
+    if (_odict_EMPTY(self)) {
         PyErr_SetObject(PyExc_KeyError, key);
         return NULL;
     }
-    node = last ? _odict_LAST(od) : _odict_FIRST(od);
+    node = last ? _odict_LAST(self) : _odict_FIRST(self);
     if (key != _odictnode_KEY(node)) {
-        node = _odict_find_node(od, key);
+        node = _odict_find_node(self, key);
         if (node == NULL) {
             if (!PyErr_Occurred())
                 PyErr_SetObject(PyExc_KeyError, key);
@@ -1358,16 +1368,16 @@ odict_move_to_end(PyODictObject *od, PyObject *args, PyObject *kwargs)
         }
         if (last) {
             /* Only move if not already the last one. */
-            if (node != _odict_LAST(od)) {
-                _odict_remove_node(od, node);
-                _odict_add_tail(od, node);
+            if (node != _odict_LAST(self)) {
+                _odict_remove_node(self, node);
+                _odict_add_tail(self, node);
             }
         }
         else {
             /* Only move if not already the first one. */
-            if (node != _odict_FIRST(od)) {
-                _odict_remove_node(od, node);
-                _odict_add_head(od, node);
+            if (node != _odict_FIRST(self)) {
+                _odict_remove_node(self, node);
+                _odict_add_head(self, node);
             }
         }
     }
@@ -1395,20 +1405,17 @@ static PyMethodDef odict_methods[] = {
      odict_repr__doc__},
     {"__setitem__",     (PyCFunction)odict_mp_ass_sub,  METH_NOARGS,
      odict_setitem__doc__},
-    {"fromkeys",        (PyCFunction)odict_fromkeys,
-     METH_VARARGS | METH_KEYWORDS | METH_CLASS, odict_fromkeys__doc__},
+    ORDEREDDICT_FROMKEYS_METHODDEF
 
     /* overridden dict methods */
     {"__sizeof__",      (PyCFunction)odict_sizeof,      METH_NOARGS,
      odict_sizeof__doc__},
     {"__reduce__",      (PyCFunction)odict_reduce,      METH_NOARGS,
      odict_reduce__doc__},
-    {"setdefault",      (PyCFunction)odict_setdefault,
-     METH_VARARGS | METH_KEYWORDS, odict_setdefault__doc__},
+    ORDEREDDICT_SETDEFAULT_METHODDEF
     {"pop",             (PyCFunction)odict_pop,
      METH_VARARGS | METH_KEYWORDS, odict_pop__doc__},
-    {"popitem",         (PyCFunction)odict_popitem,
-     METH_VARARGS | METH_KEYWORDS, odict_popitem__doc__},
+    ORDEREDDICT_POPITEM_METHODDEF
     {"keys",            (PyCFunction)odictkeys_new,     METH_NOARGS,
      odict_keys__doc__},
     {"values",          (PyCFunction)odictvalues_new,   METH_NOARGS,
@@ -1425,8 +1432,7 @@ static PyMethodDef odict_methods[] = {
     /* new methods */
     {"__reversed__",    (PyCFunction)odict_reversed,    METH_NOARGS,
      odict_reversed__doc__},
-    {"move_to_end",     (PyCFunction)odict_move_to_end,
-     METH_VARARGS | METH_KEYWORDS, odict_move_to_end__doc__},
+    ORDEREDDICT_MOVE_TO_END_METHODDEF
 
     {NULL,              NULL}   /* sentinel */
 };
@@ -1578,10 +1584,13 @@ odict_traverse(PyODictObject *od, visitproc visit, void *arg)
 static int
 odict_tp_clear(PyODictObject *od)
 {
+    PyObject *res;
     Py_CLEAR(od->od_inst_dict);
     Py_CLEAR(od->od_weakreflist);
-    PyDict_Clear((PyObject *)od);
-    _odict_clear_nodes(od);
+    res = odict_clear(od);
+    if (res == NULL)
+        return -1;
+    Py_DECREF(res);
     return 0;
 }
 
@@ -1656,6 +1665,27 @@ odict_init(PyObject *self, PyObject *args, PyObject *kwds)
     }
 }
 
+/* tp_new */
+
+static PyObject *
+odict_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+    PyODictObject *od;
+
+    od = (PyODictObject *)PyDict_Type.tp_new(type, args, kwds);
+    if (od == NULL)
+        return NULL;
+
+    /* type constructor fills the memory with zeros (see
+       PyType_GenericAlloc()), there is no need to set them to zero again */
+    if (_odict_resize(od) < 0) {
+        Py_DECREF(od);
+        return NULL;
+    }
+
+    return (PyObject*)od;
+}
+
 /* PyODict_Type */
 
 PyTypeObject PyODict_Type = {
@@ -1696,7 +1726,7 @@ PyTypeObject PyODict_Type = {
     offsetof(PyODictObject, od_inst_dict),      /* tp_dictoffset */
     (initproc)odict_init,                       /* tp_init */
     PyType_GenericAlloc,                        /* tp_alloc */
-    0,                                          /* tp_new */
+    (newfunc)odict_new,                         /* tp_new */
     0,                                          /* tp_free */
 };
 
@@ -1706,9 +1736,8 @@ PyTypeObject PyODict_Type = {
  */
 
 PyObject *
-PyODict_New(void)
-{
-    return PyDict_Type.tp_new(&PyODict_Type, NULL, NULL);
+PyODict_New(void) {
+    return odict_new(&PyODict_Type, NULL, NULL);
 }
 
 static int
@@ -1906,21 +1935,40 @@ done:
 PyDoc_STRVAR(reduce_doc, "Return state information for pickling");
 
 static PyObject *
-odictiter_reduce(odictiterobject *di, PyObject *Py_UNUSED(ignored))
+odictiter_reduce(odictiterobject *di)
 {
-    /* copy the iterator state */
-    odictiterobject tmp = *di;
-    Py_XINCREF(tmp.di_odict);
-    Py_XINCREF(tmp.di_current);
+    PyObject *list, *iter;
+
+    list = PyList_New(0);
+    if (!list)
+        return NULL;
 
     /* iterate the temporary into a list */
-    PyObject *list = PySequence_List((PyObject*)&tmp);
-    Py_XDECREF(tmp.di_odict);
-    Py_XDECREF(tmp.di_current);
-    if (list == NULL) {
+    for(;;) {
+        PyObject *element = odictiter_iternext(di);
+        if (element) {
+            if (PyList_Append(list, element)) {
+                Py_DECREF(element);
+                Py_DECREF(list);
+                return NULL;
+            }
+            Py_DECREF(element);
+        }
+        else {
+            /* done iterating? */
+            break;
+        }
+    }
+    if (PyErr_Occurred()) {
+        Py_DECREF(list);
         return NULL;
     }
-    return Py_BuildValue("N(N)", _PyObject_GetBuiltin("iter"), list);
+    iter = _PyObject_GetBuiltin("iter");
+    if (iter == NULL) {
+        Py_DECREF(list);
+        return NULL;
+    }
+    return Py_BuildValue("N(N)", iter, list);
 }
 
 static PyMethodDef odictiter_methods[] = {
@@ -2390,8 +2438,7 @@ mutablemapping_update(PyObject *self, PyObject *args, PyObject *kwargs)
 
     /* now handle kwargs */
     assert(kwargs == NULL || PyDict_Check(kwargs));
-    len = (kwargs != NULL) ? PyDict_Size(kwargs) : 0;
-    if (len > 0) {
+    if (kwargs != NULL && PyDict_GET_SIZE(kwargs)) {
         PyObject *items = PyDict_Items(kwargs);
         if (items == NULL)
             return NULL;

--- a/third_party/python/Objects/typeobject.c
+++ b/third_party/python/Objects/typeobject.c
@@ -50,9 +50,9 @@
 #define MCACHE_HASH_METHOD(type, name)                                  \
         MCACHE_HASH((type)->tp_version_tag,                     \
                     ((PyASCIIObject *)(name))->hash)
-#define MCACHE_CACHEABLE_NAME(name)                             \
-        PyUnicode_CheckExact(name) &&                           \
-        PyUnicode_IS_READY(name) &&                             \
+#define MCACHE_CACHEABLE_NAME(name)                                     \
+        PyUnicode_CheckExact(name) &&                            \
+        PyUnicode_READY(name) != -1 &&                      \
         PyUnicode_GET_LENGTH(name) <= MCACHE_MAX_ATTR_SIZE
 
 struct method_cache_entry {
@@ -149,6 +149,22 @@ skip_signature(const char *doc)
     return NULL;
 }
 
+#ifdef Py_DEBUG
+static int
+_PyType_CheckConsistency(PyTypeObject *type)
+{
+    if (!(type->tp_flags & Py_TPFLAGS_READY)) {
+        /* don't check types before PyType_Ready() */
+        return 1;
+    }
+
+    assert(!(type->tp_flags & Py_TPFLAGS_READYING));
+    assert(type->tp_mro != NULL && PyTuple_Check(type->tp_mro));
+    assert(type->tp_dict != NULL);
+    return 1;
+}
+#endif
+
 static const char *
 _PyType_DocWithoutSignature(const char *name, const char *internal_doc)
 {
@@ -168,8 +184,7 @@ _PyType_GetDocFromInternalDoc(const char *name, const char *internal_doc)
     const char *doc = _PyType_DocWithoutSignature(name, internal_doc);
 
     if (!doc || *doc == '\0') {
-        Py_INCREF(Py_None);
-        return Py_None;
+        Py_RETURN_NONE;
     }
 
     return PyUnicode_FromString(doc);
@@ -186,8 +201,7 @@ _PyType_GetTextSignatureFromInternalDoc(const char *name, const char *internal_d
     else
         end = NULL;
     if (!end) {
-        Py_INCREF(Py_None);
-        return Py_None;
+        Py_RETURN_NONE;
     }
 
     /* back "end" up until it points just past the final ')' */
@@ -749,6 +763,7 @@ type_set_bases(PyTypeObject *type, PyObject *new_bases, void *context)
     Py_DECREF(old_bases);
     Py_DECREF(old_base);
 
+    assert(_PyType_CheckConsistency(type));
     return res;
 
   undo:
@@ -782,6 +797,7 @@ type_set_bases(PyTypeObject *type, PyObject *new_bases, void *context)
         Py_DECREF(old_base);
     }
 
+    assert(_PyType_CheckConsistency(type));
     return -1;
 }
 
@@ -789,8 +805,7 @@ static PyObject *
 type_dict(PyTypeObject *type, void *context)
 {
     if (type->tp_dict == NULL) {
-        Py_INCREF(Py_None);
-        return Py_None;
+        Py_RETURN_NONE;
     }
     return PyDictProxy_New(type->tp_dict);
 }
@@ -915,7 +930,7 @@ type_call(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
 #ifdef Py_DEBUG
     /* type_call() must not be called with an exception set,
-       because it may clear it (directly or indirectly) and so the
+       because it can clear it (directly or indirectly) and so the
        caller loses its exception */
     assert(!PyErr_Occurred());
 #endif
@@ -930,7 +945,7 @@ type_call(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (type == &PyType_Type &&
         PyTuple_Check(args) && PyTuple_GET_SIZE(args) == 1 &&
         (kwds == NULL ||
-         (PyDict_Check(kwds) && PyDict_Size(kwds) == 0)))
+         (PyDict_Check(kwds) && PyDict_GET_SIZE(kwds) == 0)))
         return obj;
 
     /* If the returned object is not an instance of type,
@@ -1381,6 +1396,7 @@ int
 PyType_IsSubtype(PyTypeObject *a, PyTypeObject *b)
 {
     PyObject *mro;
+
     mro = a->tp_mro;
     if (mro != NULL) {
         /* Deal with multiple inheritance without recursion
@@ -1406,20 +1422,25 @@ PyType_IsSubtype(PyTypeObject *a, PyTypeObject *b)
    the method name as a C string, and the address of a
    static variable used to cache the interned Python string.
 
-   Two variants:
+   Variants:
 
    - lookup_maybe() returns NULL without raising an exception
      when the _PyType_Lookup() call fails;
 
-   - lookup_method() always raises an exception upon errors.
+   - lookup_maybe_method() and lookup_method() are similar to
+     lookup_maybe(), but can return unbound PyFunction
+     to avoid temporary method object. Pass self as first argument when
+     unbound == 1.
 
-   - _PyObject_LookupSpecial() exported for the benefit of other places.
+   - _PyObject_LookupSpecial() expose lookup_maybe for the benefit of
+     other places.
 */
 
 forceinline PyObject *
 lookup_maybe(PyObject *self, _Py_Identifier *attrid)
 {
     PyObject *res;
+
     res = _PyType_LookupId(Py_TYPE(self), attrid);
     if (res != NULL) {
         descrgetfunc f;
@@ -1432,11 +1453,38 @@ lookup_maybe(PyObject *self, _Py_Identifier *attrid)
 }
 
 static PyObject *
-lookup_method(PyObject *self, _Py_Identifier *attrid)
+lookup_maybe_method(PyObject *self, _Py_Identifier *attrid, int *unbound)
 {
-    PyObject *res = lookup_maybe(self, attrid);
-    if (res == NULL && !PyErr_Occurred())
+    PyObject *res = _PyType_LookupId(Py_TYPE(self), attrid);
+    if (res == NULL) {
+        return NULL;
+    }
+
+    if (PyFunction_Check(res)) {
+        /* Avoid temporary PyMethodObject */
+        *unbound = 1;
+        Py_INCREF(res);
+    }
+    else {
+        *unbound = 0;
+        descrgetfunc f = Py_TYPE(res)->tp_descr_get;
+        if (f == NULL) {
+            Py_INCREF(res);
+        }
+        else {
+            res = f(res, self, (PyObject *)(Py_TYPE(self)));
+        }
+    }
+    return res;
+}
+
+static PyObject *
+lookup_method(PyObject *self, _Py_Identifier *attrid, int *unbound)
+{
+    PyObject *res = lookup_maybe_method(self, attrid, unbound);
+    if (res == NULL && !PyErr_Occurred()) {
         PyErr_SetObject(PyExc_AttributeError, attrid->object);
+    }
     return res;
 }
 
@@ -1446,85 +1494,70 @@ _PyObject_LookupSpecial(PyObject *self, _Py_Identifier *attrid)
     return lookup_maybe(self, attrid);
 }
 
-/* A variation of PyObject_CallMethod that uses lookup_method()
-   instead of PyObject_GetAttrString().  This uses the same convention
-   as lookup_method to cache the interned name string object. */
-
-static PyObject *
-call_method(PyObject *o, _Py_Identifier *nameid, const char *format, ...)
+static PyObject*
+call_unbound(int unbound, PyObject *func, PyObject *self,
+             PyObject **args, Py_ssize_t nargs)
 {
-    va_list va;
-    PyObject *func = NULL, *retval;
+    if (unbound) {
+        return _PyObject_FastCall_Prepend(func, self, args, nargs);
+    }
+    else {
+        return _PyObject_FastCall(func, args, nargs);
+    }
+}
 
-    func = lookup_maybe(o, nameid);
+static PyObject*
+call_unbound_noarg(int unbound, PyObject *func, PyObject *self)
+{
+    if (unbound) {
+        PyObject *args[1] = {self};
+        return _PyObject_FastCall(func, args, 1);
+    }
+    else {
+        return _PyObject_CallNoArg(func);
+    }
+}
+
+/* A variation of PyObject_CallMethodObjArgs that uses lookup_maybe_method()
+   instead of PyObject_GetAttrString().  This uses the same convention
+   as lookup_maybe_method to cache the interned name string object. */
+static PyObject *
+call_method(PyObject *obj, _Py_Identifier *name,
+            PyObject **args, Py_ssize_t nargs)
+{
+    int unbound;
+    PyObject *func, *retval;
+
+    func = lookup_maybe_method(obj, name, &unbound);
     if (func == NULL) {
         if (!PyErr_Occurred())
-            PyErr_SetObject(PyExc_AttributeError, nameid->object);
+            PyErr_SetObject(PyExc_AttributeError, name->object);
         return NULL;
     }
 
-    if (format && *format) {
-        PyObject *args;
-
-        va_start(va, format);
-        args = Py_VaBuildValue(format, va);
-        va_end(va);
-
-        if (args == NULL) {
-            Py_DECREF(func);
-            return NULL;
-        }
-        assert(PyTuple_Check(args));
-
-        retval = PyObject_Call(func, args, NULL);
-        Py_DECREF(args);
-    }
-    else {
-        retval = _PyObject_CallNoArg(func);
-    }
-
+    retval = call_unbound(unbound, func, obj, args, nargs);
     Py_DECREF(func);
-
     return retval;
 }
 
 /* Clone of call_method() that returns NotImplemented when the lookup fails. */
 
 static PyObject *
-call_maybe(PyObject *o, _Py_Identifier *nameid, const char *format, ...)
+call_maybe(PyObject *obj, _Py_Identifier *name,
+           PyObject **args, Py_ssize_t nargs)
 {
-    va_list va;
-    PyObject *func = NULL, *retval;
+    int unbound;
+    PyObject *func, *retval;
 
-    func = lookup_maybe(o, nameid);
+    func = lookup_maybe_method(obj, name, &unbound);
     if (func == NULL) {
         if (!PyErr_Occurred())
             Py_RETURN_NOTIMPLEMENTED;
         return NULL;
     }
 
-    if (format && *format) {
-        PyObject *args;
-
-        va_start(va, format);
-        args = Py_VaBuildValue(format, va);
-        va_end(va);
-
-        if (args == NULL) {
-            Py_DECREF(func);
-            return NULL;
-        }
-        assert(PyTuple_Check(args));
-
-        retval = PyObject_Call(func, args, NULL);
-        Py_DECREF(args);
-    }
-    else {
-        retval = _PyObject_CallNoArg(func);
-    }
-
+    retval = call_unbound(unbound, func, obj, args, nargs);
     Py_DECREF(func);
-
     return retval;
 }
 
@@ -1643,14 +1676,14 @@ set_mro_error(PyObject *to_merge, int *remain)
             }
         }
     }
-    n = PyDict_Size(set);
+    n = PyDict_GET_SIZE(set);
 
     off = PyOS_snprintf(buf, sizeof(buf), "Cannot create a \
 consistent method resolution\norder (MRO) for bases");
     i = 0;
     while (PyDict_Next(set, &i, &k, &v) && (size_t)off < sizeof(buf)) {
         PyObject *name = class_name(k);
-        char *name_str;
+        const char *name_str;
         if (name != NULL) {
             name_str = PyUnicode_AsUTF8(name);
             if (name_str == NULL)
@@ -1879,10 +1912,12 @@ mro_invoke(PyTypeObject *type)
 
     if (custom) {
         _Py_IDENTIFIER(mro);
-        PyObject *mro_meth = lookup_method((PyObject *)type, &PyId_mro);
+        int unbound;
+        PyObject *mro_meth = lookup_method((PyObject *)type, &PyId_mro,
+                                           &unbound);
         if (mro_meth == NULL)
             return NULL;
-        mro_result = PyObject_CallObject(mro_meth, NULL);
+        mro_result = call_unbound_noarg(unbound, mro_meth, (PyObject *)type);
         Py_DECREF(mro_meth);
     }
     else {
@@ -2245,7 +2280,7 @@ type_init(PyObject *cls, PyObject *args, PyObject *kwds)
     assert(kwds == NULL || PyDict_Check(kwds));
 
     if (kwds != NULL && PyTuple_Check(args) && PyTuple_GET_SIZE(args) == 1 &&
-        PyDict_Check(kwds) && PyDict_Size(kwds) != 0) {
+        PyDict_Check(kwds) && PyDict_GET_SIZE(kwds) != 0) {
         PyErr_SetString(PyExc_TypeError,
                         "type.__init__() takes no keyword arguments");
         return -1;
@@ -2261,9 +2296,6 @@ type_init(PyObject *cls, PyObject *args, PyObject *kwds)
     /* Call object.__init__(self) now. */
     /* XXX Could call super(type, cls).__init__() but what's the point? */
     args = PyTuple_GetSlice(args, 0, 0);
-    if (args == NULL) {
-        return -1;
-    }
     res = object_init(cls, args, NULL);
     Py_DECREF(args);
     return res;
@@ -2333,7 +2365,7 @@ type_new(PyTypeObject *metatype, PyObject *args, PyObject *kwds)
        Note: We don't call PyType_CheckExact as that also allows subclasses */
     if (metatype == &PyType_Type) {
         const Py_ssize_t nargs = PyTuple_GET_SIZE(args);
-        const Py_ssize_t nkwds = kwds == NULL ? 0 : PyDict_Size(kwds);
+        const Py_ssize_t nkwds = kwds == NULL ? 0 : PyDict_GET_SIZE(kwds);
 
         if (nargs == 1 && nkwds == 0) {
             PyObject *x = PyTuple_GET_ITEM(args, 0);
@@ -2342,7 +2374,7 @@ type_new(PyTypeObject *metatype, PyObject *args, PyObject *kwds)
         }
 
         /* SF bug 475327 -- if that didn't trigger, we need 3
-           arguments. but PyArg_ParseTuple below may give
+           arguments. but PyArg_ParseTupleAndKeywords below may give
            a msg saying type() needs exactly 3. */
         if (nargs != 3) {
             PyErr_SetString(PyExc_TypeError,
@@ -2601,7 +2633,7 @@ type_new(PyTypeObject *metatype, PyObject *args, PyObject *kwds)
         PyObject *doc = _PyDict_GetItemId(dict, &PyId___doc__);
         if (doc != NULL && PyUnicode_Check(doc)) {
             Py_ssize_t len;
-            char *doc_str;
+            const char *doc_str;
             char *tp_doc;
 
             doc_str = PyUnicode_AsUTF8(doc);
@@ -2774,15 +2806,6 @@ PyType_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
     char *res_start = (char*)res;
     PyType_Slot *slot;
 
-    if (res == NULL)
-        return NULL;
-
-    if (spec->name == NULL) {
-        PyErr_SetString(PyExc_SystemError,
-                        "Type spec does not define the name field.");
-        goto fail;
-    }
-
     /* Set the type name and qualname */
     s = strrchr(spec->name, '.');
     if (s == NULL)
@@ -2790,6 +2813,8 @@ PyType_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
     else
         s++;
 
+    if (res == NULL)
+        return NULL;
     type = &res->ht_type;
     /* The flags must be initialized early, before the GC traverses us */
     type->tp_flags = spec->flags | Py_TPFLAGS_HEAPTYPE;
@@ -2799,6 +2824,8 @@ PyType_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
     res->ht_qualname = res->ht_name;
     Py_INCREF(res->ht_qualname);
     type->tp_name = spec->name;
+    if (!type->tp_name)
+        goto fail;
 
     /* Adjust for empty tuple bases */
     if (!bases) {
@@ -2978,6 +3005,7 @@ _PyType_Lookup(PyTypeObject *type, PyObject *name)
         }
     }
 
+
     res = NULL;
     /* keep a strong reference to mro because type->tp_mro can be replaced
        during PyDict_GetItem(dict, name)  */
@@ -3030,7 +3058,6 @@ type_getattro(PyTypeObject *type, PyObject *name)
     PyTypeObject *metatype = Py_TYPE(type);
     PyObject *meta_attribute, *attribute;
     descrgetfunc meta_get;
-    PyObject* res;
 
     if (!PyUnicode_Check(name)) {
         PyErr_Format(PyExc_TypeError,
@@ -3052,7 +3079,6 @@ type_getattro(PyTypeObject *type, PyObject *name)
     meta_attribute = _PyType_Lookup(metatype, name);
 
     if (meta_attribute != NULL) {
-        Py_INCREF(meta_attribute);
         meta_get = Py_TYPE(meta_attribute)->tp_descr_get;
 
         if (meta_get != NULL && PyDescr_IsData(meta_attribute)) {
@@ -3060,11 +3086,10 @@ type_getattro(PyTypeObject *type, PyObject *name)
              * writes. Assume the attribute is not overridden in
              * type's tp_dict (and bases): call the descriptor now.
              */
-            res = meta_get(meta_attribute, (PyObject *)type,
-                           (PyObject *)metatype);
-            Py_DECREF(meta_attribute);
-            return res;
+            return meta_get(meta_attribute, (PyObject *)type,
+                            (PyObject *)metatype);
         }
+        Py_INCREF(meta_attribute);
     }
 
     /* No data descriptor found on metatype. Look in tp_dict of this
@@ -3072,7 +3097,6 @@ type_getattro(PyTypeObject *type, PyObject *name)
     attribute = _PyType_Lookup(type, name);
     if (attribute != NULL) {
         /* Implement descriptor functionality, if any */
-        Py_INCREF(attribute);
         descrgetfunc local_get = Py_TYPE(attribute)->tp_descr_get;
 
         Py_XDECREF(meta_attribute);
@@ -3080,12 +3104,11 @@ type_getattro(PyTypeObject *type, PyObject *name)
         if (local_get != NULL) {
             /* NULL 2nd argument indicates the descriptor was
              * found on the target object itself (or a base)  */
-            res = local_get(attribute, (PyObject *)NULL,
-                            (PyObject *)type);
-            Py_DECREF(attribute);
-            return res;
+            return local_get(attribute, (PyObject *)NULL,
+                             (PyObject *)type);
         }
 
+        Py_INCREF(attribute);
         return attribute;
     }
 
@@ -3145,9 +3168,10 @@ type_setattro(PyTypeObject *type, PyObject *name, PyObject *value)
         /* Will fail in _PyObject_GenericSetAttrWithDict. */
         Py_INCREF(name);
     }
-    res = PyObject_GenericSetAttr((PyObject *)type, name, value);
+    res = _PyObject_GenericSetAttrWithDict((PyObject *)type, name, value, NULL);
     if (res == 0) {
         res = update_slot(type, name);
+        assert(_PyType_CheckConsistency(type));
     }
     Py_DECREF(name);
     return res;
@@ -3216,7 +3240,7 @@ type_subclasses(PyTypeObject *type, PyObject *args_ignored)
 }
 
 static PyObject *
-type_prepare(PyObject *self, PyObject **args, Py_ssize_t nargs, 
+type_prepare(PyObject *self, PyObject **args, Py_ssize_t nargs,
              PyObject *kwnames)
 {
     return PyDict_New();
@@ -3515,7 +3539,7 @@ static int
 excess_args(PyObject *args, PyObject *kwds)
 {
     return PyTuple_GET_SIZE(args) ||
-        (kwds && PyDict_Check(kwds) && PyDict_Size(kwds));
+        (kwds && PyDict_Check(kwds) && PyDict_GET_SIZE(kwds));
 }
 
 static int
@@ -3993,7 +4017,7 @@ _PyObject_GetState(PyObject *obj, int required)
                We also return None if the dict is empty to make the behavior
                consistent regardless whether the dict was initialized or not.
                This make unit testing easier. */
-            if (dict != NULL && *dict != NULL && PyDict_Size(*dict) > 0) {
+            if (dict != NULL && *dict != NULL && PyDict_GET_SIZE(*dict)) {
                 state = *dict;
             }
             else {
@@ -4082,7 +4106,7 @@ _PyObject_GetState(PyObject *obj, int required)
 
             /* If we found some slot attributes, pack them in a tuple along
                the original attribute dictionary. */
-            if (PyDict_Size(slots) > 0) {
+            if (PyDict_GET_SIZE(slots) > 0) {
                 PyObject *state2;
 
                 state2 = PyTuple_Pack(2, state, slots);
@@ -4099,7 +4123,7 @@ _PyObject_GetState(PyObject *obj, int required)
         Py_DECREF(slotnames);
     }
     else { /* getstate != NULL */
-        state = PyObject_CallObject(getstate, NULL);
+        state = _PyObject_CallNoArg(getstate);
         Py_DECREF(getstate);
         if (state == NULL)
             return NULL;
@@ -4124,7 +4148,7 @@ _PyObject_GetNewArguments(PyObject *obj, PyObject **args, PyObject **kwargs)
        __getnewargs_ex__ on the object. */
     getnewargs_ex = _PyObject_LookupSpecial(obj, &PyId___getnewargs_ex__);
     if (getnewargs_ex != NULL) {
-        PyObject *newargs = PyObject_CallObject(getnewargs_ex, NULL);
+        PyObject *newargs = _PyObject_CallNoArg(getnewargs_ex);
         Py_DECREF(getnewargs_ex);
         if (newargs == NULL) {
             return -1;
@@ -4177,7 +4201,7 @@ _PyObject_GetNewArguments(PyObject *obj, PyObject **args, PyObject **kwargs)
        __getnewargs__ instead. */
     getnewargs = _PyObject_LookupSpecial(obj, &PyId___getnewargs__);
     if (getnewargs != NULL) {
-        *args = PyObject_CallObject(getnewargs, NULL);
+        *args = _PyObject_CallNoArg(getnewargs);
         Py_DECREF(getnewargs);
         if (*args == NULL) {
             return -1;
@@ -4274,7 +4298,7 @@ reduce_newobj(PyObject *obj)
         return NULL;
     }
     hasargs = (args != NULL);
-    if (kwargs == NULL || PyDict_Size(kwargs) == 0) {
+    if (kwargs == NULL || PyDict_GET_SIZE(kwargs) == 0) {
         _Py_IDENTIFIER(__newobj__);
         PyObject *cls;
         Py_ssize_t i, n;
@@ -4429,7 +4453,7 @@ object_reduce_ex(PyObject *self, PyObject *args)
         override = (clsreduce != objreduce);
         Py_DECREF(clsreduce);
         if (override) {
-            res = PyObject_CallObject(reduce, NULL);
+            res = _PyObject_CallNoArg(reduce);
             Py_DECREF(reduce);
             return res;
         }
@@ -4625,6 +4649,7 @@ add_methods(PyTypeObject *type, PyMethodDef *meth)
     for (; meth->ml_name != NULL; meth++) {
         PyObject *descr;
         int err;
+        int isdescr = 1;
         if (PyDict_GetItemString(dict, meth->ml_name) &&
             !(meth->ml_flags & METH_COEXIST))
                 continue;
@@ -4641,6 +4666,7 @@ add_methods(PyTypeObject *type, PyMethodDef *meth)
             if (cfunc == NULL)
                 return -1;
             descr = PyStaticMethod_New(cfunc);
+            isdescr = 0;  // PyStaticMethod is not PyDescrObject
             Py_DECREF(cfunc);
         }
         else {
@@ -4648,7 +4674,12 @@ add_methods(PyTypeObject *type, PyMethodDef *meth)
         }
         if (descr == NULL)
             return -1;
-        err = PyDict_SetItemString(dict, meth->ml_name, descr);
+        if (isdescr) {
+            err = PyDict_SetItem(dict, PyDescr_NAME(descr), descr);
+        }
+        else {
+            err = PyDict_SetItemString(dict, meth->ml_name, descr);
+        }
         Py_DECREF(descr);
         if (err < 0)
             return -1;
@@ -4668,7 +4699,7 @@ add_members(PyTypeObject *type, PyMemberDef *memb)
         descr = PyDescr_NewMember(type, memb);
         if (descr == NULL)
             return -1;
-        if (PyDict_SetItemString(dict, memb->name, descr) < 0) {
+        if (PyDict_SetItem(dict, PyDescr_NAME(descr), descr) < 0) {
             Py_DECREF(descr);
             return -1;
         }
@@ -4690,7 +4721,7 @@ add_getset(PyTypeObject *type, PyGetSetDef *gsp)
 
         if (descr == NULL)
             return -1;
-        if (PyDict_SetItemString(dict, gsp->name, descr) < 0) {
+        if (PyDict_SetItem(dict, PyDescr_NAME(descr), descr) < 0) {
             Py_DECREF(descr);
             return -1;
         }
@@ -4958,7 +4989,7 @@ PyType_Ready(PyTypeObject *type)
     Py_ssize_t i, n;
 
     if (type->tp_flags & Py_TPFLAGS_READY) {
-        assert(type->tp_dict != NULL);
+        assert(_PyType_CheckConsistency(type));
         return 0;
     }
     assert((type->tp_flags & Py_TPFLAGS_READYING) == 0);
@@ -4969,7 +5000,7 @@ PyType_Ready(PyTypeObject *type)
     /* PyType_Ready is the closest thing we have to a choke point
      * for type objects, so is the best place I can think of to try
      * to get type objects into the doubly-linked list of all objects.
-     * Still, not all type objects go through PyType_Ready.
+     * Still, not all type objects go thru PyType_Ready.
      */
     _Py_AddToAllObjects((PyObject *)type, 0);
 #endif
@@ -5152,9 +5183,9 @@ PyType_Ready(PyTypeObject *type)
     }
 
     /* All done -- set the ready flag */
-    assert(type->tp_dict != NULL);
     type->tp_flags =
         (type->tp_flags & ~Py_TPFLAGS_READYING) | Py_TPFLAGS_READY;
+    assert(_PyType_CheckConsistency(type));
     return 0;
 
   error:
@@ -5434,8 +5465,7 @@ wrap_sq_setitem(PyObject *self, PyObject *args, void *wrapped)
     res = (*func)(self, i, value);
     if (res == -1 && PyErr_Occurred())
         return NULL;
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -5455,8 +5485,7 @@ wrap_sq_delitem(PyObject *self, PyObject *args, void *wrapped)
     res = (*func)(self, i, NULL);
     if (res == -1 && PyErr_Occurred())
         return NULL;
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 /* XXX objobjproc is a misnomer; should be objargpred */
@@ -5489,8 +5518,7 @@ wrap_objobjargproc(PyObject *self, PyObject *args, void *wrapped)
     res = (*func)(self, key, value);
     if (res == -1 && PyErr_Occurred())
         return NULL;
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -5506,8 +5534,7 @@ wrap_delitem(PyObject *self, PyObject *args, void *wrapped)
     res = (*func)(self, key, NULL);
     if (res == -1 && PyErr_Occurred())
         return NULL;
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 /* Helper to check for object.__setattr__ or __delattr__ applied to a type.
@@ -5544,8 +5571,7 @@ wrap_setattr(PyObject *self, PyObject *args, void *wrapped)
     res = (*func)(self, name, value);
     if (res < 0)
         return NULL;
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -5563,8 +5589,7 @@ wrap_delattr(PyObject *self, PyObject *args, void *wrapped)
     res = (*func)(self, name, NULL);
     if (res < 0)
         return NULL;
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -5675,8 +5700,7 @@ wrap_descr_set(PyObject *self, PyObject *args, void *wrapped)
     ret = (*func)(self, obj, value);
     if (ret < 0)
         return NULL;
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -5692,8 +5716,7 @@ wrap_descr_delete(PyObject *self, PyObject *args, void *wrapped)
     ret = (*func)(self, obj, NULL);
     if (ret < 0)
         return NULL;
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -5703,8 +5726,7 @@ wrap_init(PyObject *self, PyObject *args, void *wrapped, PyObject *kwds)
 
     if (func(self, args, kwds) < 0)
         return NULL;
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -5800,15 +5822,16 @@ static PyObject * \
 FUNCNAME(PyObject *self) \
 { \
     _Py_static_string(id, OPSTR); \
-    return call_method(self, &id, NULL); \
+    return call_method(self, &id, NULL, 0); \
 }
 
-#define SLOT1(FUNCNAME, OPSTR, ARG1TYPE, ARGCODES) \
+#define SLOT1(FUNCNAME, OPSTR, ARG1TYPE) \
 static PyObject * \
 FUNCNAME(PyObject *self, ARG1TYPE arg1) \
 { \
+    PyObject* stack[1] = {arg1}; \
     _Py_static_string(id, OPSTR); \
-    return call_method(self, &id, "(" ARGCODES ")", arg1); \
+    return call_method(self, &id, stack, 1); \
 }
 
 /* Boolean helper for SLOT1BINFULL().
@@ -5850,6 +5873,7 @@ method_is_overloaded(PyObject *left, PyObject *right, struct _Py_Identifier *nam
 static PyObject * \
 FUNCNAME(PyObject *self, PyObject *other) \
 { \
+    PyObject* stack[1]; \
     _Py_static_string(op_id, OPSTR); \
     _Py_static_string(rop_id, ROPSTR); \
     int do_other = Py_TYPE(self) != Py_TYPE(other) && \
@@ -5861,20 +5885,23 @@ FUNCNAME(PyObject *self, PyObject *other) \
         if (do_other && \
             PyType_IsSubtype(Py_TYPE(other), Py_TYPE(self)) && \
             method_is_overloaded(self, other, &rop_id)) { \
-            r = call_maybe(other, &rop_id, "(O)", self); \
+            stack[0] = self; \
+            r = call_maybe(other, &rop_id, stack, 1); \
             if (r != Py_NotImplemented) \
                 return r; \
             Py_DECREF(r); \
             do_other = 0; \
         } \
-        r = call_maybe(self, &op_id, "(O)", other); \
+        stack[0] = other; \
+        r = call_maybe(self, &op_id, stack, 1); \
         if (r != Py_NotImplemented || \
             Py_TYPE(other) == Py_TYPE(self)) \
             return r; \
         Py_DECREF(r); \
     } \
     if (do_other) { \
-        return call_maybe(other, &rop_id, "(O)", self); \
+        stack[0] = self; \
+        return call_maybe(other, &rop_id, stack, 1); \
     } \
     Py_RETURN_NOTIMPLEMENTED; \
 }
@@ -5882,18 +5909,10 @@ FUNCNAME(PyObject *self, PyObject *other) \
 #define SLOT1BIN(FUNCNAME, SLOTNAME, OPSTR, ROPSTR) \
     SLOT1BINFULL(FUNCNAME, FUNCNAME, SLOTNAME, OPSTR, ROPSTR)
 
-#define SLOT2(FUNCNAME, OPSTR, ARG1TYPE, ARG2TYPE, ARGCODES) \
-static PyObject * \
-FUNCNAME(PyObject *self, ARG1TYPE arg1, ARG2TYPE arg2) \
-{ \
-    _Py_static_string(id, #OPSTR); \
-    return call_method(self, &id, "(" ARGCODES ")", arg1, arg2); \
-}
-
 static Py_ssize_t
 slot_sq_length(PyObject *self)
 {
-    PyObject *res = call_method(self, &PyId___len__, NULL);
+    PyObject *res = call_method(self, &PyId___len__, NULL, 0);
     Py_ssize_t len;
 
     if (res == NULL)
@@ -5940,7 +5959,7 @@ slot_sq_item(PyObject *self, Py_ssize_t i)
         goto error;
     }
 
-    retval = _PyObject_CallArg1(func, ival);
+    retval = PyObject_CallFunctionObjArgs(func, ival, NULL);
     Py_DECREF(func);
     Py_DECREF(ival);
     return retval;
@@ -5953,14 +5972,28 @@ error:
 static int
 slot_sq_ass_item(PyObject *self, Py_ssize_t index, PyObject *value)
 {
+    PyObject *stack[2];
     PyObject *res;
+    PyObject *index_obj;
 
-    if (value == NULL)
-        res = call_method(self, &PyId___delitem__, "(n)", index);
-    else
-        res = call_method(self, &PyId___setitem__, "(nO)", index, value);
-    if (res == NULL)
+    index_obj = PyLong_FromSsize_t(index);
+    if (index_obj == NULL) {
         return -1;
+    }
+
+    stack[0] = index_obj;
+    if (value == NULL) {
+        res = call_method(self, &PyId___delitem__, stack, 1);
+    }
+    else {
+        stack[1] = value;
+        res = call_method(self, &PyId___setitem__, stack, 2);
+    }
+    Py_DECREF(index_obj);
+
+    if (res == NULL) {
+        return -1;
+    }
     Py_DECREF(res);
     return 0;
 }
@@ -5969,10 +6002,10 @@ static int
 slot_sq_contains(PyObject *self, PyObject *value)
 {
     PyObject *func, *res;
-    int result = -1;
+    int result = -1, unbound;
     _Py_IDENTIFIER(__contains__);
 
-    func = lookup_maybe(self, &PyId___contains__);
+    func = lookup_maybe_method(self, &PyId___contains__, &unbound);
     if (func == Py_None) {
         Py_DECREF(func);
         PyErr_Format(PyExc_TypeError,
@@ -5981,7 +6014,8 @@ slot_sq_contains(PyObject *self, PyObject *value)
         return -1;
     }
     if (func != NULL) {
-        res = _PyObject_CallArg1(func, value);
+        PyObject *args[1] = {value};
+        res = call_unbound(unbound, func, self, args, 1);
         Py_DECREF(func);
         if (res != NULL) {
             result = PyObject_IsTrue(res);
@@ -5998,17 +6032,22 @@ slot_sq_contains(PyObject *self, PyObject *value)
 
 #define slot_mp_length slot_sq_length
 
-SLOT1(slot_mp_subscript, "__getitem__", PyObject *, "O")
+SLOT1(slot_mp_subscript, "__getitem__", PyObject *)
 
 static int
 slot_mp_ass_subscript(PyObject *self, PyObject *key, PyObject *value)
 {
+    PyObject *stack[2];
     PyObject *res;
 
-    if (value == NULL)
-        res = call_method(self, &PyId___delitem__, "(O)", key);
-    else
-        res = call_method(self, &PyId___setitem__, "(OO)", key, value);
+    stack[0] = key;
+    if (value == NULL) {
+        res = call_method(self, &PyId___delitem__, stack, 1);
+    }
+    else {
+        stack[1] = value;
+        res = call_method(self, &PyId___setitem__, stack, 2);
+    }
 
     if (res == NULL)
         return -1;
@@ -6040,7 +6079,8 @@ slot_nb_power(PyObject *self, PyObject *other, PyObject *modulus)
        slot_nb_power, so check before calling self.__pow__. */
     if (Py_TYPE(self)->tp_as_number != NULL &&
         Py_TYPE(self)->tp_as_number->nb_power == slot_nb_power) {
-        return call_method(self, &PyId___pow__, "(OO)", other, modulus);
+        PyObject* stack[2] = {other, modulus};
+        return call_method(self, &PyId___pow__, stack, 2);
     }
     Py_RETURN_NOTIMPLEMENTED;
 }
@@ -6053,17 +6093,17 @@ static int
 slot_nb_bool(PyObject *self)
 {
     PyObject *func, *value;
-    int result;
+    int result, unbound;
     int using_len = 0;
     _Py_IDENTIFIER(__bool__);
 
-    func = lookup_maybe(self, &PyId___bool__);
+    func = lookup_maybe_method(self, &PyId___bool__, &unbound);
     if (func == NULL) {
         if (PyErr_Occurred()) {
             return -1;
         }
 
-        func = lookup_maybe(self, &PyId___len__);
+        func = lookup_maybe_method(self, &PyId___len__, &unbound);
         if (func == NULL) {
             if (PyErr_Occurred()) {
                 return -1;
@@ -6073,7 +6113,7 @@ slot_nb_bool(PyObject *self)
         using_len = 1;
     }
 
-    value = _PyObject_CallNoArg(func);
+    value = call_unbound_noarg(unbound, func, self);
     if (value == NULL) {
         goto error;
     }
@@ -6107,7 +6147,7 @@ static PyObject *
 slot_nb_index(PyObject *self)
 {
     _Py_IDENTIFIER(__index__);
-    return call_method(self, &PyId___index__, NULL);
+    return call_method(self, &PyId___index__, NULL, 0);
 }
 
 
@@ -6120,38 +6160,40 @@ SLOT1BIN(slot_nb_or, nb_or, "__or__", "__ror__")
 
 SLOT0(slot_nb_int, "__int__")
 SLOT0(slot_nb_float, "__float__")
-SLOT1(slot_nb_inplace_add, "__iadd__", PyObject *, "O")
-SLOT1(slot_nb_inplace_subtract, "__isub__", PyObject *, "O")
-SLOT1(slot_nb_inplace_multiply, "__imul__", PyObject *, "O")
-SLOT1(slot_nb_inplace_matrix_multiply, "__imatmul__", PyObject *, "O")
-SLOT1(slot_nb_inplace_remainder, "__imod__", PyObject *, "O")
+SLOT1(slot_nb_inplace_add, "__iadd__", PyObject *)
+SLOT1(slot_nb_inplace_subtract, "__isub__", PyObject *)
+SLOT1(slot_nb_inplace_multiply, "__imul__", PyObject *)
+SLOT1(slot_nb_inplace_matrix_multiply, "__imatmul__", PyObject *)
+SLOT1(slot_nb_inplace_remainder, "__imod__", PyObject *)
 /* Can't use SLOT1 here, because nb_inplace_power is ternary */
 static PyObject *
 slot_nb_inplace_power(PyObject *self, PyObject * arg1, PyObject *arg2)
 {
+    PyObject *stack[1] = {arg1};
     _Py_IDENTIFIER(__ipow__);
-    return call_method(self, &PyId___ipow__, "(" "O" ")", arg1);
+    return call_method(self, &PyId___ipow__, stack, 1);
 }
-SLOT1(slot_nb_inplace_lshift, "__ilshift__", PyObject *, "O")
-SLOT1(slot_nb_inplace_rshift, "__irshift__", PyObject *, "O")
-SLOT1(slot_nb_inplace_and, "__iand__", PyObject *, "O")
-SLOT1(slot_nb_inplace_xor, "__ixor__", PyObject *, "O")
-SLOT1(slot_nb_inplace_or, "__ior__", PyObject *, "O")
+SLOT1(slot_nb_inplace_lshift, "__ilshift__", PyObject *)
+SLOT1(slot_nb_inplace_rshift, "__irshift__", PyObject *)
+SLOT1(slot_nb_inplace_and, "__iand__", PyObject *)
+SLOT1(slot_nb_inplace_xor, "__ixor__", PyObject *)
+SLOT1(slot_nb_inplace_or, "__ior__", PyObject *)
 SLOT1BIN(slot_nb_floor_divide, nb_floor_divide,
          "__floordiv__", "__rfloordiv__")
 SLOT1BIN(slot_nb_true_divide, nb_true_divide, "__truediv__", "__rtruediv__")
-SLOT1(slot_nb_inplace_floor_divide, "__ifloordiv__", PyObject *, "O")
-SLOT1(slot_nb_inplace_true_divide, "__itruediv__", PyObject *, "O")
+SLOT1(slot_nb_inplace_floor_divide, "__ifloordiv__", PyObject *)
+SLOT1(slot_nb_inplace_true_divide, "__itruediv__", PyObject *)
 
 static PyObject *
 slot_tp_repr(PyObject *self)
 {
     PyObject *func, *res;
     _Py_IDENTIFIER(__repr__);
+    int unbound;
 
-    func = lookup_method(self, &PyId___repr__);
+    func = lookup_method(self, &PyId___repr__, &unbound);
     if (func != NULL) {
-        res = PyEval_CallObject(func, NULL);
+        res = call_unbound_noarg(unbound, func, self);
         Py_DECREF(func);
         return res;
     }
@@ -6160,27 +6202,16 @@ slot_tp_repr(PyObject *self)
                                Py_TYPE(self)->tp_name, self);
 }
 
-static PyObject *
-slot_tp_str(PyObject *self)
-{
-    PyObject *func, *res;
-    _Py_IDENTIFIER(__str__);
-
-    func = lookup_method(self, &PyId___str__);
-    if (func == NULL)
-        return NULL;
-    res = PyEval_CallObject(func, NULL);
-    Py_DECREF(func);
-    return res;
-}
+SLOT0(slot_tp_str, "__str__")
 
 static Py_hash_t
 slot_tp_hash(PyObject *self)
 {
     PyObject *func, *res;
     Py_ssize_t h;
+    int unbound;
 
-    func = lookup_method(self, &PyId___hash__);
+    func = lookup_method(self, &PyId___hash__, &unbound);
 
     if (func == Py_None) {
         Py_DECREF(func);
@@ -6191,7 +6222,7 @@ slot_tp_hash(PyObject *self)
         return PyObject_HashNotImplemented(self);
     }
 
-    res = PyEval_CallObject(func, NULL);
+    res = call_unbound_noarg(unbound, func, self);
     Py_DECREF(func);
     if (res == NULL)
         return -1;
@@ -6225,13 +6256,19 @@ static PyObject *
 slot_tp_call(PyObject *self, PyObject *args, PyObject *kwds)
 {
     _Py_IDENTIFIER(__call__);
-    PyObject *meth = lookup_method(self, &PyId___call__);
+    int unbound;
+    PyObject *meth = lookup_method(self, &PyId___call__, &unbound);
     PyObject *res;
 
     if (meth == NULL)
         return NULL;
 
-    res = PyObject_Call(meth, args, kwds);
+    if (unbound) {
+        res = _PyObject_Call_Prepend(meth, self, args, kwds);
+    }
+    else {
+        res = PyObject_Call(meth, args, kwds);
+    }
 
     Py_DECREF(meth);
     return res;
@@ -6251,7 +6288,8 @@ slot_tp_call(PyObject *self, PyObject *args, PyObject *kwds)
 static PyObject *
 slot_tp_getattro(PyObject *self, PyObject *name)
 {
-    return call_method(self, &PyId___getattribute__, "(O)", name);
+    PyObject *stack[1] = {name};
+    return call_method(self, &PyId___getattribute__, stack, 1);
 }
 
 static PyObject *
@@ -6285,6 +6323,7 @@ slot_tp_getattr_hook(PyObject *self, PyObject *name)
        _PyType_Lookup and create the method only when needed, with
        call_attribute. */
     getattr = _PyType_LookupId(tp, &PyId___getattr__);
+
     if (getattr == NULL) {
         /* No __getattr__ hook: use a simpler dispatcher */
         tp->tp_getattro = slot_tp_getattro;
@@ -6318,14 +6357,19 @@ slot_tp_getattr_hook(PyObject *self, PyObject *name)
 static int
 slot_tp_setattro(PyObject *self, PyObject *name, PyObject *value)
 {
+    PyObject *stack[2];
     PyObject *res;
     _Py_IDENTIFIER(__delattr__);
     _Py_IDENTIFIER(__setattr__);
 
-    if (value == NULL)
-        res = call_method(self, &PyId___delattr__, "(O)", name);
-    else
-        res = call_method(self, &PyId___setattr__, "(OO)", name, value);
+    stack[0] = name;
+    if (value == NULL) {
+        res = call_method(self, &PyId___delattr__, stack, 1);
+    }
+    else {
+        stack[1] = value;
+        res = call_method(self, &PyId___setattr__, stack, 2);
+    }
     if (res == NULL)
         return -1;
     Py_DECREF(res);
@@ -6344,14 +6388,17 @@ static _Py_Identifier name_op[] = {
 static PyObject *
 slot_tp_richcompare(PyObject *self, PyObject *other, int op)
 {
+    int unbound;
     PyObject *func, *res;
 
-    func = lookup_method(self, &name_op[op]);
+    func = lookup_method(self, &name_op[op], &unbound);
     if (func == NULL) {
         PyErr_Clear();
         Py_RETURN_NOTIMPLEMENTED;
     }
-    res = _PyObject_CallArg1(func, other);
+
+    PyObject *args[1] = {other};
+    res = call_unbound(unbound, func, self, args, 1);
     Py_DECREF(func);
     return res;
 }
@@ -6359,10 +6406,11 @@ slot_tp_richcompare(PyObject *self, PyObject *other, int op)
 static PyObject *
 slot_tp_iter(PyObject *self)
 {
+    int unbound;
     PyObject *func, *res;
     _Py_IDENTIFIER(__iter__);
 
-    func = lookup_method(self, &PyId___iter__);
+    func = lookup_method(self, &PyId___iter__, &unbound);
     if (func == Py_None) {
         Py_DECREF(func);
         PyErr_Format(PyExc_TypeError,
@@ -6372,13 +6420,13 @@ slot_tp_iter(PyObject *self)
     }
 
     if (func != NULL) {
-        res = _PyObject_CallNoArg(func);
+        res = call_unbound_noarg(unbound, func, self);
         Py_DECREF(func);
         return res;
     }
 
     PyErr_Clear();
-    func = lookup_method(self, &PyId___getitem__);
+    func = lookup_method(self, &PyId___getitem__, &unbound);
     if (func == NULL) {
         PyErr_Format(PyExc_TypeError,
                      "'%.200s' object is not iterable",
@@ -6393,7 +6441,7 @@ static PyObject *
 slot_tp_iternext(PyObject *self)
 {
     _Py_IDENTIFIER(__next__);
-    return call_method(self, &PyId___next__, NULL);
+    return call_method(self, &PyId___next__, NULL, 0);
 }
 
 static PyObject *
@@ -6421,14 +6469,19 @@ slot_tp_descr_get(PyObject *self, PyObject *obj, PyObject *type)
 static int
 slot_tp_descr_set(PyObject *self, PyObject *target, PyObject *value)
 {
+    PyObject* stack[2];
     PyObject *res;
     _Py_IDENTIFIER(__delete__);
     _Py_IDENTIFIER(__set__);
 
-    if (value == NULL)
-        res = call_method(self, &PyId___delete__, "(O)", target);
-    else
-        res = call_method(self, &PyId___set__, "(OO)", target, value);
+    stack[0] = target;
+    if (value == NULL) {
+        res = call_method(self, &PyId___delete__, stack, 1);
+    }
+    else {
+        stack[1] = value;
+        res = call_method(self, &PyId___set__, stack, 2);
+    }
     if (res == NULL)
         return -1;
     Py_DECREF(res);
@@ -6439,12 +6492,18 @@ static int
 slot_tp_init(PyObject *self, PyObject *args, PyObject *kwds)
 {
     _Py_IDENTIFIER(__init__);
-    PyObject *meth = lookup_method(self, &PyId___init__);
+    int unbound;
+    PyObject *meth = lookup_method(self, &PyId___init__, &unbound);
     PyObject *res;
 
     if (meth == NULL)
         return -1;
-    res = PyObject_Call(meth, args, kwds);
+    if (unbound) {
+        res = _PyObject_Call_Prepend(meth, self, args, kwds);
+    }
+    else {
+        res = PyObject_Call(meth, args, kwds);
+    }
     Py_DECREF(meth);
     if (res == NULL)
         return -1;
@@ -6478,6 +6537,7 @@ static void
 slot_tp_finalize(PyObject *self)
 {
     _Py_IDENTIFIER(__del__);
+    int unbound;
     PyObject *del, *res;
     PyObject *error_type, *error_value, *error_traceback;
 
@@ -6485,9 +6545,9 @@ slot_tp_finalize(PyObject *self)
     PyErr_Fetch(&error_type, &error_value, &error_traceback);
 
     /* Execute __del__ method, if any. */
-    del = lookup_maybe(self, &PyId___del__);
+    del = lookup_maybe_method(self, &PyId___del__, &unbound);
     if (del != NULL) {
-        res = PyEval_CallObject(del, NULL);
+        res = call_unbound_noarg(unbound, del, self);
         if (res == NULL)
             PyErr_WriteUnraisable(del);
         else
@@ -6502,12 +6562,13 @@ slot_tp_finalize(PyObject *self)
 static PyObject *
 slot_am_await(PyObject *self)
 {
+    int unbound;
     PyObject *func, *res;
     _Py_IDENTIFIER(__await__);
 
-    func = lookup_method(self, &PyId___await__);
+    func = lookup_method(self, &PyId___await__, &unbound);
     if (func != NULL) {
-        res = PyEval_CallObject(func, NULL);
+        res = call_unbound_noarg(unbound, func, self);
         Py_DECREF(func);
         return res;
     }
@@ -6520,12 +6581,13 @@ slot_am_await(PyObject *self)
 static PyObject *
 slot_am_aiter(PyObject *self)
 {
+    int unbound;
     PyObject *func, *res;
     _Py_IDENTIFIER(__aiter__);
 
-    func = lookup_method(self, &PyId___aiter__);
+    func = lookup_method(self, &PyId___aiter__, &unbound);
     if (func != NULL) {
-        res = PyEval_CallObject(func, NULL);
+        res = call_unbound_noarg(unbound, func, self);
         Py_DECREF(func);
         return res;
     }
@@ -6538,12 +6600,13 @@ slot_am_aiter(PyObject *self)
 static PyObject *
 slot_am_anext(PyObject *self)
 {
+    int unbound;
     PyObject *func, *res;
     _Py_IDENTIFIER(__anext__);
 
-    func = lookup_method(self, &PyId___anext__);
+    func = lookup_method(self, &PyId___anext__, &unbound);
     if (func != NULL) {
-        res = PyEval_CallObject(func, NULL);
+        res = call_unbound_noarg(unbound, func, self);
         Py_DECREF(func);
         return res;
     }
@@ -6623,7 +6686,7 @@ static slotdef slotdefs[] = {
            "__repr__($self, /)\n--\n\nReturn repr(self)."),
     TPSLOT("__hash__", tp_hash, slot_tp_hash, wrap_hashfunc,
            "__hash__($self, /)\n--\n\nReturn hash(self)."),
-    FLSLOT("__call__", tp_call, slot_tp_call, (wrapperfunc)(void(*)(void))wrap_call,
+    FLSLOT("__call__", tp_call, slot_tp_call, (wrapperfunc)wrap_call,
            "__call__($self, /, *args, **kwargs)\n--\n\nCall self as a function.",
            PyWrapperFlag_KEYWORDS),
     TPSLOT("__str__", tp_str, slot_tp_str, wrap_unaryfunc,
@@ -6659,7 +6722,7 @@ static slotdef slotdefs[] = {
     TPSLOT("__delete__", tp_descr_set, slot_tp_descr_set,
            wrap_descr_delete,
            "__delete__($self, instance, /)\n--\n\nDelete an attribute of instance."),
-    FLSLOT("__init__", tp_init, slot_tp_init, (wrapperfunc)(void(*)(void))wrap_init,
+    FLSLOT("__init__", tp_init, slot_tp_init, (wrapperfunc)wrap_init,
            "__init__($self, /, *args, **kwargs)\n--\n\n"
            "Initialize self.  See help(type(self)) for accurate signature.",
            PyWrapperFlag_KEYWORDS),
@@ -6780,9 +6843,9 @@ static slotdef slotdefs[] = {
     SQSLOT("__add__", sq_concat, NULL, wrap_binaryfunc,
            "__add__($self, value, /)\n--\n\nReturn self+value."),
     SQSLOT("__mul__", sq_repeat, NULL, wrap_indexargfunc,
-           "__mul__($self, value, /)\n--\n\nReturn self*value."),
+           "__mul__($self, value, /)\n--\n\nReturn self*value.n"),
     SQSLOT("__rmul__", sq_repeat, NULL, wrap_indexargfunc,
-           "__rmul__($self, value, /)\n--\n\nReturn value*self."),
+           "__rmul__($self, value, /)\n--\n\nReturn self*value."),
     SQSLOT("__getitem__", sq_item, slot_sq_item, wrap_sq_item,
            "__getitem__($self, key, /)\n--\n\nReturn self[key]."),
     SQSLOT("__setitem__", sq_ass_item, slot_sq_ass_item, wrap_sq_setitem,
@@ -6996,7 +7059,7 @@ init_slotdefs(void)
         /* Slots must be ordered by their offset in the PyHeapTypeObject. */
         assert(!p[1].name || p->offset <= p[1].offset);
         p->name_strobj = PyUnicode_InternFromString(p->name);
-        if (!p->name_strobj || !PyUnicode_CHECK_INTERNED(p->name_strobj))
+        if (!p->name_strobj)
             Py_FatalError("Out of memory interning slotdef names");
     }
     slotdefs_initialized = 1;
@@ -7021,9 +7084,6 @@ update_slot(PyTypeObject *type, PyObject *name)
     slotdef **pp;
     int offset;
 
-    assert(PyUnicode_CheckExact(name));
-    assert(PyUnicode_CHECK_INTERNED(name));
-
     /* Clear the VALID_VERSION flag of 'type' and all its
        subclasses.  This could possibly be unified with the
        update_subclasses() recursion below, but carefully:
@@ -7034,6 +7094,7 @@ update_slot(PyTypeObject *type, PyObject *name)
     init_slotdefs();
     pp = ptrs;
     for (p = slotdefs; p->name; p++) {
+        /* XXX assume name is interned! */
         if (p->name_strobj == name)
             *pp++ = p;
     }

--- a/third_party/python/Objects/typeobject.c
+++ b/third_party/python/Objects/typeobject.c
@@ -3216,7 +3216,8 @@ type_subclasses(PyTypeObject *type, PyObject *args_ignored)
 }
 
 static PyObject *
-type_prepare(PyObject *self, PyObject *args, PyObject *kwds)
+type_prepare(PyObject *self, PyObject **args, Py_ssize_t nargs, 
+             PyObject *kwnames)
 {
     return PyDict_New();
 }
@@ -3320,7 +3321,7 @@ static PyMethodDef type_methods[] = {
     {"__subclasses__", (PyCFunction)type_subclasses, METH_NOARGS,
      PyDoc_STR("__subclasses__() -> list of immediate subclasses")},
     {"__prepare__", (PyCFunction)type_prepare,
-     METH_VARARGS | METH_KEYWORDS | METH_CLASS,
+     METH_FASTCALL | METH_CLASS,
      PyDoc_STR("__prepare__() -> dict\n"
                "used to create the namespace for the class statement")},
     {"__instancecheck__", type___instancecheck__, METH_O,

--- a/third_party/python/Python/bltinmodule.c
+++ b/third_party/python/Python/bltinmodule.c
@@ -1936,18 +1936,19 @@ builtin_pow_impl(PyObject *module, PyObject *x, PyObject *y, PyObject *z)
 
 /* AC: cannot convert yet, waiting for *args support */
 static PyObject *
-builtin_print(PyObject *self, PyObject *args, PyObject *kwds)
+builtin_print(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
-    static char *kwlist[] = {"sep", "end", "file", "flush", 0};
-    static PyObject *dummy_args;
+    static const char * const _keywords[] = {"sep", "end", "file", "flush", 0};
+    static struct _PyArg_Parser _parser = {"|OOOO:print", _keywords, 0};
     PyObject *sep = NULL, *end = NULL, *file = NULL, *flush = NULL;
     int i, err;
 
-    if (dummy_args == NULL && !(dummy_args = PyTuple_New(0)))
+    if (kwnames != NULL &&
+            !_PyArg_ParseStackAndKeywords(args + nargs, 0, kwnames, &_parser,
+                                          &sep, &end, &file, &flush)) {
         return NULL;
-    if (!PyArg_ParseTupleAndKeywords(dummy_args, kwds, "|OOOO:print",
-                                     kwlist, &sep, &end, &file, &flush))
-        return NULL;
+    }
+
     if (file == NULL || file == Py_None) {
         file = _PySys_GetObjectId(&PyId_stdout);
         if (file == NULL) {
@@ -1979,7 +1980,7 @@ builtin_print(PyObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
-    for (i = 0; i < PyTuple_Size(args); i++) {
+    for (i = 0; i < nargs; i++) {
         if (i > 0) {
             if (sep == NULL)
                 err = PyFile_WriteString(" ", file);
@@ -1989,8 +1990,7 @@ builtin_print(PyObject *self, PyObject *args, PyObject *kwds)
             if (err)
                 return NULL;
         }
-        err = PyFile_WriteObject(PyTuple_GetItem(args, i), file,
-                                 Py_PRINT_RAW);
+        err = PyFile_WriteObject(args[i], file, Py_PRINT_RAW);
         if (err)
             return NULL;
     }
@@ -2854,7 +2854,7 @@ static PyMethodDef builtin_methods[] = {
     BUILTIN_OCT_METHODDEF
     BUILTIN_ORD_METHODDEF
     BUILTIN_POW_METHODDEF
-    {"print",           (PyCFunction)builtin_print,      METH_VARARGS | METH_KEYWORDS, print_doc},
+    {"print",           (PyCFunction)builtin_print,      METH_FASTCALL, print_doc},
     BUILTIN_REPR_METHODDEF
     {"round",           (PyCFunction)builtin_round,      METH_VARARGS | METH_KEYWORDS, round_doc},
     BUILTIN_SETATTR_METHODDEF

--- a/third_party/python/Python/bltinmodule.c
+++ b/third_party/python/Python/bltinmodule.c
@@ -239,51 +239,45 @@ _Py_IDENTIFIER(stderr);
 
 /* AC: cannot convert yet, waiting for *args support */
 static PyObject *
-builtin___build_class__(PyObject *self, PyObject *args, PyObject *kwds)
+builtin___build_class__(PyObject *self, PyObject **args, Py_ssize_t nargs,
+                        PyObject *kwnames)
 {
     PyObject *func, *name, *bases, *mkw, *meta, *winner, *prep, *ns;
     PyObject *cls = NULL, *cell = NULL;
-    Py_ssize_t nargs;
     int isclass = 0;   /* initialize to prevent gcc warning */
 
-    assert(args != NULL);
-    if (!PyTuple_Check(args)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "__build_class__: args is not a tuple");
-        return NULL;
-    }
-    nargs = PyTuple_GET_SIZE(args);
     if (nargs < 2) {
         PyErr_SetString(PyExc_TypeError,
                         "__build_class__: not enough arguments");
         return NULL;
     }
-    func = PyTuple_GET_ITEM(args, 0); /* Better be callable */
+    func = args[0];   /* Better be callable */
     if (!PyFunction_Check(func)) {
         PyErr_SetString(PyExc_TypeError,
                         "__build_class__: func must be a function");
         return NULL;
     }
-    name = PyTuple_GET_ITEM(args, 1);
+    name = args[1];
     if (!PyUnicode_Check(name)) {
         PyErr_SetString(PyExc_TypeError,
                         "__build_class__: name is not a string");
         return NULL;
     }
-    bases = PyTuple_GetSlice(args, 2, nargs);
+    bases = _PyStack_AsTupleSlice(args, nargs, 2, nargs);
     if (bases == NULL)
         return NULL;
 
-    if (kwds == NULL) {
+    if (kwnames == NULL) {
         meta = NULL;
         mkw = NULL;
     }
     else {
-        mkw = PyDict_Copy(kwds); /* Don't modify kwds passed in! */
+        mkw = _PyStack_AsDict(args + nargs, kwnames);
         if (mkw == NULL) {
             Py_DECREF(bases);
             return NULL;
         }
+
         meta = _PyDict_GetItemId(mkw, &PyId_metaclass);
         if (meta != NULL) {
             Py_INCREF(meta);
@@ -353,13 +347,6 @@ builtin___build_class__(PyObject *self, PyObject *args, PyObject *kwds)
         Py_XDECREF(mkw);
         Py_DECREF(bases);
         return NULL;
-    }
-    if (!PyMapping_Check(ns)) {
-        PyErr_Format(PyExc_TypeError,
-                     "%.200s.__prepare__() must return a mapping, not %.200s",
-                     isclass ? ((PyTypeObject *)meta)->tp_name : "<metaclass>",
-                     Py_TYPE(ns)->tp_name);
-        goto error;
     }
     cell = PyEval_EvalCodeEx(PyFunction_GET_CODE(func), PyFunction_GET_GLOBALS(func), ns,
                              NULL, 0, NULL, 0, NULL, 0, NULL,
@@ -2825,7 +2812,7 @@ PyTypeObject PyZip_Type = {
 
 static PyMethodDef builtin_methods[] = {
     {"__build_class__", (PyCFunction)builtin___build_class__,
-     METH_VARARGS | METH_KEYWORDS, build_class_doc},
+     METH_FASTCALL, build_class_doc},
     {"__import__",      (PyCFunction)builtin___import__, METH_VARARGS | METH_KEYWORDS, import_doc},
     BUILTIN_ABS_METHODDEF
     BUILTIN_ALL_METHODDEF

--- a/third_party/python/Python/bltinmodule.c
+++ b/third_party/python/Python/bltinmodule.c
@@ -406,15 +406,16 @@ PyDoc_STRVAR(build_class_doc,
 Internal helper function used by the class statement.");
 
 static PyObject *
-builtin___import__(PyObject *self, PyObject *args, PyObject *kwds)
+builtin___import__(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwds)
 {
-    static char *kwlist[] = {"name", "globals", "locals", "fromlist",
+    static const char * const kwlist[] = {"name", "globals", "locals", "fromlist",
                              "level", 0};
     PyObject *name, *globals = NULL, *locals = NULL, *fromlist = NULL;
     int level = 0;
+    static _PyArg_Parser _parser = {"U|OOOi:__import__", kwlist, 0};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "U|OOOi:__import__",
-                    kwlist, &name, &globals, &locals, &fromlist, &level))
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwds, &_parser,
+                    &name, &globals, &locals, &fromlist, &level))
         return NULL;
     return PyImport_ImportModuleLevelObject(name, globals, locals,
                                             fromlist, level);
@@ -973,11 +974,13 @@ finally:
 
 /* AC: cannot convert yet, as needs PEP 457 group support in inspect */
 static PyObject *
-builtin_dir(PyObject *self, PyObject *args)
+builtin_dir(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *arg = NULL;
 
-    if (!PyArg_UnpackTuple(args, "dir", 0, 1, &arg))
+    if (!_PyArg_UnpackStack(args, nargs, "dir", 0, 1, &arg))
+        return NULL;
+    if (!_PyArg_NoStackKeywords("dir", kwnames))
         return NULL;
     return PyObject_Dir(arg);
 }
@@ -1640,11 +1643,13 @@ builtin_hex(PyObject *module, PyObject *number)
 
 /* AC: cannot convert yet, as needs PEP 457 group support in inspect */
 static PyObject *
-builtin_iter(PyObject *self, PyObject *args)
+builtin_iter(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *v, *w = NULL;
 
-    if (!PyArg_UnpackTuple(args, "iter", 1, 2, &v, &w))
+    if (!_PyArg_UnpackStack(args, nargs, "iter", 1, 2, &v, &w))
+        return NULL;
+    if(!_PyArg_NoStackKeywords("iter", kwnames))
         return NULL;
     if (w == NULL)
         return PyObject_GetIter(v);
@@ -2367,12 +2372,14 @@ builtin_sorted(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwna
 
 /* AC: cannot convert yet, as needs PEP 457 group support in inspect */
 static PyObject *
-builtin_vars(PyObject *self, PyObject *args)
+builtin_vars(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *v = NULL;
     PyObject *d;
 
-    if (!PyArg_UnpackTuple(args, "vars", 0, 1, &v))
+    if (!_PyArg_UnpackStack(args, nargs, "vars", 0, 1, &v))
+        return NULL;
+    if(!_PyArg_NoStackKeywords("vars", kwnames))
         return NULL;
     if (v == NULL) {
         d = PyEval_GetLocals();
@@ -2828,7 +2835,7 @@ PyTypeObject PyZip_Type = {
 static PyMethodDef builtin_methods[] = {
     {"__build_class__", (PyCFunction)builtin___build_class__,
      METH_FASTCALL, build_class_doc},
-    {"__import__",      (PyCFunction)builtin___import__, METH_VARARGS | METH_KEYWORDS, import_doc},
+    {"__import__",      (PyCFunction)builtin___import__, METH_FASTCALL, import_doc},
     BUILTIN_ABS_METHODDEF
     BUILTIN_ALL_METHODDEF
     BUILTIN_ANY_METHODDEF
@@ -2838,7 +2845,7 @@ static PyMethodDef builtin_methods[] = {
     BUILTIN_CHR_METHODDEF
     BUILTIN_COMPILE_METHODDEF
     BUILTIN_DELATTR_METHODDEF
-    {"dir",             builtin_dir,        METH_VARARGS, dir_doc},
+    {"dir",             (PyCFunction)builtin_dir,        METH_FASTCALL, dir_doc},
     BUILTIN_DIVMOD_METHODDEF
     BUILTIN_EVAL_METHODDEF
     BUILTIN_EXEC_METHODDEF
@@ -2852,7 +2859,7 @@ static PyMethodDef builtin_methods[] = {
     BUILTIN_INPUT_METHODDEF
     BUILTIN_ISINSTANCE_METHODDEF
     BUILTIN_ISSUBCLASS_METHODDEF
-    {"iter",            builtin_iter,       METH_VARARGS, iter_doc},
+    {"iter",            (PyCFunction)builtin_iter,       METH_FASTCALL, iter_doc},
     BUILTIN_LEN_METHODDEF
     BUILTIN_LOCALS_METHODDEF
     {"max",             (PyCFunction)builtin_max,        METH_VARARGS | METH_KEYWORDS, max_doc},
@@ -2867,7 +2874,7 @@ static PyMethodDef builtin_methods[] = {
     BUILTIN_SETATTR_METHODDEF
     BUILTIN_SORTED_METHODDEF
     BUILTIN_SUM_METHODDEF
-    {"vars",            builtin_vars,       METH_VARARGS, vars_doc},
+    {"vars",            (PyCFunction)builtin_vars,       METH_FASTCALL, vars_doc},
     {NULL,              NULL},
 };
 

--- a/third_party/python/Python/bltinmodule.c
+++ b/third_party/python/Python/bltinmodule.c
@@ -348,6 +348,13 @@ builtin___build_class__(PyObject *self, PyObject **args, Py_ssize_t nargs,
         Py_DECREF(bases);
         return NULL;
     }
+    if (!PyMapping_Check(ns)) {
+        PyErr_Format(PyExc_TypeError,
+                     "%.200s.__prepare__() must return a mapping, not %.200s",
+                     isclass ? ((PyTypeObject *)meta)->tp_name : "<metaclass>",
+                     Py_TYPE(ns)->tp_name);
+        goto error;
+    }
     cell = PyEval_EvalCodeEx(PyFunction_GET_CODE(func), PyFunction_GET_GLOBALS(func), ns,
                              NULL, 0, NULL, 0, NULL, 0, NULL,
                              PyFunction_GET_CLOSURE(func));

--- a/third_party/python/Python/clinic/bltinmodule.inc
+++ b/third_party/python/Python/clinic/bltinmodule.inc
@@ -1,11 +1,4 @@
-/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:4;tab-width:8;coding:utf-8 -*-│
-│vi: set net ft=c ts=4 sts=4 sw=4 fenc=utf-8                                :vi│
-╞══════════════════════════════════════════════════════════════════════════════╡
-│ Python 3                                                                     │
-│ https://docs.python.org/3/license.html                                       │
-╚─────────────────────────────────────────────────────────────────────────────*/
 /* clang-format off */
-
 /*[clinic input]
 preserve
 [clinic start generated code]*/
@@ -90,20 +83,24 @@ PyDoc_STRVAR(builtin_format__doc__,
 "details.");
 
 #define BUILTIN_FORMAT_METHODDEF    \
-    {"format", (PyCFunction)builtin_format, METH_VARARGS, builtin_format__doc__},
+    {"format", (PyCFunction)builtin_format, METH_FASTCALL, builtin_format__doc__},
 
 static PyObject *
 builtin_format_impl(PyObject *module, PyObject *value, PyObject *format_spec);
 
 static PyObject *
-builtin_format(PyObject *module, PyObject *args)
+builtin_format(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *value;
     PyObject *format_spec = NULL;
 
-    if (!PyArg_ParseTuple(args, "O|U:format",
+    if (!_PyArg_ParseStack(args, nargs, "O|U:format",
         &value, &format_spec)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("format", kwnames)) {
         goto exit;
     }
     return_value = builtin_format_impl(module, value, format_spec);
@@ -127,9 +124,16 @@ builtin_chr_impl(PyObject *module, int i);
 static PyObject *
 builtin_chr(PyObject *module, PyObject *arg)
 {
+    PyObject *return_value = NULL;
     int i;
-    if (!PyArg_Parse(arg, "i:chr", &i)) return 0;
-    return builtin_chr_impl(module, i);
+
+    if (!PyArg_Parse(arg, "i:chr", &i)) {
+        goto exit;
+    }
+    return_value = builtin_chr_impl(module, i);
+
+exit:
+    return return_value;
 }
 
 PyDoc_STRVAR(builtin_compile__doc__,
@@ -677,4 +681,4 @@ builtin_issubclass(PyObject *module, PyObject *args)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=2ef82846acdfa0f5 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c0201eb152977af0 input=a9049054013a1b77]*/

--- a/third_party/python/Python/clinic/bltinmodule.inc
+++ b/third_party/python/Python/clinic/bltinmodule.inc
@@ -171,7 +171,7 @@ builtin_compile(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *k
     int dont_inherit = 0;
     int optimize = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &source, PyUnicode_FSDecoder, &filename, &mode, &flags, &dont_inherit, &optimize)) {
         goto exit;
     }

--- a/third_party/python/Python/clinic/bltinmodule.inc
+++ b/third_party/python/Python/clinic/bltinmodule.inc
@@ -192,21 +192,25 @@ PyDoc_STRVAR(builtin_divmod__doc__,
 "Return the tuple (x//y, x%y).  Invariant: div*y + mod == x.");
 
 #define BUILTIN_DIVMOD_METHODDEF    \
-    {"divmod", (PyCFunction)builtin_divmod, METH_VARARGS, builtin_divmod__doc__},
+    {"divmod", (PyCFunction)builtin_divmod, METH_FASTCALL, builtin_divmod__doc__},
 
 static PyObject *
 builtin_divmod_impl(PyObject *module, PyObject *x, PyObject *y);
 
 static PyObject *
-builtin_divmod(PyObject *module, PyObject *args)
+builtin_divmod(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *x;
     PyObject *y;
 
-    if (!PyArg_UnpackTuple(args, "divmod",
+    if (!_PyArg_UnpackStack(args, nargs, "divmod",
         2, 2,
         &x, &y)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("divmod", kwnames)) {
         goto exit;
     }
     return_value = builtin_divmod_impl(module, x, y);
@@ -228,23 +232,27 @@ PyDoc_STRVAR(builtin_eval__doc__,
 "If only globals is given, locals defaults to it.");
 
 #define BUILTIN_EVAL_METHODDEF    \
-    {"eval", (PyCFunction)builtin_eval, METH_VARARGS, builtin_eval__doc__},
+    {"eval", (PyCFunction)builtin_eval, METH_FASTCALL, builtin_eval__doc__},
 
 static PyObject *
 builtin_eval_impl(PyObject *module, PyObject *source, PyObject *globals,
                   PyObject *locals);
 
 static PyObject *
-builtin_eval(PyObject *module, PyObject *args)
+builtin_eval(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *source;
     PyObject *globals = Py_None;
     PyObject *locals = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "eval",
+    if (!_PyArg_UnpackStack(args, nargs, "eval",
         1, 3,
         &source, &globals, &locals)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("eval", kwnames)) {
         goto exit;
     }
     return_value = builtin_eval_impl(module, source, globals, locals);
@@ -266,23 +274,27 @@ PyDoc_STRVAR(builtin_exec__doc__,
 "If only globals is given, locals defaults to it.");
 
 #define BUILTIN_EXEC_METHODDEF    \
-    {"exec", (PyCFunction)builtin_exec, METH_VARARGS, builtin_exec__doc__},
+    {"exec", (PyCFunction)builtin_exec, METH_FASTCALL, builtin_exec__doc__},
 
 static PyObject *
 builtin_exec_impl(PyObject *module, PyObject *source, PyObject *globals,
                   PyObject *locals);
 
 static PyObject *
-builtin_exec(PyObject *module, PyObject *args)
+builtin_exec(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *source;
     PyObject *globals = Py_None;
     PyObject *locals = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "exec",
+    if (!_PyArg_UnpackStack(args, nargs, "exec",
         1, 3,
         &source, &globals, &locals)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("exec", kwnames)) {
         goto exit;
     }
     return_value = builtin_exec_impl(module, source, globals, locals);
@@ -321,21 +333,25 @@ PyDoc_STRVAR(builtin_hasattr__doc__,
 "This is done by calling getattr(obj, name) and catching AttributeError.");
 
 #define BUILTIN_HASATTR_METHODDEF    \
-    {"hasattr", (PyCFunction)builtin_hasattr, METH_VARARGS, builtin_hasattr__doc__},
+    {"hasattr", (PyCFunction)builtin_hasattr, METH_FASTCALL, builtin_hasattr__doc__},
 
 static PyObject *
 builtin_hasattr_impl(PyObject *module, PyObject *obj, PyObject *name);
 
 static PyObject *
-builtin_hasattr(PyObject *module, PyObject *args)
+builtin_hasattr(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *obj;
     PyObject *name;
 
-    if (!PyArg_UnpackTuple(args, "hasattr",
+    if (!_PyArg_UnpackStack(args, nargs, "hasattr",
         2, 2,
         &obj, &name)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("hasattr", kwnames)) {
         goto exit;
     }
     return_value = builtin_hasattr_impl(module, obj, name);
@@ -365,23 +381,27 @@ PyDoc_STRVAR(builtin_setattr__doc__,
 "setattr(x, \'y\', v) is equivalent to ``x.y = v\'\'");
 
 #define BUILTIN_SETATTR_METHODDEF    \
-    {"setattr", (PyCFunction)builtin_setattr, METH_VARARGS, builtin_setattr__doc__},
+    {"setattr", (PyCFunction)builtin_setattr, METH_FASTCALL, builtin_setattr__doc__},
 
 static PyObject *
 builtin_setattr_impl(PyObject *module, PyObject *obj, PyObject *name,
                      PyObject *value);
 
 static PyObject *
-builtin_setattr(PyObject *module, PyObject *args)
+builtin_setattr(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *obj;
     PyObject *name;
     PyObject *value;
 
-    if (!PyArg_UnpackTuple(args, "setattr",
+    if (!_PyArg_UnpackStack(args, nargs, "setattr",
         3, 3,
         &obj, &name, &value)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("setattr", kwnames)) {
         goto exit;
     }
     return_value = builtin_setattr_impl(module, obj, name, value);
@@ -399,21 +419,25 @@ PyDoc_STRVAR(builtin_delattr__doc__,
 "delattr(x, \'y\') is equivalent to ``del x.y\'\'");
 
 #define BUILTIN_DELATTR_METHODDEF    \
-    {"delattr", (PyCFunction)builtin_delattr, METH_VARARGS, builtin_delattr__doc__},
+    {"delattr", (PyCFunction)builtin_delattr, METH_FASTCALL, builtin_delattr__doc__},
 
 static PyObject *
 builtin_delattr_impl(PyObject *module, PyObject *obj, PyObject *name);
 
 static PyObject *
-builtin_delattr(PyObject *module, PyObject *args)
+builtin_delattr(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *obj;
     PyObject *name;
 
-    if (!PyArg_UnpackTuple(args, "delattr",
+    if (!_PyArg_UnpackStack(args, nargs, "delattr",
         2, 2,
         &obj, &name)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("delattr", kwnames)) {
         goto exit;
     }
     return_value = builtin_delattr_impl(module, obj, name);
@@ -508,22 +532,26 @@ PyDoc_STRVAR(builtin_pow__doc__,
 "invoked using the three argument form.");
 
 #define BUILTIN_POW_METHODDEF    \
-    {"pow", (PyCFunction)builtin_pow, METH_VARARGS, builtin_pow__doc__},
+    {"pow", (PyCFunction)builtin_pow, METH_FASTCALL, builtin_pow__doc__},
 
 static PyObject *
 builtin_pow_impl(PyObject *module, PyObject *x, PyObject *y, PyObject *z);
 
 static PyObject *
-builtin_pow(PyObject *module, PyObject *args)
+builtin_pow(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *x;
     PyObject *y;
     PyObject *z = Py_None;
 
-    if (!PyArg_UnpackTuple(args, "pow",
+    if (!_PyArg_UnpackStack(args, nargs, "pow",
         2, 3,
         &x, &y, &z)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("pow", kwnames)) {
         goto exit;
     }
     return_value = builtin_pow_impl(module, x, y, z);
@@ -545,20 +573,24 @@ PyDoc_STRVAR(builtin_input__doc__,
 "On *nix systems, readline is used if available.");
 
 #define BUILTIN_INPUT_METHODDEF    \
-    {"input", (PyCFunction)builtin_input, METH_VARARGS, builtin_input__doc__},
+    {"input", (PyCFunction)builtin_input, METH_FASTCALL, builtin_input__doc__},
 
 static PyObject *
 builtin_input_impl(PyObject *module, PyObject *prompt);
 
 static PyObject *
-builtin_input(PyObject *module, PyObject *args)
+builtin_input(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *prompt = NULL;
 
-    if (!PyArg_UnpackTuple(args, "input",
+    if (!_PyArg_UnpackStack(args, nargs, "input",
         0, 1,
         &prompt)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("input", kwnames)) {
         goto exit;
     }
     return_value = builtin_input_impl(module, prompt);
@@ -589,21 +621,25 @@ PyDoc_STRVAR(builtin_sum__doc__,
 "reject non-numeric types.");
 
 #define BUILTIN_SUM_METHODDEF    \
-    {"sum", (PyCFunction)builtin_sum, METH_VARARGS, builtin_sum__doc__},
+    {"sum", (PyCFunction)builtin_sum, METH_FASTCALL, builtin_sum__doc__},
 
 static PyObject *
 builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start);
 
 static PyObject *
-builtin_sum(PyObject *module, PyObject *args)
+builtin_sum(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *iterable;
     PyObject *start = NULL;
 
-    if (!PyArg_UnpackTuple(args, "sum",
+    if (!_PyArg_UnpackStack(args, nargs, "sum",
         1, 2,
         &iterable, &start)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("sum", kwnames)) {
         goto exit;
     }
     return_value = builtin_sum_impl(module, iterable, start);
@@ -623,22 +659,26 @@ PyDoc_STRVAR(builtin_isinstance__doc__,
 "or ...`` etc.");
 
 #define BUILTIN_ISINSTANCE_METHODDEF    \
-    {"isinstance", (PyCFunction)builtin_isinstance, METH_VARARGS, builtin_isinstance__doc__},
+    {"isinstance", (PyCFunction)builtin_isinstance, METH_FASTCALL, builtin_isinstance__doc__},
 
 static PyObject *
 builtin_isinstance_impl(PyObject *module, PyObject *obj,
                         PyObject *class_or_tuple);
 
 static PyObject *
-builtin_isinstance(PyObject *module, PyObject *args)
+builtin_isinstance(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *obj;
     PyObject *class_or_tuple;
 
-    if (!PyArg_UnpackTuple(args, "isinstance",
+    if (!_PyArg_UnpackStack(args, nargs, "isinstance",
         2, 2,
         &obj, &class_or_tuple)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("isinstance", kwnames)) {
         goto exit;
     }
     return_value = builtin_isinstance_impl(module, obj, class_or_tuple);
@@ -658,22 +698,26 @@ PyDoc_STRVAR(builtin_issubclass__doc__,
 "or ...`` etc.");
 
 #define BUILTIN_ISSUBCLASS_METHODDEF    \
-    {"issubclass", (PyCFunction)builtin_issubclass, METH_VARARGS, builtin_issubclass__doc__},
+    {"issubclass", (PyCFunction)builtin_issubclass, METH_FASTCALL, builtin_issubclass__doc__},
 
 static PyObject *
 builtin_issubclass_impl(PyObject *module, PyObject *cls,
                         PyObject *class_or_tuple);
 
 static PyObject *
-builtin_issubclass(PyObject *module, PyObject *args)
+builtin_issubclass(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *cls;
     PyObject *class_or_tuple;
 
-    if (!PyArg_UnpackTuple(args, "issubclass",
+    if (!_PyArg_UnpackStack(args, nargs, "issubclass",
         2, 2,
         &cls, &class_or_tuple)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("issubclass", kwnames)) {
         goto exit;
     }
     return_value = builtin_issubclass_impl(module, cls, class_or_tuple);
@@ -681,4 +725,4 @@ builtin_issubclass(PyObject *module, PyObject *args)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=c0201eb152977af0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=17fedd2dec148677 input=a9049054013a1b77]*/

--- a/third_party/python/Python/clinic/import.inc
+++ b/third_party/python/Python/clinic/import.inc
@@ -274,21 +274,25 @@ PyDoc_STRVAR(_imp_create_dynamic__doc__,
 "Create an extension module.");
 
 #define _IMP_CREATE_DYNAMIC_METHODDEF    \
-    {"create_dynamic", (PyCFunction)_imp_create_dynamic, METH_VARARGS, _imp_create_dynamic__doc__},
+    {"create_dynamic", (PyCFunction)_imp_create_dynamic, METH_FASTCALL, _imp_create_dynamic__doc__},
 
 static PyObject *
 _imp_create_dynamic_impl(PyObject *module, PyObject *spec, PyObject *file);
 
 static PyObject *
-_imp_create_dynamic(PyObject *module, PyObject *args)
+_imp_create_dynamic(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     PyObject *spec;
     PyObject *file = NULL;
 
-    if (!PyArg_UnpackTuple(args, "create_dynamic",
+    if (!_PyArg_UnpackStack(args, nargs, "create_dynamic",
         1, 2,
         &spec, &file)) {
+        goto exit;
+    }
+
+    if (!_PyArg_NoStackKeywords("create_dynamic", kwnames)) {
         goto exit;
     }
     return_value = _imp_create_dynamic_impl(module, spec, file);
@@ -366,4 +370,4 @@ exit:
 #ifndef _IMP_EXEC_DYNAMIC_METHODDEF
     #define _IMP_EXEC_DYNAMIC_METHODDEF
 #endif /* !defined(_IMP_EXEC_DYNAMIC_METHODDEF) */
-/*[clinic end generated code: output=5a3f012344950548 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c1d0e65d04114958 input=a9049054013a1b77]*/

--- a/third_party/python/Python/clinic/import.inc
+++ b/third_party/python/Python/clinic/import.inc
@@ -1,348 +1,369 @@
-/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:4;tab-width:8;coding:utf-8 -*-│
-│vi: set net ft=c ts=4 sts=4 sw=4 fenc=utf-8                                :vi│
-╞══════════════════════════════════════════════════════════════════════════════╡
-│ Python 3                                                                     │
-│ https://docs.python.org/3/license.html                                       │
-╚─────────────────────────────────────────────────────────────────────────────*/
-#include "third_party/python/Include/pymacro.h"
-
+/* clang-format off */
 /*[clinic input]
 preserve
 [clinic start generated code]*/
 
 PyDoc_STRVAR(_imp_lock_held__doc__,
-             "lock_held($module, /)\n"
-             "--\n"
-             "\n"
-             "Return True if the import lock is currently held, else False.\n"
-             "\n"
-             "On platforms without threads, return False.");
+"lock_held($module, /)\n"
+"--\n"
+"\n"
+"Return True if the import lock is currently held, else False.\n"
+"\n"
+"On platforms without threads, return False.");
 
-#define _IMP_LOCK_HELD_METHODDEF                          \
-  {"lock_held", (PyCFunction)_imp_lock_held, METH_NOARGS, \
-   _imp_lock_held__doc__},
+#define _IMP_LOCK_HELD_METHODDEF    \
+    {"lock_held", (PyCFunction)_imp_lock_held, METH_NOARGS, _imp_lock_held__doc__},
 
-static PyObject *_imp_lock_held_impl(PyObject *module);
+static PyObject *
+_imp_lock_held_impl(PyObject *module);
 
-static PyObject *_imp_lock_held(PyObject *module,
-                                PyObject *Py_UNUSED(ignored)) {
-  return _imp_lock_held_impl(module);
+static PyObject *
+_imp_lock_held(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    return _imp_lock_held_impl(module);
 }
 
-PyDoc_STRVAR(
-    _imp_acquire_lock__doc__,
-    "acquire_lock($module, /)\n"
-    "--\n"
-    "\n"
-    "Acquires the interpreter\'s import lock for the current thread.\n"
-    "\n"
-    "This lock should be used by import hooks to ensure thread-safety when "
-    "importing\n"
-    "modules. On platforms without threads, this function does nothing.");
+PyDoc_STRVAR(_imp_acquire_lock__doc__,
+"acquire_lock($module, /)\n"
+"--\n"
+"\n"
+"Acquires the interpreter\'s import lock for the current thread.\n"
+"\n"
+"This lock should be used by import hooks to ensure thread-safety when importing\n"
+"modules. On platforms without threads, this function does nothing.");
 
-#define _IMP_ACQUIRE_LOCK_METHODDEF                             \
-  {"acquire_lock", (PyCFunction)_imp_acquire_lock, METH_NOARGS, \
-   _imp_acquire_lock__doc__},
+#define _IMP_ACQUIRE_LOCK_METHODDEF    \
+    {"acquire_lock", (PyCFunction)_imp_acquire_lock, METH_NOARGS, _imp_acquire_lock__doc__},
 
-static PyObject *_imp_acquire_lock_impl(PyObject *module);
+static PyObject *
+_imp_acquire_lock_impl(PyObject *module);
 
-static PyObject *_imp_acquire_lock(PyObject *module,
-                                   PyObject *Py_UNUSED(ignored)) {
-  return _imp_acquire_lock_impl(module);
+static PyObject *
+_imp_acquire_lock(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    return _imp_acquire_lock_impl(module);
 }
 
 PyDoc_STRVAR(_imp_release_lock__doc__,
-             "release_lock($module, /)\n"
-             "--\n"
-             "\n"
-             "Release the interpreter\'s import lock.\n"
-             "\n"
-             "On platforms without threads, this function does nothing.");
+"release_lock($module, /)\n"
+"--\n"
+"\n"
+"Release the interpreter\'s import lock.\n"
+"\n"
+"On platforms without threads, this function does nothing.");
 
-#define _IMP_RELEASE_LOCK_METHODDEF                             \
-  {"release_lock", (PyCFunction)_imp_release_lock, METH_NOARGS, \
-   _imp_release_lock__doc__},
+#define _IMP_RELEASE_LOCK_METHODDEF    \
+    {"release_lock", (PyCFunction)_imp_release_lock, METH_NOARGS, _imp_release_lock__doc__},
 
-static PyObject *_imp_release_lock_impl(PyObject *module);
+static PyObject *
+_imp_release_lock_impl(PyObject *module);
 
-static PyObject *_imp_release_lock(PyObject *module,
-                                   PyObject *Py_UNUSED(ignored)) {
-  return _imp_release_lock_impl(module);
+static PyObject *
+_imp_release_lock(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    return _imp_release_lock_impl(module);
 }
 
 PyDoc_STRVAR(_imp__fix_co_filename__doc__,
-             "_fix_co_filename($module, code, path, /)\n"
-             "--\n"
-             "\n"
-             "Changes code.co_filename to specify the passed-in file path.\n"
-             "\n"
-             "  code\n"
-             "    Code object to change.\n"
-             "  path\n"
-             "    File path to use.");
+"_fix_co_filename($module, code, path, /)\n"
+"--\n"
+"\n"
+"Changes code.co_filename to specify the passed-in file path.\n"
+"\n"
+"  code\n"
+"    Code object to change.\n"
+"  path\n"
+"    File path to use.");
 
-#define _IMP__FIX_CO_FILENAME_METHODDEF                                  \
-  {"_fix_co_filename", (PyCFunction)_imp__fix_co_filename, METH_VARARGS, \
-   _imp__fix_co_filename__doc__},
+#define _IMP__FIX_CO_FILENAME_METHODDEF    \
+    {"_fix_co_filename", (PyCFunction)_imp__fix_co_filename, METH_FASTCALL, _imp__fix_co_filename__doc__},
 
-static PyObject *_imp__fix_co_filename_impl(PyObject *module,
-                                            PyCodeObject *code, PyObject *path);
+static PyObject *
+_imp__fix_co_filename_impl(PyObject *module, PyCodeObject *code,
+                           PyObject *path);
 
-static PyObject *_imp__fix_co_filename(PyObject *module, PyObject *args) {
-  PyObject *return_value = NULL;
-  PyCodeObject *code;
-  PyObject *path;
+static PyObject *
+_imp__fix_co_filename(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    PyCodeObject *code;
+    PyObject *path;
 
-  if (!PyArg_ParseTuple(args, "O!U:_fix_co_filename", &PyCode_Type, &code,
-                        &path)) {
-    goto exit;
-  }
-  return_value = _imp__fix_co_filename_impl(module, code, path);
+    if (!_PyArg_ParseStack(args, nargs, "O!U:_fix_co_filename",
+        &PyCode_Type, &code, &path)) {
+        goto exit;
+    }
 
-exit:
-  return return_value;
-}
-
-PyDoc_STRVAR(_imp_create_builtin__doc__, "create_builtin($module, spec, /)\n"
-                                         "--\n"
-                                         "\n"
-                                         "Create an extension module.");
-
-#define _IMP_CREATE_BUILTIN_METHODDEF                          \
-  {"create_builtin", (PyCFunction)_imp_create_builtin, METH_O, \
-   _imp_create_builtin__doc__},
-
-PyDoc_STRVAR(
-    _imp_extension_suffixes__doc__,
-    "extension_suffixes($module, /)\n"
-    "--\n"
-    "\n"
-    "Returns the list of file suffixes used to identify extension modules.");
-
-#define _IMP_EXTENSION_SUFFIXES_METHODDEF                                   \
-  {"extension_suffixes", (PyCFunction)_imp_extension_suffixes, METH_NOARGS, \
-   _imp_extension_suffixes__doc__},
-
-static PyObject *_imp_extension_suffixes_impl(PyObject *module);
-
-static PyObject *_imp_extension_suffixes(PyObject *module,
-                                         PyObject *Py_UNUSED(ignored)) {
-  return _imp_extension_suffixes_impl(module);
-}
-
-PyDoc_STRVAR(_imp_init_frozen__doc__, "init_frozen($module, name, /)\n"
-                                      "--\n"
-                                      "\n"
-                                      "Initializes a frozen module.");
-
-#define _IMP_INIT_FROZEN_METHODDEF                       \
-  {"init_frozen", (PyCFunction)_imp_init_frozen, METH_O, \
-   _imp_init_frozen__doc__},
-
-static PyObject *_imp_init_frozen_impl(PyObject *module, PyObject *name);
-
-static PyObject *_imp_init_frozen(PyObject *module, PyObject *arg) {
-  PyObject *return_value = NULL;
-  PyObject *name;
-
-  if (!PyArg_Parse(arg, "U:init_frozen", &name)) {
-    goto exit;
-  }
-  return_value = _imp_init_frozen_impl(module, name);
+    if (!_PyArg_NoStackKeywords("_fix_co_filename", kwnames)) {
+        goto exit;
+    }
+    return_value = _imp__fix_co_filename_impl(module, code, path);
 
 exit:
-  return return_value;
+    return return_value;
+}
+
+PyDoc_STRVAR(_imp_create_builtin__doc__,
+"create_builtin($module, spec, /)\n"
+"--\n"
+"\n"
+"Create an extension module.");
+
+#define _IMP_CREATE_BUILTIN_METHODDEF    \
+    {"create_builtin", (PyCFunction)_imp_create_builtin, METH_O, _imp_create_builtin__doc__},
+
+PyDoc_STRVAR(_imp_extension_suffixes__doc__,
+"extension_suffixes($module, /)\n"
+"--\n"
+"\n"
+"Returns the list of file suffixes used to identify extension modules.");
+
+#define _IMP_EXTENSION_SUFFIXES_METHODDEF    \
+    {"extension_suffixes", (PyCFunction)_imp_extension_suffixes, METH_NOARGS, _imp_extension_suffixes__doc__},
+
+static PyObject *
+_imp_extension_suffixes_impl(PyObject *module);
+
+static PyObject *
+_imp_extension_suffixes(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    return _imp_extension_suffixes_impl(module);
+}
+
+PyDoc_STRVAR(_imp_init_frozen__doc__,
+"init_frozen($module, name, /)\n"
+"--\n"
+"\n"
+"Initializes a frozen module.");
+
+#define _IMP_INIT_FROZEN_METHODDEF    \
+    {"init_frozen", (PyCFunction)_imp_init_frozen, METH_O, _imp_init_frozen__doc__},
+
+static PyObject *
+_imp_init_frozen_impl(PyObject *module, PyObject *name);
+
+static PyObject *
+_imp_init_frozen(PyObject *module, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    PyObject *name;
+
+    if (!PyArg_Parse(arg, "U:init_frozen", &name)) {
+        goto exit;
+    }
+    return_value = _imp_init_frozen_impl(module, name);
+
+exit:
+    return return_value;
 }
 
 PyDoc_STRVAR(_imp_get_frozen_object__doc__,
-             "get_frozen_object($module, name, /)\n"
-             "--\n"
-             "\n"
-             "Create a code object for a frozen module.");
+"get_frozen_object($module, name, /)\n"
+"--\n"
+"\n"
+"Create a code object for a frozen module.");
 
-#define _IMP_GET_FROZEN_OBJECT_METHODDEF                             \
-  {"get_frozen_object", (PyCFunction)_imp_get_frozen_object, METH_O, \
-   _imp_get_frozen_object__doc__},
+#define _IMP_GET_FROZEN_OBJECT_METHODDEF    \
+    {"get_frozen_object", (PyCFunction)_imp_get_frozen_object, METH_O, _imp_get_frozen_object__doc__},
 
-static PyObject *_imp_get_frozen_object_impl(PyObject *module, PyObject *name);
+static PyObject *
+_imp_get_frozen_object_impl(PyObject *module, PyObject *name);
 
-static PyObject *_imp_get_frozen_object(PyObject *module, PyObject *arg) {
-  PyObject *return_value = NULL;
-  PyObject *name;
+static PyObject *
+_imp_get_frozen_object(PyObject *module, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    PyObject *name;
 
-  if (!PyArg_Parse(arg, "U:get_frozen_object", &name)) {
-    goto exit;
-  }
-  return_value = _imp_get_frozen_object_impl(module, name);
+    if (!PyArg_Parse(arg, "U:get_frozen_object", &name)) {
+        goto exit;
+    }
+    return_value = _imp_get_frozen_object_impl(module, name);
 
 exit:
-  return return_value;
+    return return_value;
 }
 
 PyDoc_STRVAR(_imp_is_frozen_package__doc__,
-             "is_frozen_package($module, name, /)\n"
-             "--\n"
-             "\n"
-             "Returns True if the module name is of a frozen package.");
+"is_frozen_package($module, name, /)\n"
+"--\n"
+"\n"
+"Returns True if the module name is of a frozen package.");
 
-#define _IMP_IS_FROZEN_PACKAGE_METHODDEF                             \
-  {"is_frozen_package", (PyCFunction)_imp_is_frozen_package, METH_O, \
-   _imp_is_frozen_package__doc__},
+#define _IMP_IS_FROZEN_PACKAGE_METHODDEF    \
+    {"is_frozen_package", (PyCFunction)_imp_is_frozen_package, METH_O, _imp_is_frozen_package__doc__},
 
-static PyObject *_imp_is_frozen_package_impl(PyObject *module, PyObject *name);
+static PyObject *
+_imp_is_frozen_package_impl(PyObject *module, PyObject *name);
 
-static PyObject *_imp_is_frozen_package(PyObject *module, PyObject *arg) {
-  PyObject *return_value = NULL;
-  PyObject *name;
+static PyObject *
+_imp_is_frozen_package(PyObject *module, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    PyObject *name;
 
-  if (!PyArg_Parse(arg, "U:is_frozen_package", &name)) {
-    goto exit;
-  }
-  return_value = _imp_is_frozen_package_impl(module, name);
+    if (!PyArg_Parse(arg, "U:is_frozen_package", &name)) {
+        goto exit;
+    }
+    return_value = _imp_is_frozen_package_impl(module, name);
 
 exit:
-  return return_value;
+    return return_value;
 }
 
-PyDoc_STRVAR(
-    _imp_is_builtin__doc__,
-    "is_builtin($module, name, /)\n"
-    "--\n"
-    "\n"
-    "Returns True if the module name corresponds to a built-in module.");
+PyDoc_STRVAR(_imp_is_builtin__doc__,
+"is_builtin($module, name, /)\n"
+"--\n"
+"\n"
+"Returns True if the module name corresponds to a built-in module.");
 
-#define _IMP_IS_BUILTIN_METHODDEF \
-  {"is_builtin", (PyCFunction)_imp_is_builtin, METH_O, _imp_is_builtin__doc__},
+#define _IMP_IS_BUILTIN_METHODDEF    \
+    {"is_builtin", (PyCFunction)_imp_is_builtin, METH_O, _imp_is_builtin__doc__},
 
-static PyObject *_imp_is_builtin_impl(PyObject *module, PyObject *name);
+static PyObject *
+_imp_is_builtin_impl(PyObject *module, PyObject *name);
 
-static PyObject *_imp_is_builtin(PyObject *module, PyObject *arg) {
-  PyObject *return_value = NULL;
-  PyObject *name;
+static PyObject *
+_imp_is_builtin(PyObject *module, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    PyObject *name;
 
-  if (!PyArg_Parse(arg, "U:is_builtin", &name)) {
-    goto exit;
-  }
-  return_value = _imp_is_builtin_impl(module, name);
+    if (!PyArg_Parse(arg, "U:is_builtin", &name)) {
+        goto exit;
+    }
+    return_value = _imp_is_builtin_impl(module, name);
 
 exit:
-  return return_value;
+    return return_value;
 }
 
 PyDoc_STRVAR(_imp_is_frozen__doc__,
-             "is_frozen($module, name, /)\n"
-             "--\n"
-             "\n"
-             "Returns True if the module name corresponds to a frozen module.");
+"is_frozen($module, name, /)\n"
+"--\n"
+"\n"
+"Returns True if the module name corresponds to a frozen module.");
 
-#define _IMP_IS_FROZEN_METHODDEF \
-  {"is_frozen", (PyCFunction)_imp_is_frozen, METH_O, _imp_is_frozen__doc__},
+#define _IMP_IS_FROZEN_METHODDEF    \
+    {"is_frozen", (PyCFunction)_imp_is_frozen, METH_O, _imp_is_frozen__doc__},
 
-static PyObject *_imp_is_frozen_impl(PyObject *module, PyObject *name);
+static PyObject *
+_imp_is_frozen_impl(PyObject *module, PyObject *name);
 
-static PyObject *_imp_is_frozen(PyObject *module, PyObject *arg) {
-  PyObject *return_value = NULL;
-  PyObject *name;
+static PyObject *
+_imp_is_frozen(PyObject *module, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    PyObject *name;
 
-  if (!PyArg_Parse(arg, "U:is_frozen", &name)) {
-    goto exit;
-  }
-  return_value = _imp_is_frozen_impl(module, name);
+    if (!PyArg_Parse(arg, "U:is_frozen", &name)) {
+        goto exit;
+    }
+    return_value = _imp_is_frozen_impl(module, name);
 
 exit:
-  return return_value;
+    return return_value;
 }
 
 #if defined(HAVE_DYNAMIC_LOADING)
 
 PyDoc_STRVAR(_imp_create_dynamic__doc__,
-             "create_dynamic($module, spec, file=None, /)\n"
-             "--\n"
-             "\n"
-             "Create an extension module.");
+"create_dynamic($module, spec, file=None, /)\n"
+"--\n"
+"\n"
+"Create an extension module.");
 
-#define _IMP_CREATE_DYNAMIC_METHODDEF                                \
-  {"create_dynamic", (PyCFunction)_imp_create_dynamic, METH_VARARGS, \
-   _imp_create_dynamic__doc__},
+#define _IMP_CREATE_DYNAMIC_METHODDEF    \
+    {"create_dynamic", (PyCFunction)_imp_create_dynamic, METH_VARARGS, _imp_create_dynamic__doc__},
 
-static PyObject *_imp_create_dynamic_impl(PyObject *module, PyObject *spec,
-                                          PyObject *file);
+static PyObject *
+_imp_create_dynamic_impl(PyObject *module, PyObject *spec, PyObject *file);
 
-static PyObject *_imp_create_dynamic(PyObject *module, PyObject *args) {
-  PyObject *return_value = NULL;
-  PyObject *spec;
-  PyObject *file = NULL;
+static PyObject *
+_imp_create_dynamic(PyObject *module, PyObject *args)
+{
+    PyObject *return_value = NULL;
+    PyObject *spec;
+    PyObject *file = NULL;
 
-  if (!PyArg_UnpackTuple(args, "create_dynamic", 1, 2, &spec, &file)) {
-    goto exit;
-  }
-  return_value = _imp_create_dynamic_impl(module, spec, file);
+    if (!PyArg_UnpackTuple(args, "create_dynamic",
+        1, 2,
+        &spec, &file)) {
+        goto exit;
+    }
+    return_value = _imp_create_dynamic_impl(module, spec, file);
 
 exit:
-  return return_value;
+    return return_value;
 }
 
 #endif /* defined(HAVE_DYNAMIC_LOADING) */
 
 #if defined(HAVE_DYNAMIC_LOADING)
 
-PyDoc_STRVAR(_imp_exec_dynamic__doc__, "exec_dynamic($module, mod, /)\n"
-                                       "--\n"
-                                       "\n"
-                                       "Initialize an extension module.");
+PyDoc_STRVAR(_imp_exec_dynamic__doc__,
+"exec_dynamic($module, mod, /)\n"
+"--\n"
+"\n"
+"Initialize an extension module.");
 
-#define _IMP_EXEC_DYNAMIC_METHODDEF                        \
-  {"exec_dynamic", (PyCFunction)_imp_exec_dynamic, METH_O, \
-   _imp_exec_dynamic__doc__},
+#define _IMP_EXEC_DYNAMIC_METHODDEF    \
+    {"exec_dynamic", (PyCFunction)_imp_exec_dynamic, METH_O, _imp_exec_dynamic__doc__},
 
-static int _imp_exec_dynamic_impl(PyObject *module, PyObject *mod);
+static int
+_imp_exec_dynamic_impl(PyObject *module, PyObject *mod);
 
-static PyObject *_imp_exec_dynamic(PyObject *module, PyObject *mod) {
-  PyObject *return_value = NULL;
-  int _return_value;
+static PyObject *
+_imp_exec_dynamic(PyObject *module, PyObject *mod)
+{
+    PyObject *return_value = NULL;
+    int _return_value;
 
-  _return_value = _imp_exec_dynamic_impl(module, mod);
-  if ((_return_value == -1) && PyErr_Occurred()) {
-    goto exit;
-  }
-  return_value = PyLong_FromLong((long)_return_value);
+    _return_value = _imp_exec_dynamic_impl(module, mod);
+    if ((_return_value == -1) && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = PyLong_FromLong((long)_return_value);
 
 exit:
-  return return_value;
+    return return_value;
 }
 
 #endif /* defined(HAVE_DYNAMIC_LOADING) */
 
-PyDoc_STRVAR(_imp_exec_builtin__doc__, "exec_builtin($module, mod, /)\n"
-                                       "--\n"
-                                       "\n"
-                                       "Initialize a built-in module.");
+PyDoc_STRVAR(_imp_exec_builtin__doc__,
+"exec_builtin($module, mod, /)\n"
+"--\n"
+"\n"
+"Initialize a built-in module.");
 
-#define _IMP_EXEC_BUILTIN_METHODDEF                        \
-  {"exec_builtin", (PyCFunction)_imp_exec_builtin, METH_O, \
-   _imp_exec_builtin__doc__},
+#define _IMP_EXEC_BUILTIN_METHODDEF    \
+    {"exec_builtin", (PyCFunction)_imp_exec_builtin, METH_O, _imp_exec_builtin__doc__},
 
-static int _imp_exec_builtin_impl(PyObject *module, PyObject *mod);
+static int
+_imp_exec_builtin_impl(PyObject *module, PyObject *mod);
 
-static PyObject *_imp_exec_builtin(PyObject *module, PyObject *mod) {
-  PyObject *return_value = NULL;
-  int _return_value;
+static PyObject *
+_imp_exec_builtin(PyObject *module, PyObject *mod)
+{
+    PyObject *return_value = NULL;
+    int _return_value;
 
-  _return_value = _imp_exec_builtin_impl(module, mod);
-  if ((_return_value == -1) && PyErr_Occurred()) {
-    goto exit;
-  }
-  return_value = PyLong_FromLong((long)_return_value);
+    _return_value = _imp_exec_builtin_impl(module, mod);
+    if ((_return_value == -1) && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = PyLong_FromLong((long)_return_value);
 
 exit:
-  return return_value;
+    return return_value;
 }
 
 #ifndef _IMP_CREATE_DYNAMIC_METHODDEF
-#define _IMP_CREATE_DYNAMIC_METHODDEF
+    #define _IMP_CREATE_DYNAMIC_METHODDEF
 #endif /* !defined(_IMP_CREATE_DYNAMIC_METHODDEF) */
 
 #ifndef _IMP_EXEC_DYNAMIC_METHODDEF
-#define _IMP_EXEC_DYNAMIC_METHODDEF
+    #define _IMP_EXEC_DYNAMIC_METHODDEF
 #endif /* !defined(_IMP_EXEC_DYNAMIC_METHODDEF) */
-/*[clinic end generated code: output=d24d7f73702a907f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5a3f012344950548 input=a9049054013a1b77]*/

--- a/third_party/python/Python/getargs.c
+++ b/third_party/python/Python/getargs.c
@@ -43,6 +43,8 @@ typedef struct {
 #define STATIC_FREELIST_ENTRIES 8
 
 static const char *skipitem(const char **, va_list *, int);
+static int vgetargs1_impl(PyObject *args, PyObject **stack, Py_ssize_t nargs,
+                          const char *format, va_list *p_va, int flags);
 static int vgetargs1(PyObject *, const char *, va_list *, int);
 static void seterror(Py_ssize_t, const char *, int *, const char *, const char *);
 static const char *convertitem(PyObject *, const char **, va_list *, int, int *,
@@ -117,6 +119,31 @@ _PyArg_ParseTuple_SizeT(PyObject *args, const char *format, ...)
 }
 
 int
+_PyArg_ParseStack(PyObject **args, Py_ssize_t nargs, const char *format, ...)
+{
+    int retval;
+    va_list va;
+
+    va_start(va, format);
+    retval = vgetargs1_impl(NULL, args, nargs, format, &va, 0);
+    va_end(va);
+    return retval;
+}
+
+int
+_PyArg_ParseStack_SizeT(PyObject **args, Py_ssize_t nargs, const char *format, ...)
+{
+    int retval;
+    va_list va;
+
+    va_start(va, format);
+    retval = vgetargs1_impl(NULL, args, nargs, format, &va, FLAG_SIZE_T);
+    va_end(va);
+    return retval;
+}
+
+
+int
 PyArg_VaParse(PyObject *args, const char *format, va_list va)
 {
     va_list lva;
@@ -188,7 +215,8 @@ cleanreturn(int retval, freelist_t *freelist)
 }
 
 static int
-vgetargs1(PyObject *args, const char *format, va_list *p_va, int flags)
+vgetargs1_impl(PyObject *compat_args, PyObject **stack, Py_ssize_t nargs, const char *format,
+               va_list *p_va, int flags)
 {
     char msgbuf[256];
     int levels[32];
@@ -199,16 +227,20 @@ vgetargs1(PyObject *args, const char *format, va_list *p_va, int flags)
     int level = 0;
     int endfmt = 0;
     const char *formatsave = format;
-    Py_ssize_t i, len;
+    Py_ssize_t i;
     const char *msg;
     int compat = flags & FLAG_COMPAT;
     freelistentry_t static_entries[STATIC_FREELIST_ENTRIES];
     freelist_t freelist;
+
+    assert(nargs == 0 || stack != NULL);
+
     freelist.entries = static_entries;
     freelist.first_available = 0;
     freelist.entries_malloced = 0;
-    assert(compat || (args != (PyObject*)NULL));
+
     flags = flags & ~FLAG_COMPAT;
+
     while (endfmt == 0) {
         int c = *format++;
         switch (c) {
@@ -243,18 +275,22 @@ vgetargs1(PyObject *args, const char *format, va_list *p_va, int flags)
             break;
         default:
             if (level == 0) {
-                if (Py_ISALPHA(c))
+                if (Py_ISALPHA(Py_CHARMASK(c)))
                     if (c != 'e') /* skip encoded */
                         max++;
             }
             break;
         }
     }
+
     if (level != 0)
         Py_FatalError(/* '(' */ "missing ')' in getargs format");
+
     if (min < 0)
         min = max;
+
     format = formatsave;
+
     if (max > STATIC_FREELIST_ENTRIES) {
         freelist.entries = PyMem_NEW(freelistentry_t, max);
         if (freelist.entries == NULL) {
@@ -263,9 +299,10 @@ vgetargs1(PyObject *args, const char *format, va_list *p_va, int flags)
         }
         freelist.entries_malloced = 1;
     }
+
     if (compat) {
         if (max == 0) {
-            if (args == NULL)
+            if (compat_args == NULL)
                 return 1;
             PyErr_Format(PyExc_TypeError,
                          "%.200s%s takes no arguments",
@@ -274,14 +311,14 @@ vgetargs1(PyObject *args, const char *format, va_list *p_va, int flags)
             return cleanreturn(0, &freelist);
         }
         else if (min == 1 && max == 1) {
-            if (args == NULL) {
+            if (compat_args == NULL) {
                 PyErr_Format(PyExc_TypeError,
                              "%.200s%s takes at least one argument",
                              fname==NULL ? "function" : fname,
                              fname==NULL ? "" : "()");
                 return cleanreturn(0, &freelist);
             }
-            msg = convertitem(args, &format, p_va, flags, levels,
+            msg = convertitem(compat_args, &format, p_va, flags, levels,
                               msgbuf, sizeof(msgbuf), &freelist);
             if (msg == NULL)
                 return cleanreturn(1, &freelist);
@@ -294,31 +331,27 @@ vgetargs1(PyObject *args, const char *format, va_list *p_va, int flags)
             return cleanreturn(0, &freelist);
         }
     }
-    if (!PyTuple_Check(args)) {
-        PyErr_SetString(PyExc_SystemError,
-            "new style getargs format but argument is not a tuple");
-        return cleanreturn(0, &freelist);
-    }
-    len = PyTuple_GET_SIZE(args);
-    if (len < min || max < len) {
+
+    if (nargs < min || max < nargs) {
         if (message == NULL)
             PyErr_Format(PyExc_TypeError,
                          "%.150s%s takes %s %d argument%s (%ld given)",
                          fname==NULL ? "function" : fname,
                          fname==NULL ? "" : "()",
                          min==max ? "exactly"
-                         : len < min ? "at least" : "at most",
-                         len < min ? min : max,
-                         (len < min ? min : max) == 1 ? "" : "s",
-                         Py_SAFE_DOWNCAST(len, Py_ssize_t, long));
+                         : nargs < min ? "at least" : "at most",
+                         nargs < min ? min : max,
+                         (nargs < min ? min : max) == 1 ? "" : "s",
+                         Py_SAFE_DOWNCAST(nargs, Py_ssize_t, long));
         else
             PyErr_SetString(PyExc_TypeError, message);
         return cleanreturn(0, &freelist);
     }
-    for (i = 0; i < len; i++) {
+
+    for (i = 0; i < nargs; i++) {
         if (*format == '|')
             format++;
-        msg = convertitem(PyTuple_GET_ITEM(args, i), &format, p_va,
+        msg = convertitem(stack[i], &format, p_va,
                           flags, levels, msgbuf,
                           sizeof(msgbuf), &freelist);
         if (msg) {
@@ -326,15 +359,46 @@ vgetargs1(PyObject *args, const char *format, va_list *p_va, int flags)
             return cleanreturn(0, &freelist);
         }
     }
-    if (*format != '\0' && !Py_ISALPHA(*format) &&
+
+    if (*format != '\0' && !Py_ISALPHA(Py_CHARMASK(*format)) &&
         *format != '(' &&
         *format != '|' && *format != ':' && *format != ';') {
         PyErr_Format(PyExc_SystemError,
                      "bad format string: %.200s", formatsave);
         return cleanreturn(0, &freelist);
     }
+
     return cleanreturn(1, &freelist);
 }
+
+static int
+vgetargs1(PyObject *args, const char *format, va_list *p_va, int flags)
+{
+    PyObject **stack;
+    Py_ssize_t nargs;
+
+    if (!(flags & FLAG_COMPAT)) {
+        assert(args != NULL);
+
+        if (!PyTuple_Check(args)) {
+            PyErr_SetString(PyExc_SystemError,
+                "new style getargs format but argument is not a tuple");
+            return 0;
+        }
+
+        stack = &PyTuple_GET_ITEM(args, 0);
+        nargs = PyTuple_GET_SIZE(args);
+    }
+    else {
+        stack = NULL;
+        nargs = 0;
+    }
+
+    return vgetargs1_impl(args, stack, nargs, format, p_va, flags);
+}
+
+
+
 
 static void
 seterror(Py_ssize_t iarg, const char *msg, int *levels, const char *fname,
@@ -1283,7 +1347,7 @@ getbuffer(PyObject *arg, Py_buffer *view, const char **errmsg)
 /* Return false (0) for error, else true. */
 int
 PyArg_ParseTupleAndKeywords(PyObject *args,
-                            PyObject *keywords,
+                            PyObject *kwargs,
                             const char *format,
                             char **kwlist, ...)
 {
@@ -1291,7 +1355,7 @@ PyArg_ParseTupleAndKeywords(PyObject *args,
     va_list va;
 
     if ((args == NULL || !PyTuple_Check(args)) ||
-        (keywords != NULL && !PyDict_Check(keywords)) ||
+        (kwargs != NULL && !PyDict_Check(kwargs)) ||
         format == NULL ||
         kwlist == NULL)
     {
@@ -1300,21 +1364,21 @@ PyArg_ParseTupleAndKeywords(PyObject *args,
     }
 
     va_start(va, kwlist);
-    retval = vgetargskeywords(args, keywords, format, kwlist, &va, 0);
+    retval = vgetargskeywords(args, kwargs, format, kwlist, &va, 0);
     va_end(va);
     return retval;
 }
 
 int
 _PyArg_ParseTupleAndKeywords_SizeT(PyObject *args,
-                                  PyObject *keywords,
+                                  PyObject *kwargs,
                                   const char *format,
                                   char **kwlist, ...)
 {
     int retval;
     va_list va;
     if ((args == NULL || !PyTuple_Check(args)) ||
-        (keywords != NULL && !PyDict_Check(keywords)) ||
+        (kwargs != NULL && !PyDict_Check(kwargs)) ||
         format == NULL ||
         kwlist == NULL)
     {
@@ -1322,7 +1386,7 @@ _PyArg_ParseTupleAndKeywords_SizeT(PyObject *args,
         return 0;
     }
     va_start(va, kwlist);
-    retval = vgetargskeywords(args, keywords, format,
+    retval = vgetargskeywords(args, kwargs, format,
                               kwlist, &va, FLAG_SIZE_T);
     va_end(va);
     return retval;
@@ -1330,14 +1394,14 @@ _PyArg_ParseTupleAndKeywords_SizeT(PyObject *args,
 
 int
 PyArg_VaParseTupleAndKeywords(PyObject *args,
-                              PyObject *keywords,
+                              PyObject *kwargs,
                               const char *format,
                               char **kwlist, va_list va)
 {
     int retval;
     va_list lva;
     if ((args == NULL || !PyTuple_Check(args)) ||
-        (keywords != NULL && !PyDict_Check(keywords)) ||
+        (kwargs != NULL && !PyDict_Check(kwargs)) ||
         format == NULL ||
         kwlist == NULL)
     {
@@ -1345,21 +1409,21 @@ PyArg_VaParseTupleAndKeywords(PyObject *args,
         return 0;
     }
     va_copy(lva, va);
-    retval = vgetargskeywords(args, keywords, format, kwlist, &lva, 0);
+    retval = vgetargskeywords(args, kwargs, format, kwlist, &lva, 0);
     va_end(lva);
     return retval;
 }
 
 int
 _PyArg_VaParseTupleAndKeywords_SizeT(PyObject *args,
-                                    PyObject *keywords,
+                                    PyObject *kwargs,
                                     const char *format,
                                     char **kwlist, va_list va)
 {
     int retval;
     va_list lva;
     if ((args == NULL || !PyTuple_Check(args)) ||
-        (keywords != NULL && !PyDict_Check(keywords)) ||
+        (kwargs != NULL && !PyDict_Check(kwargs)) ||
         format == NULL ||
         kwlist == NULL)
     {
@@ -1367,40 +1431,40 @@ _PyArg_VaParseTupleAndKeywords_SizeT(PyObject *args,
         return 0;
     }
     va_copy(lva, va);
-    retval = vgetargskeywords(args, keywords, format,
+    retval = vgetargskeywords(args, kwargs, format,
                               kwlist, &lva, FLAG_SIZE_T);
     va_end(lva);
     return retval;
 }
 
 int
-_PyArg_ParseTupleAndKeywordsFast(PyObject *args, PyObject *keywords,
+_PyArg_ParseTupleAndKeywordsFast(PyObject *args, PyObject *kwargs,
                             struct _PyArg_Parser *parser, ...)
 {
     int retval;
     va_list va;
 
     va_start(va, parser);
-    retval = vgetargskeywordsfast(args, keywords, parser, &va, 0);
+    retval = vgetargskeywordsfast(args, kwargs, parser, &va, 0);
     va_end(va);
     return retval;
 }
 
 int
-_PyArg_ParseTupleAndKeywordsFast_SizeT(PyObject *args, PyObject *keywords,
+_PyArg_ParseTupleAndKeywordsFast_SizeT(PyObject *args, PyObject *kwargs,
                             struct _PyArg_Parser *parser, ...)
 {
     int retval;
     va_list va;
 
     va_start(va, parser);
-    retval = vgetargskeywordsfast(args, keywords, parser, &va, FLAG_SIZE_T);
+    retval = vgetargskeywordsfast(args, kwargs, parser, &va, FLAG_SIZE_T);
     va_end(va);
     return retval;
 }
 
 int
-_PyArg_ParseStack(PyObject **args, Py_ssize_t nargs, PyObject *kwnames,
+_PyArg_ParseStackAndKeywords(PyObject **args, Py_ssize_t nargs, PyObject *kwnames,
                   struct _PyArg_Parser *parser, ...)
 {
     int retval;
@@ -1413,7 +1477,7 @@ _PyArg_ParseStack(PyObject **args, Py_ssize_t nargs, PyObject *kwnames,
 }
 
 int
-_PyArg_ParseStack_SizeT(PyObject **args, Py_ssize_t nargs, PyObject *kwnames,
+_PyArg_ParseStackAndKeywords_SizeT(PyObject **args, Py_ssize_t nargs, PyObject *kwnames,
                         struct _PyArg_Parser *parser, ...)
 {
     int retval;
@@ -1426,27 +1490,27 @@ _PyArg_ParseStack_SizeT(PyObject **args, Py_ssize_t nargs, PyObject *kwnames,
 }
 
 int
-_PyArg_VaParseTupleAndKeywordsFast(PyObject *args, PyObject *keywords,
+_PyArg_VaParseTupleAndKeywordsFast(PyObject *args, PyObject *kwargs,
                             struct _PyArg_Parser *parser, va_list va)
 {
     int retval;
     va_list lva;
 
     va_copy(lva, va);
-    retval = vgetargskeywordsfast(args, keywords, parser, &lva, 0);
+    retval = vgetargskeywordsfast(args, kwargs, parser, &lva, 0);
     va_end(lva);
     return retval;
 }
 
 int
-_PyArg_VaParseTupleAndKeywordsFast_SizeT(PyObject *args, PyObject *keywords,
+_PyArg_VaParseTupleAndKeywordsFast_SizeT(PyObject *args, PyObject *kwargs,
                             struct _PyArg_Parser *parser, va_list va)
 {
     int retval;
     va_list lva;
 
     va_copy(lva, va);
-    retval = vgetargskeywordsfast(args, keywords, parser, &lva, FLAG_SIZE_T);
+    retval = vgetargskeywordsfast(args, kwargs, parser, &lva, FLAG_SIZE_T);
     va_end(lva);
     return retval;
 }
@@ -1469,7 +1533,7 @@ PyArg_ValidateKeywordArguments(PyObject *kwargs)
 #define IS_END_OF_FORMAT(c) (c == '\0' || c == ';' || c == ':')
 
 static int
-vgetargskeywords(PyObject *args, PyObject *keywords, const char *format,
+vgetargskeywords(PyObject *args, PyObject *kwargs, const char *format,
                  char **kwlist, va_list *p_va, int flags)
 {
     char msgbuf[512];
@@ -1479,7 +1543,7 @@ vgetargskeywords(PyObject *args, PyObject *keywords, const char *format,
     int max = INT_MAX;
     int i, pos, len;
     int skip = 0;
-    Py_ssize_t nargs, nkeywords;
+    Py_ssize_t nargs, nkwargs;
     PyObject *current_arg;
     freelistentry_t static_entries[STATIC_FREELIST_ENTRIES];
     freelist_t freelist;
@@ -1489,7 +1553,7 @@ vgetargskeywords(PyObject *args, PyObject *keywords, const char *format,
     freelist.entries_malloced = 0;
 
     assert(args != NULL && PyTuple_Check(args));
-    assert(keywords == NULL || PyDict_Check(keywords));
+    assert(kwargs == NULL || PyDict_Check(kwargs));
     assert(format != NULL);
     assert(kwlist != NULL);
     assert(p_va != NULL);
@@ -1528,15 +1592,15 @@ vgetargskeywords(PyObject *args, PyObject *keywords, const char *format,
     }
 
     nargs = PyTuple_GET_SIZE(args);
-    nkeywords = (keywords == NULL) ? 0 : PyDict_Size(keywords);
-    if (nargs + nkeywords > len) {
+    nkwargs = (kwargs == NULL) ? 0 : PyDict_Size(kwargs);
+    if (nargs + nkwargs > len) {
         PyErr_Format(PyExc_TypeError,
                      "%s%s takes at most %d argument%s (%zd given)",
                      (fname == NULL) ? "function" : fname,
                      (fname == NULL) ? "" : "()",
                      len,
                      (len == 1) ? "" : "s",
-                     nargs + nkeywords);
+                     nargs + nkwargs);
         return cleanreturn(0, &freelist);
     }
 
@@ -1597,14 +1661,14 @@ vgetargskeywords(PyObject *args, PyObject *keywords, const char *format,
         }
         if (!skip) {
             current_arg = NULL;
-            if (nkeywords && i >= pos) {
-                current_arg = PyDict_GetItemString(keywords, keyword);
+            if (nkwargs && i >= pos) {
+                current_arg = PyDict_GetItemString(kwargs, keyword);
                 if (!current_arg && PyErr_Occurred()) {
                     return cleanreturn(0, &freelist);
                 }
             }
             if (current_arg) {
-                --nkeywords;
+                --nkwargs;
                 if (i < nargs) {
                     /* arg present in tuple and in dict */
                     PyErr_Format(PyExc_TypeError,
@@ -1648,7 +1712,7 @@ vgetargskeywords(PyObject *args, PyObject *keywords, const char *format,
              * fulfilled and no keyword args left, with no further
              * validation. XXX Maybe skip this in debug build ?
              */
-            if (!nkeywords && !skip) {
+            if (!nkwargs && !skip) {
                 return cleanreturn(1, &freelist);
             }
         }
@@ -1680,14 +1744,14 @@ vgetargskeywords(PyObject *args, PyObject *keywords, const char *format,
     }
 
     /* make sure there are no extraneous keyword arguments */
-    if (nkeywords > 0) {
+    if (nkwargs > 0) {
         PyObject *key, *value;
         Py_ssize_t pos = 0;
-        while (PyDict_Next(keywords, &pos, &key, &value)) {
+        while (PyDict_Next(kwargs, &pos, &key, &value)) {
             int match = 0;
             if (!PyUnicode_Check(key)) {
                 PyErr_SetString(PyExc_TypeError,
-                                "keywords must be strings");
+                                "kwargs must be strings");
                 return cleanreturn(0, &freelist);
             }
             for (i = 0; i < len; i++) {
@@ -1716,13 +1780,13 @@ static struct _PyArg_Parser *static_arg_parsers = NULL;
 static int
 parser_init(struct _PyArg_Parser *parser)
 {
-    const char * const *keywords;
+    const char * const *kwargs;
     const char *format, *msg;
     int i, len, min, max, nkw;
     PyObject *kwtuple;
 
     assert(parser->format != NULL);
-    assert(parser->keywords != NULL);
+    assert(parser->kwargs != NULL);
     if (parser->kwtuple != NULL) {
         return 1;
     }
@@ -1739,14 +1803,14 @@ parser_init(struct _PyArg_Parser *parser)
             parser->custom_msg++;
     }
 
-    keywords = parser->keywords;
-    /* scan keywords and count the number of positional-only parameters */
-    for (i = 0; keywords[i] && !*keywords[i]; i++) {
+    kwargs = parser->keywords;
+    /* scan kwargs and count the number of positional-only parameters */
+    for (i = 0; kwargs[i] && !*kwargs[i]; i++) {
     }
     parser->pos = i;
-    /* scan keywords and get greatest possible nbr of args */
-    for (; keywords[i]; i++) {
-        if (!*keywords[i]) {
+    /* scan kwargs and get greatest possible nbr of args */
+    for (; kwargs[i]; i++) {
+        if (!*kwargs[i]) {
             PyErr_SetString(PyExc_SystemError,
                             "Empty keyword parameter name");
             return 0;
@@ -1814,9 +1878,9 @@ parser_init(struct _PyArg_Parser *parser)
     if (kwtuple == NULL) {
         return 0;
     }
-    keywords = parser->keywords + parser->pos;
+    kwargs = parser->keywords + parser->pos;
     for (i = 0; i < nkw; i++) {
-        PyObject *str = PyUnicode_FromString(keywords[i]);
+        PyObject *str = PyUnicode_FromString(kwargs[i]);
         if (str == NULL) {
             Py_DECREF(kwtuple);
             return 0;
@@ -1866,7 +1930,7 @@ find_keyword(PyObject *kwnames, PyObject **kwstack, PyObject *key)
 
 static int
 vgetargskeywordsfast_impl(PyObject **args, Py_ssize_t nargs,
-                          PyObject *keywords, PyObject *kwnames,
+                          PyObject *kwargs, PyObject *kwnames,
                           struct _PyArg_Parser *parser,
                           va_list *p_va, int flags)
 {
@@ -1877,7 +1941,7 @@ vgetargskeywordsfast_impl(PyObject **args, Py_ssize_t nargs,
     const char *msg;
     PyObject *keyword;
     int i, pos, len;
-    Py_ssize_t nkeywords;
+    Py_ssize_t nkwargs;
     PyObject *current_arg;
     freelistentry_t static_entries[STATIC_FREELIST_ENTRIES];
     freelist_t freelist;
@@ -1887,9 +1951,9 @@ vgetargskeywordsfast_impl(PyObject **args, Py_ssize_t nargs,
     freelist.first_available = 0;
     freelist.entries_malloced = 0;
 
-    assert(keywords == NULL || PyDict_Check(keywords));
-    assert((keywords != NULL || kwnames != NULL)
-           || (keywords == NULL && kwnames == NULL));
+    assert(kwargs == NULL || PyDict_Check(kwargs));
+    assert((kwargs != NULL || kwnames != NULL)
+           || (kwargs == NULL && kwnames == NULL));
     assert(p_va != NULL);
 
     if (parser == NULL
@@ -1916,24 +1980,24 @@ vgetargskeywordsfast_impl(PyObject **args, Py_ssize_t nargs,
         freelist.entries_malloced = 1;
     }
 
-    if (keywords != NULL) {
-        nkeywords = PyDict_Size(keywords);
+    if (kwargs != NULL) {
+        nkwargs = PyDict_Size(kwargs);
     }
     else if (kwnames != NULL) {
-        nkeywords = PyTuple_GET_SIZE(kwnames);
+        nkwargs = PyTuple_GET_SIZE(kwnames);
         kwstack = args + nargs;
     }
     else {
-        nkeywords = 0;
+        nkwargs = 0;
     }
-    if (nargs + nkeywords > len) {
+    if (nargs + nkwargs > len) {
         PyErr_Format(PyExc_TypeError,
                      "%s%s takes at most %d argument%s (%zd given)",
                      (parser->fname == NULL) ? "function" : parser->fname,
                      (parser->fname == NULL) ? "" : "()",
                      len,
                      (len == 1) ? "" : "s",
-                     nargs + nkeywords);
+                     nargs + nkwargs);
         return cleanreturn(0, &freelist);
     }
     if (parser->max < nargs) {
@@ -1957,9 +2021,9 @@ vgetargskeywordsfast_impl(PyObject **args, Py_ssize_t nargs,
         assert(!IS_END_OF_FORMAT(*format));
 
         current_arg = NULL;
-        if (nkeywords && i >= pos) {
-            if (keywords != NULL) {
-                current_arg = PyDict_GetItem(keywords, keyword);
+        if (nkwargs && i >= pos) {
+            if (kwargs != NULL) {
+                current_arg = PyDict_GetItem(kwargs, keyword);
                 if (!current_arg && PyErr_Occurred()) {
                     return cleanreturn(0, &freelist);
                 }
@@ -1969,7 +2033,7 @@ vgetargskeywordsfast_impl(PyObject **args, Py_ssize_t nargs,
             }
         }
         if (current_arg) {
-            --nkeywords;
+            --nkwargs;
             if (i < nargs) {
                 /* arg present in tuple and in dict */
                 PyErr_Format(PyExc_TypeError,
@@ -2013,7 +2077,7 @@ vgetargskeywordsfast_impl(PyObject **args, Py_ssize_t nargs,
          * fulfilled and no keyword args left, with no further
          * validation. XXX Maybe skip this in debug build ?
          */
-        if (!nkeywords) {
+        if (!nkwargs) {
             return cleanreturn(1, &freelist);
         }
 
@@ -2026,15 +2090,15 @@ vgetargskeywordsfast_impl(PyObject **args, Py_ssize_t nargs,
     assert(IS_END_OF_FORMAT(*format) || (*format == '|') || (*format == '$'));
 
     /* make sure there are no extraneous keyword arguments */
-    if (nkeywords > 0) {
-        if (keywords != NULL) {
+    if (nkwargs > 0) {
+        if (kwargs != NULL) {
             PyObject *key, *value;
             Py_ssize_t pos = 0;
-            while (PyDict_Next(keywords, &pos, &key, &value)) {
+            while (PyDict_Next(kwargs, &pos, &key, &value)) {
                 int match;
                 if (!PyUnicode_Check(key)) {
                     PyErr_SetString(PyExc_TypeError,
-                                    "keywords must be strings");
+                                    "kwargs must be strings");
                     return cleanreturn(0, &freelist);
                 }
                 match = PySequence_Contains(kwtuple, key);
@@ -2059,7 +2123,7 @@ vgetargskeywordsfast_impl(PyObject **args, Py_ssize_t nargs,
 
                 if (!PyUnicode_Check(key)) {
                     PyErr_SetString(PyExc_TypeError,
-                                    "keywords must be strings");
+                                    "kwargs must be strings");
                     return cleanreturn(0, &freelist);
                 }
 
@@ -2081,7 +2145,7 @@ vgetargskeywordsfast_impl(PyObject **args, Py_ssize_t nargs,
 }
 
 static int
-vgetargskeywordsfast(PyObject *args, PyObject *keywords,
+vgetargskeywordsfast(PyObject *args, PyObject *kwargs,
                      struct _PyArg_Parser *parser, va_list *p_va, int flags)
 {
     PyObject **stack;
@@ -2089,7 +2153,7 @@ vgetargskeywordsfast(PyObject *args, PyObject *keywords,
 
     if(args == NULL 
             || !PyTuple_Check(args)
-            || (keywords != NULL && !PyDict_Check(keywords)))
+            || (kwargs != NULL && !PyDict_Check(kwargs)))
     {
         PyErr_BadInternalCall();
         return 0;
@@ -2097,7 +2161,7 @@ vgetargskeywordsfast(PyObject *args, PyObject *keywords,
 
     stack = &PyTuple_GET_ITEM(args, 0);
     nargs = PyTuple_GET_SIZE(args);
-    return vgetargskeywordsfast_impl(stack, nargs, keywords, NULL,
+    return vgetargskeywordsfast_impl(stack, nargs, kwargs, NULL,
                                      parser, p_va, flags);
 }
 

--- a/third_party/python/Python/getargs.c
+++ b/third_party/python/Python/getargs.c
@@ -1789,7 +1789,7 @@ parser_init(struct _PyArg_Parser *parser)
     PyObject *kwtuple;
 
     assert(parser->format != NULL);
-    assert(parser->kwargs != NULL);
+    assert(parser->keywords != NULL);
     if (parser->kwtuple != NULL) {
         return 1;
     }

--- a/third_party/python/Python/getargs.c
+++ b/third_party/python/Python/getargs.c
@@ -1379,13 +1379,7 @@ _PyArg_ParseTupleAndKeywordsFast(PyObject *args, PyObject *keywords,
 {
     int retval;
     va_list va;
-    if ((args == NULL || !PyTuple_Check(args)) ||
-        (keywords != NULL && !PyDict_Check(keywords)) ||
-        parser == NULL)
-    {
-        PyErr_BadInternalCall();
-        return 0;
-    }
+
     va_start(va, parser);
     retval = vgetargskeywordsfast(args, keywords, parser, &va, 0);
     va_end(va);
@@ -1398,13 +1392,7 @@ _PyArg_ParseTupleAndKeywordsFast_SizeT(PyObject *args, PyObject *keywords,
 {
     int retval;
     va_list va;
-    if ((args == NULL || !PyTuple_Check(args)) ||
-        (keywords != NULL && !PyDict_Check(keywords)) ||
-        parser == NULL)
-    {
-        PyErr_BadInternalCall();
-        return 0;
-    }
+
     va_start(va, parser);
     retval = vgetargskeywordsfast(args, keywords, parser, &va, FLAG_SIZE_T);
     va_end(va);
@@ -1417,12 +1405,7 @@ _PyArg_ParseStack(PyObject **args, Py_ssize_t nargs, PyObject *kwnames,
 {
     int retval;
     va_list va;
-    if ((kwnames != NULL && !PyTuple_Check(kwnames)) ||
-        parser == NULL)
-    {
-        PyErr_BadInternalCall();
-        return 0;
-    }
+
     va_start(va, parser);
     retval = vgetargskeywordsfast_impl(args, nargs, NULL, kwnames, parser, &va, 0);
     va_end(va);
@@ -1435,12 +1418,7 @@ _PyArg_ParseStack_SizeT(PyObject **args, Py_ssize_t nargs, PyObject *kwnames,
 {
     int retval;
     va_list va;
-    if ((kwnames != NULL && !PyTuple_Check(kwnames)) ||
-        parser == NULL)
-    {
-        PyErr_BadInternalCall();
-        return 0;
-    }
+
     va_start(va, parser);
     retval = vgetargskeywordsfast_impl(args, nargs, NULL, kwnames, parser, &va, FLAG_SIZE_T);
     va_end(va);
@@ -1453,13 +1431,7 @@ _PyArg_VaParseTupleAndKeywordsFast(PyObject *args, PyObject *keywords,
 {
     int retval;
     va_list lva;
-    if ((args == NULL || !PyTuple_Check(args)) ||
-        (keywords != NULL && !PyDict_Check(keywords)) ||
-        parser == NULL)
-    {
-        PyErr_BadInternalCall();
-        return 0;
-    }
+
     va_copy(lva, va);
     retval = vgetargskeywordsfast(args, keywords, parser, &lva, 0);
     va_end(lva);
@@ -1472,13 +1444,7 @@ _PyArg_VaParseTupleAndKeywordsFast_SizeT(PyObject *args, PyObject *keywords,
 {
     int retval;
     va_list lva;
-    if ((args == NULL || !PyTuple_Check(args)) ||
-        (keywords != NULL && !PyDict_Check(keywords)) ||
-        parser == NULL)
-    {
-        PyErr_BadInternalCall();
-        return 0;
-    }
+
     va_copy(lva, va);
     retval = vgetargskeywordsfast(args, keywords, parser, &lva, FLAG_SIZE_T);
     va_end(lva);
@@ -1922,11 +1888,16 @@ vgetargskeywordsfast_impl(PyObject **args, Py_ssize_t nargs,
     freelist.entries_malloced = 0;
 
     assert(keywords == NULL || PyDict_Check(keywords));
-    assert(kwnames == NULL || PyTuple_Check(kwnames));
     assert((keywords != NULL || kwnames != NULL)
            || (keywords == NULL && kwnames == NULL));
-    assert(parser != NULL);
     assert(p_va != NULL);
+
+    if (parser == NULL
+            || (kwnames != NULL && !PyTuple_Check(kwnames)))
+    {
+        PyErr_BadInternalCall();
+        return 0;
+    }
 
     if (!parser_init(parser)) {
         return 0;
@@ -2116,7 +2087,13 @@ vgetargskeywordsfast(PyObject *args, PyObject *keywords,
     PyObject **stack;
     Py_ssize_t nargs;
 
-    assert(args != NULL && PyTuple_Check(args));
+    if(args == NULL 
+            || !PyTuple_Check(args)
+            || (keywords != NULL && !PyDict_Check(keywords)))
+    {
+        PyErr_BadInternalCall();
+        return 0;
+    }
 
     stack = &PyTuple_GET_ITEM(args, 0);
     nargs = PyTuple_GET_SIZE(args);

--- a/third_party/python/Python/getargs.c
+++ b/third_party/python/Python/getargs.c
@@ -2394,7 +2394,7 @@ _PyArg_UnpackStack(PyObject **args, Py_ssize_t nargs, const char *name,
  * not empty, returns 1 otherwise
  */
 int
-_PyArg_NoKeywords(const char *funcname, PyObject *kwargs)
+(_PyArg_NoKeywords)(const char *funcname, PyObject *kwargs)
 {
     if (kwargs == NULL)
         return 1;
@@ -2412,7 +2412,7 @@ _PyArg_NoKeywords(const char *funcname, PyObject *kwargs)
 }
 
 int
-_PyArg_NoStackKeywords(const char *funcname, PyObject *kwnames)
+(_PyArg_NoStackKeywords)(const char *funcname, PyObject *kwnames)
 {
     if (kwnames == NULL)
         return 1;
@@ -2427,7 +2427,7 @@ _PyArg_NoStackKeywords(const char *funcname, PyObject *kwnames)
 }
 
 int
-_PyArg_NoPositional(const char *funcname, PyObject *args)
+(_PyArg_NoPositional)(const char *funcname, PyObject *args)
 {
     if (args == NULL)
         return 1;

--- a/third_party/python/Python/getargs.c
+++ b/third_party/python/Python/getargs.c
@@ -2367,16 +2367,33 @@ PyArg_UnpackTuple(PyObject *args, const char *name, Py_ssize_t min, Py_ssize_t m
  * not empty, returns 1 otherwise
  */
 int
-_PyArg_NoKeywords(const char *funcname, PyObject *kw)
+_PyArg_NoKeywords(const char *funcname, PyObject *kwargs)
 {
-    if (kw == NULL)
+    if (kwargs == NULL)
         return 1;
-    if (!PyDict_CheckExact(kw)) {
+    if (!PyDict_CheckExact(kwargs)) {
         PyErr_BadInternalCall();
         return 0;
     }
-    if (PyDict_Size(kw) == 0)
+    if (PyDict_GET_SIZE(kwargs) == 0) {
         return 1;
+    }
+
+    PyErr_Format(PyExc_TypeError, "%s does not take keyword arguments",
+                    funcname);
+    return 0;
+}
+
+int
+_PyArg_NoStackKeywords(const char *funcname, PyObject *kwnames)
+{
+    if (kwnames == NULL)
+        return 1;
+    assert(PyTuple_CheckExact(kwnames));
+    if (PyTuple_GET_SIZE(kwnames) == 0) {
+        return 1;
+    }
+
     PyErr_Format(PyExc_TypeError, "%s does not take keyword arguments",
                     funcname);
     return 0;


### PR DESCRIPTION
All commits have reference commit from cpython linked in the message.

A couple of backports are partial (IIRC the ones with OrderedDict and RecursiveCall) because the linked commits are not isolated changes; they build on some features tangentially related to METH_FASTCALL.

I'm still wary about compatibility (dictionary lookup has changed internally from 3.6 to 3.7, got segfaults when I attempted to port python/cpython@7dc6a5f50aa). However, all existing tests pass under `MODE=`, `MODE=dbg`, `MODE=opt`, and `MODE=optlinux`, so I expect backporting `METH_FASTCALL` is still ok.

`python.com` under `MODE=optlinux` is now 1.05x faster than vanilla Python 3.6.15.

| Benchmark               | py36-15  | APE-optlinux       | APE-optlinux-fastcall  |
|-------------------------|:--------:|:----------------------:|:----------------------:|
| Geometric mean          | (ref)    | 1.02x faster           | 1.05x faster           |
| chaos                   | 247 ms   | 242 ms: 1.02x faster   | 239 ms: 1.03x faster   |
| crypto_pyaes            | 214 ms   | 212 ms: 1.01x faster   | 213 ms: 1.01x faster   |
| deltablue               | 17.2 ms  | 16.3 ms: 1.05x faster  | 16.0 ms: 1.07x faster  |
| fannkuch                | 997 ms   | 1.58 sec: 1.59x slower | 1.02 sec: 1.03x slower |
| float                   | 228 ms   | 221 ms: 1.03x faster   | 213 ms: 1.07x faster   |
| go                      | 555 ms   | 524 ms: 1.06x faster   | 515 ms: 1.08x faster   |
| hexiom                  | 22.7 ms  | 22.3 ms: 1.02x faster  | 22.1 ms: 1.03x faster  |
| json_dumps              | 24.7 ms  | 27.2 ms: 1.10x slower  | 27.0 ms: 1.09x slower  |
| json_loads              | 51.5 us  | 48.3 us: 1.07x faster  | 47.2 us: 1.09x faster  |
| logging_format          | 23.7 us  | 27.0 us: 1.14x slower  | 26.2 us: 1.11x slower  |
| logging_silent          | 745 ns   | 697 ns: 1.07x faster   | 692 ns: 1.08x faster   |
| logging_simple          | 20.4 us  | 23.4 us: 1.15x slower  | 22.8 us: 1.12x slower  |
| meteor_contest          | 199 ms   | 202 ms: 1.02x slower   | 201 ms: 1.01x slower   |
| nbody                   | 245 ms   | 249 ms: 1.02x slower   | 244 ms: 1.01x faster   |
| nqueens                 | 206 ms   | 199 ms: 1.03x faster   | 202 ms: 1.02x faster   |
| pathlib                 | 39.5 ms  | 36.9 ms: 1.07x faster  | not significant        |
| pickle                  | 20.1 us  | 17.3 us: 1.16x faster  | 17.9 us: 1.12x faster  |
| pickle_dict             | 57.5 us  | 39.5 us: 1.45x faster  | 39.4 us: 1.46x faster  |
| pickle_list             | 8.10 us  | 6.19 us: 1.31x faster  | 6.20 us: 1.31x faster  |
| pickle_pure_python      | 1.07 ms  | 994 us: 1.08x faster   | 978 us: 1.10x faster   |
| pidigits                | 293 ms   | 293 ms: 1.00x faster   | 292 ms: 1.00x faster   |
| pyflate                 | 1.45 sec | not significant        | 1.47 sec: 1.01x slower |
| python_startup          | 17.3 ms  | 17.4 ms: 1.01x slower  | 15.9 ms: 1.09x faster  |
| python_startup_no_site  | 10.8 ms  | 10.5 ms: 1.03x faster  | 10.4 ms: 1.04x faster  |
| raytrace                | 1.23 sec | 1.14 sec: 1.07x faster | 1.14 sec: 1.08x faster |
| regex_compile           | 384 ms   | 364 ms: 1.06x faster   | 365 ms: 1.05x faster   |
| regex_dna               | 281 ms   | 288 ms: 1.02x slower   | 286 ms: 1.02x slower   |
| regex_effbot            | 4.97 ms  | 5.00 ms: 1.01x slower  | 4.86 ms: 1.02x faster  |
| regex_v8                | 43.1 ms  | 43.5 ms: 1.01x slower  | 41.9 ms: 1.03x faster  |
| richards                | 171 ms   | 163 ms: 1.05x faster   | 161 ms: 1.06x faster   |
| scimark_fft             | 624 ms   | 617 ms: 1.01x faster   | 632 ms: 1.01x slower   |
| scimark_lu              | 486 ms   | 473 ms: 1.03x faster   | 440 ms: 1.11x faster   |
| scimark_monte_carlo     | 222 ms   | 219 ms: 1.01x faster   | 215 ms: 1.04x faster   |
| scimark_sor             | 466 ms   | 456 ms: 1.02x faster   | 445 ms: 1.05x faster   |
| scimark_sparse_mat_mult | 7.57 ms  | 6.97 ms: 1.09x faster  | not significant        |
| spectral_norm           | 254 ms   | 258 ms: 1.01x slower   | 261 ms: 1.03x slower   |
| telco                   | 14.3 ms  | 13.2 ms: 1.08x faster  | 10.9 ms: 1.30x faster  |
| unpack_sequence         | 85.1 ns  | 91.1 ns: 1.07x slower  | 90.9 ns: 1.07x slower  |
| unpickle                | 28.2 us  | 25.7 us: 1.10x faster  | 24.7 us: 1.14x faster  |
| unpickle_list           | 7.27 us  | 7.10 us: 1.02x faster  | 7.09 us: 1.03x faster  |
| unpickle_pure_python    | 796 us   | 750 us: 1.06x faster   | 705 us: 1.13x faster   |
| xml_etree_parse         | 277 ms   | 263 ms: 1.05x faster   | 262 ms: 1.05x faster   |
| xml_etree_iterparse     | 222 ms   | 213 ms: 1.04x faster   | 204 ms: 1.09x faster   |
| xml_etree_generate      | 223 ms   | 208 ms: 1.07x faster   | 204 ms: 1.09x faster   |
| xml_etree_process       | 178 ms   | 174 ms: 1.02x faster   | 171 ms: 1.04x faster   |