### PR TITLE
Fix executable name generation under QEMU (closes #346)

### DIFF
--- a/libc/runtime/program_executable_name.c
+++ b/libc/runtime/program_executable_name.c
@@ -78,10 +78,9 @@ static textstartup void GetProgramExecutableName(char executable[SIZE],
                                                  char *p) {
   char *t;
   size_t m;
-  ssize_t n;
   int cmd[4];
+  ssize_t n = 0;
   if (IsWindows() && GetNtExePath(executable)) return;
-  n = 0;
   if (fileexists(p)) {
     if (!_isabspath(p)) {
       if (getcwd(executable, SIZE - 1)) {
@@ -111,6 +110,7 @@ static textstartup void GetProgramExecutableName(char executable[SIZE],
       return;
     }
   }
+  if (n < 0) n = 0;
   for (; *p; ++p) {
     if (n + 1 < SIZE) {
       executable[n++] = *p;


### PR DESCRIPTION
Per discussion in #346, this should fix the clobbering of the return address. Thanks to @tkchia for the patch suggestion.