### PR TITLE
Redbean ssl identification

### DIFF
--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -672,6 +672,10 @@ FUNCTIONS
    GetScheme() → str
            Returns scheme from Request-URL, if any.
 
+   GetSslIdentity() → str
+           Returns certificate subject or PSK identity from the current SSL
+           session. `nil` is returned for regular (non-SSL) connections.
+
    GetStatus() → int
            Returns current status (as set by an earlier SetStatus call) or
            `nil` if the status hasn't been set yet.

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -604,9 +604,9 @@ static void InternCertificate(mbedtls_x509_crt *cert, mbedtls_x509_crt *prev) {
     }
   }
   if (mbedtls_x509_time_is_past(&cert->valid_to)) {
-    WARNF("(ssl) certificate is expired", gc(FormatX509Name(&cert->subject)));
+    WARNF("(ssl) certificate %`'s is expired", gc(FormatX509Name(&cert->subject)));
   } else if (mbedtls_x509_time_is_future(&cert->valid_from)) {
-    WARNF("(ssl) certificate is from the future",
+    WARNF("(ssl) certificate %`'s is from the future",
           gc(FormatX509Name(&cert->subject)));
   }
   for (i = 0; i < certs.n; ++i) {

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -3201,16 +3201,18 @@ static int LuaGetStatus(lua_State *L) {
 static int LuaGetSslIdentity(lua_State *L) {
   const mbedtls_x509_crt *cert;
   OnlyCallDuringRequest(L, "GetSslIdentity");
-  if (!usessl)
+  if (!usessl) {
     lua_pushnil(L);
-  else
+  } else {
     if (sslpskindex) {
+      CHECK((sslpskindex-1) >= 0 && (sslpskindex-1) < psks.n);
       lua_pushlstring(L, psks.p[sslpskindex-1].identity,
                          psks.p[sslpskindex-1].identity_len);
     } else {
       cert = mbedtls_ssl_get_peer_cert(&ssl);
       lua_pushstring(L, cert ? gc(FormatX509Name(&cert->subject)) : "");
     }
+  }
   return 1;
 }
 


### PR DESCRIPTION
@jart, this PR implements several changes:

1. Fixes a small issue with SSL error messages
2. Updates Fetch to initialize TLS instead of failing
3. Adds GetSslIdentity that reports PSK identity or cert->subject
4. Adds ProgramSslInit (undocumented per our discussion) that resets some of PSK/cipher initializations (but not all; I think these are enough).

I tested on reporting PSK identity and on adding a new private key and calling ProgramSslInit to make fetch work with the new key. Everything checks out for me, but I haven't tested client certs.