### PR TITLE
Redbean StoreAsset fix and lua cli

### DIFF
--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -34,6 +34,7 @@ FLAGS
   -b        log message bodies
   -a        log resource usage
   -g        log handler latency
+  -e        run specified Lua command
   -j        enable ssl client verify
   -k        disable ssl fetch verify
   -f        log worker function calls
@@ -47,6 +48,7 @@ FLAGS
   -R /X=/Y  rewrites X to Y                   [repeatable]
   -K PATH   tls private key path              [repeatable]
   -C PATH   tls certificate(s) path           [repeatable]
+  -A PATH   add asset with path               [repeatable]
   -M INT    tunes max message payload size    [def. 65536]
   -t INT    timeout ms or keepalive sec if <0 [def. 60000]
   -p PORT   listen port                       [def. 8080; repeatable]
@@ -743,7 +745,7 @@ FUNCTIONS
            flag was used. If slurping large file into memory is a concern,
            then consider using ServeAsset which can serve directly off disk.
 
-   StoreAsset(path:str,data:str,mode:int)
+   StoreAsset(path:str,data:str[,mode:int])
            Stores asset to executable's ZIP central directory. This currently
            happens in an append-only fashion and is still largely in the
            proof-of-concept stages. Currently only supported on Linux, XNU,

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -3303,11 +3303,15 @@ static int LuaStoreAsset(lua_State *L) {
   oldcdirsize = GetZipCdirSize(zcdir);
   oldcdiroffset = GetZipCdirOffset(zcdir);
   if (a) {
+    // to remove an existing asset,
+    // first copy the central directory part before its record
     v[4].iov_base = zbase + oldcdiroffset;
     v[4].iov_len = a->cf - oldcdiroffset;
-    v[5].iov_base = zbase + oldcdiroffset + ZIP_CFILE_HDRSIZE(zbase + a->cf);
-    v[5].iov_len =
-        oldcdirsize - v[4].iov_len - ZIP_CFILE_HDRSIZE(zbase + a->cf);
+    // and then the rest of the central directory
+    v[5].iov_base = zbase + oldcdiroffset +
+        (v[4].iov_len + ZIP_CFILE_HDRSIZE(zbase + a->cf));
+    v[5].iov_len = oldcdirsize -
+        (v[4].iov_len + ZIP_CFILE_HDRSIZE(zbase + a->cf));
   } else {
     v[4].iov_base = zbase + oldcdiroffset;
     v[4].iov_len = oldcdirsize;


### PR DESCRIPTION
@jart, this patch implements three (related) changes:

(removed this one, as it's handled in #360) 1. Moves Fetch SSL check to a later spot and makes the dependency more clear
2. Fixes an issue with StoreAsset when the asset with the same name is already present (the base for the rest of the central dictionary was off, which was creating an invalid archive)
3. Adds -A and -e options to add asset(s) from the comment line and executing Lua commands from the command line. I realize that StoreAsset is not available on Windows and some other systems, but I find it very convenient to have a self-reliant system and expect StoreAsset to become available on Windows as well. The documentation/convenience would be improved as well, as it wouldn't require using system zip and archive renaming.

Feel free to cherry-pick if you disagree with some of these items proposed.