### PR TITLE
fix basename error with cp.com

### DIFF
--- a/examples/cp.c
+++ b/examples/cp.c
@@ -73,7 +73,7 @@ void GetOpts(int argc, char *argv[]) {
 
 int cp(const char *src, const char *dst) {
   if (endswith(dst, "/") || isdirectory(dst)) {
-    dst = _gc(xasprintf("%s/%s", dst, basename));
+    dst = _gc(xasprintf("%s/%s", dst, basename(src)));
   }
   if (!force && access(dst, W_OK) == -1 && errno != ENOENT) goto OnFail;
   if (copyfile(src, dst, flags) == -1) goto OnFail;

--- a/examples/cp.c
+++ b/examples/cp.c
@@ -80,7 +80,7 @@ int cp(const char *src, const char *dst) {
   return 0;
 OnFail:
   fprintf(stderr, "%s %s %s: %s\n", "error: cp", src, dst, strerror(errno));
-  return 1;
+  return -1;
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
when the destination is a folder, cp.com should take the basename of the
source file and add it to the destination. cp.c was instead using the
basename function itself as a string (?), and not calling basename.