### PR TITLE
Build on macOS/Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ PKGS =
 
 -include ~/.cosmo.mk
 include build/functions.mk			#─┐
+include build/compiler.mk			#─┐
 include build/definitions.mk			# ├──META
 include build/config.mk				# │  You can build
 include build/rules.mk				# │  You can topologically order

--- a/build/compiler.mk
+++ b/build/compiler.mk
@@ -12,7 +12,8 @@ PKG = build/bootstrap/package.com
 MKDEPS = build/bootstrap/mkdeps.com
 ZIPOBJ = build/bootstrap/zipobj.com
 
-ifeq ($(MODE), darwin)
+ifeq ($(shell uname), Darwin)
+
 TOOLPREFIX=/usr/local/bin/x86_64-linux-musl-
 AS = $(TOOLPREFIX)as
 CC = $(TOOLPREFIX)gcc

--- a/build/compiler.mk
+++ b/build/compiler.mk
@@ -1,0 +1,43 @@
+#-*-mode:makefile-gmake;indent-tabs-mode:t;tab-width:8;coding:utf-8-*-┐
+#───vi: set et ft=make ts=8 tw=8 fenc=utf-8 :vi───────────────────────┘
+#
+# SYNOPSIS
+#
+#   Cosmopolitan Compiler and Toold Definitions
+#
+
+# see build/compile, etc. which run third_party/gcc/unbundle.sh
+AR = build/bootstrap/ar.com
+PKG = build/bootstrap/package.com
+MKDEPS = build/bootstrap/mkdeps.com
+ZIPOBJ = build/bootstrap/zipobj.com
+
+ifeq ($(MODE), darwin)
+TOOLPREFIX=/usr/local/bin/x86_64-linux-musl-
+AS = $(TOOLPREFIX)as
+CC = $(TOOLPREFIX)gcc
+CXX = $(TOOLPREFIX)g++
+CXXFILT = $(TOOLPREFIX)c++filt
+LD = $(TOOLPREFIX)ld.bfd
+NM = $(TOOLPREFIX)nm
+GCC = $(TOOLPREFIX)gcc
+STRIP = $(TOOLPREFIX)strip
+OBJCOPY = $(TOOLPREFIX)objcopy
+OBJDUMP = $(TOOLPREFIX)ojbdump
+ADDRLINE = $(TOOLPREFIX)addr2line
+
+else
+
+AS = o/third_party/gcc/bin/x86_64-linux-musl-as
+CC = o/third_party/gcc/bin/x86_64-linux-musl-gcc
+CXX = o/third_party/gcc/bin/x86_64-linux-musl-g++
+CXXFILT = o/third_party/gcc/bin/x86_64-linux-musl-c++filt
+LD = o/third_party/gcc/bin/x86_64-linux-musl-ld.bfd
+NM = o/third_party/gcc/bin/x86_64-linux-musl-nm
+GCC = o/third_party/gcc/bin/x86_64-linux-musl-gcc
+STRIP = o/third_party/gcc/bin/x86_64-linux-musl-strip
+OBJCOPY = o/third_party/gcc/bin/x86_64-linux-musl-objcopy
+OBJDUMP = o/third_party/gcc/bin/x86_64-linux-musl-objdump
+ADDR2LINE = $(shell pwd)/o/third_party/gcc/bin/x86_64-linux-musl-addr2line
+
+endif

--- a/build/config.mk
+++ b/build/config.mk
@@ -308,6 +308,23 @@ OBJDUMP = llvm-objdump
 ADDR2LINE = llvm-addr2line
 endif
 
+# macOS using gcc - options copied from Tiny Metallic Unix Mode
+ifeq ($(MODE), darwin)
+CONFIG_CPPFLAGS +=		\
+	-DTINY			\
+	-DNDEBUG		\
+	-DTRUSTWORTHY		\
+	-DSUPPORT_VECTOR=251
+CONFIG_CCFLAGS +=		\
+	-Os			\
+	-fno-align-functions	\
+	-fno-align-jumps	\
+	-fno-align-labels	\
+	-fno-align-loops
+TARGET_ARCH ?=			\
+	-msse3
+endif
+
 # ANSI Mode
 #
 # These flags cause GCC to predefine __STRICT_ANSI__. Please be warned

--- a/build/config.mk
+++ b/build/config.mk
@@ -308,23 +308,6 @@ OBJDUMP = llvm-objdump
 ADDR2LINE = llvm-addr2line
 endif
 
-# macOS using gcc - options copied from Tiny Metallic Unix Mode
-ifeq ($(MODE), darwin)
-CONFIG_CPPFLAGS +=		\
-	-DTINY			\
-	-DNDEBUG		\
-	-DTRUSTWORTHY		\
-	-DSUPPORT_VECTOR=251
-CONFIG_CCFLAGS +=		\
-	-Os			\
-	-fno-align-functions	\
-	-fno-align-jumps	\
-	-fno-align-labels	\
-	-fno-align-loops
-TARGET_ARCH ?=			\
-	-msse3
-endif
-
 # ANSI Mode
 #
 # These flags cause GCC to predefine __STRICT_ANSI__. Please be warned

--- a/build/definitions.mk
+++ b/build/definitions.mk
@@ -54,23 +54,6 @@ GZ ?= gzip
 CLANG = clang
 FC = gfortran  #/opt/cross9f/bin/x86_64-linux-musl-gfortran
 
-# see build/compile, etc. which run third_party/gcc/unbundle.sh
-AR = build/bootstrap/ar.com
-PKG = build/bootstrap/package.com
-MKDEPS = build/bootstrap/mkdeps.com
-ZIPOBJ = build/bootstrap/zipobj.com
-AS = o/third_party/gcc/bin/x86_64-linux-musl-as
-CC = o/third_party/gcc/bin/x86_64-linux-musl-gcc
-CXX = o/third_party/gcc/bin/x86_64-linux-musl-g++
-CXXFILT = o/third_party/gcc/bin/x86_64-linux-musl-c++filt
-LD = o/third_party/gcc/bin/x86_64-linux-musl-ld.bfd
-NM = o/third_party/gcc/bin/x86_64-linux-musl-nm
-GCC = o/third_party/gcc/bin/x86_64-linux-musl-gcc
-STRIP = o/third_party/gcc/bin/x86_64-linux-musl-strip
-OBJCOPY = o/third_party/gcc/bin/x86_64-linux-musl-objcopy
-OBJDUMP = o/third_party/gcc/bin/x86_64-linux-musl-objdump
-ADDR2LINE = $(shell pwd)/o/third_party/gcc/bin/x86_64-linux-musl-addr2line
-
 COMMA := ,
 PWD := $(shell pwd)
 IMAGE_BASE_VIRTUAL ?= 0x400000

--- a/build/getccversion
+++ b/build/getccversion
@@ -18,8 +18,10 @@
 #   links GCC runtimes when using later versions, so some concerns might
 #   not apply.
 
-if [ ! -d o/third_party/gcc ]; then
-  third_party/gcc/unbundle.sh
+if [ x`uname -s` != xDarwin ]; then
+    if [ ! -d o/third_party/gcc ]; then
+      third_party/gcc/unbundle.sh
+    fi
 fi
 
 set -e

--- a/build/sanitycheck
+++ b/build/sanitycheck
@@ -9,7 +9,7 @@
 #   This script is launched at the start of Makefile to detect if
 #   binfmt_misc was tuned to launch 'MZ' shell scripts under WINE
 
-if [ x`uname -s` != xLinux ]; then
+if [ x`uname -s` != xLinux -a x`uname -s` != xDarwin ]; then
   cat <<'EOF' >&2
 
 ERROR

--- a/test/libc/release/emulate.sh
+++ b/test/libc/release/emulate.sh
@@ -8,6 +8,10 @@ if [ "$MODE" = opt ] || [ "$MODE" = optlinux ]; then
   exit
 fi
 
+if [ "$MODE" = darwin ]; then
+  exit  # TODO
+fi
+
 # smoke test userspace binary emulation
 CMD="o/$MODE/tool/build/blinkenlights.com.dbg o/$MODE/examples/hello.com"
 if OUTPUT="$($CMD)"; then

--- a/tool/build/compile.c
+++ b/tool/build/compile.c
@@ -946,7 +946,9 @@ int main(int argc, char *argv[]) {
       AddArg("-Wno-unused-command-line-argument");
       AddArg("-Wno-incompatible-pointer-types-discards-qualifiers");
     }
-    AddArg("-no-canonical-prefixes");
+    if (!IsXnu()) {
+      AddArg("-no-canonical-prefixes");
+    }
     if (!__nocolor) {
       AddArg(firstnonnull(colorflag, "-fdiagnostics-color=always"));
     }


### PR DESCRIPTION
Adds the ability to build Cosmopolitan on macOS.

Prerequisites:
[Rich Felker's gcc cross-compiler](https://github.com/FiloSottile/homebrew-musl-cross).
[Gnu Make v4.3](https://stackoverflow.com/questions/43175529/updating-make-version-on-mac).
These can quickly be installed using:
```
brew install filosottile/musl-cross/musl-cross
brew install make --with-default-names
```
Note: Test with `make --version` and make sure NOT v3.8. Using make v3.8 will result in very strange errors, as the $(file...) function is silently ignored.

After installation of the cross compiler and make, the repo can be compiled using:
```
make MODE=darwin
```

@jart, the file build/compiler.mk was added as the CC= variable must be set prior to including build/definitions.mk, or the Linux bootstrapped versions of the cross compiler end up being called due to SPAWNER and COMPILE macros. I thought adding this new file was the best solution, and it is also the easiest to understand and/or modify for future cross-compilers. Ideally, $(MODE) isn't checked in compiler.mk, but instead `uname -s` run and compared with "Darwin". This would separate the cross compiler used from the MODE= options in the future.

The options I selected for MODE=darwin in config.mk are just copied from the Tiny Metallic Unix Mode. Ultimately, we shouldn't have to specify MODE=darwin, but instead be allowed to use any MODE=, just like Linux. This would work if `uname -s` were used in compiler.mk. I don't know enough about the various MODEs to feel comfortable changing that yet.

Of course, build/bootstrap/compile.com will need to be updated; this PR does not supply a binary compile.com.

If accepted, I can change README.md for macOS build instructions.

The libc tests aren't done in test/libc/release/emulate.sh, which will need further work. The build was completing up to the chibicc compile, which then tries to run chibicc.dbg, which of course is an ELF binary and won't run on macOS. That can be looked into later.

On pulling the latest repo to test this PR, the build is failing on test/libc/runtime/mprotect_test.c, for which new repo code must have changed something. I haven't had time to look into that yet. Here is the full error:
```
make MODE=darwin
♥cosmo
error:test/libc/runtime/mprotect_test.c:202: mprotect_testBadProt_failsEinval() on zorg
	EXPECT_EQ(-1, mprotect(p, 0, -1))
		need -1	(or 0xffffffffffffffff) =
		 got 0	(or 0 or ' ')
	EUNKNOWN
	o/darwin/test/libc/runtime/mprotect_test.com.tmp.14409 @ zorg
error:test/libc/runtime/mprotect_test.c:203: mprotect_testBadProt_failsEinval() on zorg
	EXPECT_EQ(EINVAL, errno)
		need 22	(or 0x16 or '▬') =
		 got 0	(or 0 or ' ')
	EUNKNOWN
	o/darwin/test/libc/runtime/mprotect_test.com.tmp.14409 @ zorg
2 / 44 tests failed

`make MODE=darwin -j4 o/darwin/test/libc/runtime/mprotect_test.com.runs` exited with 2:
o/darwin/test/libc/runtime/mprotect_test.com
```
I will look further into the regression tests with fixes, if required, in a separate PR.
