### PR TITLE
Fix Content-Type being generated twice after setting content type

### DIFF
--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -353,6 +353,7 @@ static bool connectionclose;
 static bool hasonworkerstop;
 static bool hasonworkerstart;
 static bool hasonhttprequest;
+static bool hascontenttype;
 static bool ishandlingrequest;
 static bool keyboardinterrupt;
 static bool listeningonport443;
@@ -1958,6 +1959,7 @@ static char *AppendContentType(char *p, const char *ct) {
       referrerpolicy = "no-referrer-when-downgrade";
     }
   }
+  hascontenttype = true;
   return AppendCrlf(p);
 }
 
@@ -2865,12 +2867,7 @@ static char *ServeIndex(const char *path, size_t pathlen) {
 }
 
 static char *GetLuaResponse(void) {
-  char *p;
-  if (!(p = luaheaderp)) {
-    p = SetStatus(200, "OK");
-    p = AppendContentType(p, "text/html");
-  }
-  return p;
+  return luaheaderp ? luaheaderp : SetStatus(200, "OK");
 }
 
 static bool IsLoopbackClient() {
@@ -6349,6 +6346,7 @@ static char *SetStatus(unsigned code, const char *reason) {
     if (code == 308) code = 301;
   }
   statuscode = code;
+  hascontenttype = false; // reset, as the headers are reset
   stpcpy(hdrbuf.p, "HTTP/1.0 000 ");
   hdrbuf.p[7] += msg.version & 1;
   hdrbuf.p[9] += code / 100;
@@ -6495,6 +6493,11 @@ static bool HandleMessageAcutal(void) {
       p = stpcpy(p, "Connection: keep-alive\r\n");
     }
   }
+  // keep content-type update *before* referrerpolicy
+  // https://datatracker.ietf.org/doc/html/rfc2616#section-7.2.1
+  if (!hascontenttype && contentlength > 0) {
+    p = AppendContentType(p, "text/html");
+  }
   if (referrerpolicy) {
     p = stpcpy(p, "Referrer-Policy: ");
     p = stpcpy(p, referrerpolicy);
@@ -6533,6 +6536,7 @@ static void InitRequest(void) {
   generator = 0;
   luaheaderp = 0;
   contentlength = 0;
+  hascontenttype = false;
   referrerpolicy = 0;
   InitHttpMessage(&msg, kHttpRequest);
 }


### PR DESCRIPTION
@jart, this fixes a couple of issues with the current content-type header generation:

1. `SetStatus(200); Write("foo")` does not send content-type at all
2. `SetHeader('Content-Type', "some value")` sets two content-type headers (as the first one is being set by `GetLuaResponse`) and the second is set by the SetHeader itself, which is not correct according to the spec

I confirmed that the sequence `SetHeader('Content-Type', "some value"); SetStatus(200); Write("foo")` correctly sets the default header value (as the existing one is reset after `SetStatus()`). There shouldn't be any interaction with all Serve* methods (as long as the content type is set using `AppendContentType`).

I also added a check for the content length being non-zero, as the content type is not needed otherwise.
