### PR TITLE
Makefile: incorrect executable location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@
 #
 #   # basic debugging
 #   make -j8 -O MODE=dbg o/dbg/examples/crashreport.com
-#   o/dbg/examples/crashreport.com
+#   o/examples/crashreport.com
 #   less examples/crashreport.c
 #
 #   # extremely tiny binaries


### PR DESCRIPTION
`o/dbg/` only contains `.o` files from what I can see. The desired `.com` is in `o/examples/`