### PR TITLE
Fix incorrect reference in Lua encoding

### DIFF
--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -4763,8 +4763,8 @@ static void EscapeLuaString(char *s, size_t len, char **buf) {
     if (s[i] == '\\' || s[i] == '\"' || s[i] == '\n' ||
         s[i] == '\0' || s[i] == '\r') {
       appendw(buf, '\\' | 'x' << 010 |
-        "0123456789abcdef"[(c & 0xF0) >> 4] << 020 |
-        "0123456789abcdef"[(c & 0x0F) >> 0] << 030);
+        "0123456789abcdef"[(s[i] & 0xF0) >> 4] << 020 |
+        "0123456789abcdef"[(s[i] & 0x0F) >> 0] << 030);
     } else {
       appendd(buf, s+i, 1);
     }


### PR DESCRIPTION
@jart, this is a follow-up to #322, as I marked the comment as resolved before the compilation was done and there was a typo that needs to be fixed. My apologies.