### PR TITLE
Redbean fixes for ProgramUniprocess and storing symlinked folders with -A

### DIFF
--- a/tool/net/demo/maxmind.lua
+++ b/tool/net/demo/maxmind.lua
@@ -297,14 +297,14 @@ local function main()
       if geo then
          Dump(geo)
       else
-         Write('<p>Not found\n')
+         Write('<p>Not found</p>\n')
       end
 
       Write('<h3>Maxmind ASN DB</h3>')
       if asn then
          Dump(asn)
       else
-         Write('<p>Not found\n')
+         Write('<p>Not found</p>\n')
       end
    end
 

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -3532,7 +3532,7 @@ static void StorePath(const char *dirpath) {
   while ((e = readdir(d))) {
     if (strcmp(e->d_name, ".") == 0) continue;
     if (strcmp(e->d_name, "..") == 0) continue;
-    path = _gc(xjoinpaths(dirpath, e->d_name));
+    path = gc(xjoinpaths(dirpath, e->d_name));
     if (e->d_type == DT_DIR) {
       StorePath(path);
     } else {

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -5153,9 +5153,7 @@ static int LuaProgramUniprocess(lua_State *L) {
     return luaL_argerror(L, 1, "invalid uniprocess mode; boolean expected");
 
   lua_pushboolean(L, uniprocess);
-  if (!IsWindows()) {  // uniprocess can't be disabled on Windows yet
-    if (lua_isboolean(L, 1)) uniprocess = lua_toboolean(L, 1);
-  }
+  if (lua_isboolean(L, 1)) uniprocess = lua_toboolean(L, 1);
   return 1;
 }
 

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -3526,7 +3526,8 @@ static void StorePath(const char *dirpath) {
   DIR *d;
   char *path;
   struct dirent *e;
-  if (!isdirectory(dirpath)) return StoreFile(dirpath);
+  if (!isdirectory(dirpath) && !endswith(dirpath, "/"))
+    return StoreFile(dirpath);
   if (!(d = opendir(dirpath))) DIEF("Can't open %`'s", dirpath);
   while ((e = readdir(d))) {
     if (strcmp(e->d_name, ".") == 0) continue;

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -4637,6 +4637,7 @@ static int LuaEncodeUrl(lua_State *L) {
     }
     data = EncodeUrl(&h, &size);
     lua_pushlstring(L, data, size);
+    free(h.params.p);
     free(data);
   } else {
     lua_pushnil(L);


### PR DESCRIPTION
This makes several small improvements/fixes:
- Allows -A to store symlinked directories
- Fixes ProgramUniprocess to enable it on Windows (since forking is supported there)
- Improves StoreFile to drop leading `./` in the path for the stored file and to check for reasonable path (also free memory).
- Adds freeing memory in LuaEncodeUrl (which was reported as unfreed with debug build)