### PR TITLE
Redbean save ape

### DIFF
--- a/libc/runtime/openexecutable.S
+++ b/libc/runtime/openexecutable.S
@@ -121,19 +121,20 @@ OpenExecutable:
 	mov	-0x08(%rbp),%eax		# __NR_open
 	mov	%r14,%rdi
 	mov	-0x20(%rbp),%esi		# O_RDWR
-	syscall
-	mov	%eax,%r15d
-	mov	$-1,%eax			# check if successful
-	cmp	%eax,%r15d
-	jne	0f
+        clc                                     # clear carry flag
+        syscall
+        jc      .Lohno                          # bsd error
+        cmp     $-4095,%eax
+        jae     .Lohno                          # linux error
+        jmp     .Lok
 
-//	Open executable in read-only mode.
-	mov	-0x08(%rbp),%eax		# __NR_open
-	mov	%r14,%rdi
-	mov	-0x48(%rbp),%esi		# O_RDONLY
-	syscall
-	mov	%eax,%r15d
-0:
+//      Open executable in read-only mode.
+.Lohno: mov     -0x08(%rbp),%eax                # __NR_open
+        mov     %r14,%rdi
+        mov     -0x48(%rbp),%esi                # O_RDONLY
+        syscall
+
+.Lok:   mov	%eax,%r15d
 
 //	Map code segment.
 	mov	-0x10(%rbp),%eax		# __NR_mmap

--- a/libc/runtime/openexecutable.S
+++ b/libc/runtime/openexecutable.S
@@ -41,6 +41,7 @@ OpenExecutable:
 	pushq	MAP_PRIVATE(%rip)		# -0x30(%rbp)
 	pushq	MAP_FIXED(%rip)			# -0x38(%rbp)
 	pushq	__NR_mprotect(%rip)		# -0x40(%rbp)
+	pushq	O_RDONLY(%rip)			# -0x48(%rbp)
 	push	%rbx				# code buffer
 	push	%r12				# data buffer
 	push	%r14				# filename
@@ -122,6 +123,17 @@ OpenExecutable:
 	mov	-0x20(%rbp),%esi		# O_RDWR
 	syscall
 	mov	%eax,%r15d
+	mov	$-1,%eax			# check if successful
+	cmp	%eax,%r15d
+	jne	0f
+
+//	Open executable in read-only mode.
+	mov	-0x08(%rbp),%eax		# __NR_open
+	mov	%r14,%rdi
+	mov	-0x48(%rbp),%esi		# O_RDONLY
+	syscall
+	mov	%eax,%r15d
+0:
 
 //	Map code segment.
 	mov	-0x10(%rbp),%eax		# __NR_mmap

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -6854,8 +6854,8 @@ static void RestoreApe(void) {
   if (endswith(zpath, ".com.dbg")) return;
   if ((a = GetAssetZip("/.ape", 5)) && (p = LoadAsset(a, &n))) {
     close(zfd);
-    zfd = OpenExecutable();
-    write(zfd, p, n);
+    if ((zfd = OpenExecutable()) == -1 || write(zfd, p, n) == -1)
+      WARNF("(srvr) can't restore .ape");
     free(p);
   } else {
     WARNF("(srvr) /.ape not found");


### PR DESCRIPTION
This should fix a crash on Linux/BSD when OpenExecutable fails to open redbean image in RW mode (#344). The image is opened in readonly mode, so a subsequent write will fail, but that's the best that can be done anyway.