### PR TITLE
Extend GetZipPaths to accept an optional prefix to filter based on

### DIFF
--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -742,9 +742,10 @@ FUNCTIONS
            minor (mm), and patch (pp) versions encoded. The version value 1.4
            would be represented as 0x010400.
 
-   GetZipPaths() → {path:str,...}
+   GetZipPaths([prefix:str]) → {path:str,...}
            Returns paths of all assets in the zip central directory, prefixed
-           by a slash.
+           by a slash. If prefix parameter is provided, then only paths that
+           start with the prefix (case sensitive) are returned.
 
    HasParam(name:str) → bool
            Returns true if parameter with name was supplied in either the

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -4999,7 +4999,8 @@ static int LuaIsHiddenPath(lua_State *L) {
 static int LuaGetZipPaths(lua_State *L) {
   char *path;
   uint8_t *zcf;
-  size_t i, n, pathlen;
+  size_t i, n, pathlen, prefixlen;
+  char *prefix = luaL_optlstring(L, 1, "", &prefixlen);
   lua_newtable(L);
   i = 0;
   n = GetZipCdirRecords(zcdir);
@@ -5007,8 +5008,10 @@ static int LuaGetZipPaths(lua_State *L) {
        zcf += ZIP_CFILE_HDRSIZE(zcf)) {
     CHECK_EQ(kZipCfileHdrMagic, ZIP_CFILE_MAGIC(zcf));
     path = GetAssetPath(zcf, &pathlen);
-    lua_pushlstring(L, path, pathlen);
-    lua_seti(L, -2, ++i);
+    if (prefixlen == 0 || startswith(path, prefix)) {
+      lua_pushlstring(L, path, pathlen);
+      lua_seti(L, -2, ++i);
+    }
     free(path);
   }
   return 1;


### PR DESCRIPTION
This allows pre-filtering returned paths instead of post-filtering them.