### PR TITLE
Reset Lua stack to drop unused returned values

### DIFF
--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -176,6 +176,7 @@ STATIC_YOINK("zip_uri_support");
       char *s = LuaFormatStack(L);                \
       WARNF("lua stack should be empty!\n%s", s); \
       free(s);                                    \
+      lua_settop(L, 0);                           \
     }                                             \
   } while (0)
 
@@ -1065,9 +1066,9 @@ static bool LuaOnClientConnection(void) {
     dropit = lua_toboolean(L, -1);
   } else {
     LogLuaError("OnClientConnection", lua_tostring(L, -1));
-    lua_pop(L, 1);  // pop error
     dropit = false;
   }
+  lua_pop(L, 1);  // pop result or error
   AssertLuaStackIsEmpty(L);
   return dropit;
 #else


### PR DESCRIPTION
Since some Lua code may return values that will be left on stack, they need to be removed to avoid growing the stack unnecessarily.

@jart, I left the stack reporting intact, but added resetting the Lua stack, so subsequent requests are not affected by previous ones that may leave something on the Lua stack.

Also fixed a small issue where a legitimate return value was reported as a warning.