### PR TITLE
Fix reporting of Lua stack items after some hook calls

### DIFF
--- a/tool/net/luacheck.h
+++ b/tool/net/luacheck.h
@@ -7,13 +7,15 @@
 #if !(__ASSEMBLER__ + __LINKER__ + 0)
 COSMOPOLITAN_C_START_
 
-#define AssertLuaStackIsEmpty(L)                  \
-  do {                                            \
-    if (lua_gettop(L)) {                          \
-      char *s = LuaFormatStack(L);                \
-      WARNF("lua stack should be empty!\n%s", s); \
-      free(s);                                    \
-    }                                             \
+#define AssertLuaStackIsAt(L, level)       \
+  do {                                     \
+    if (lua_gettop(L) > level) {           \
+      char *s = LuaFormatStack(L);         \
+      WARNF("lua stack should be at %d;"   \
+            " extra values ignored:\n%s",  \
+            level, s);                     \
+      free(s);                             \
+    }                                      \
   } while (0)
 
 COSMOPOLITAN_C_END_

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -1071,7 +1071,7 @@ static bool LuaEvalCode(const char *code) {
     lua_pop(L, 1);  // pop error
     return false;
   }
-  AssertLuaStackIsEmpty(L);
+  AssertLuaStackIsAt(L, 0);
   return true;
 }
 
@@ -1099,7 +1099,7 @@ static bool LuaOnClientConnection(void) {
     dropit = false;
   }
   lua_pop(L, 1);  // pop result or error
-  AssertLuaStackIsEmpty(L);
+  AssertLuaStackIsAt(L, 0);
   return dropit;
 #else
   return false;
@@ -1123,7 +1123,7 @@ static void LuaOnProcessCreate(int pid) {
     LogLuaError("OnProcessCreate", lua_tostring(L, -1));
     lua_pop(L, 1);  // pop error
   }
-  AssertLuaStackIsEmpty(L);
+  AssertLuaStackIsAt(L, 0);
 #endif
 }
 
@@ -1136,7 +1136,7 @@ static void LuaOnProcessDestroy(int pid) {
     LogLuaError("OnProcessDestroy", lua_tostring(L, -1));
     lua_pop(L, 1);  // pop error
   }
-  AssertLuaStackIsEmpty(L);
+  AssertLuaStackIsAt(L, 0);
 #endif
 }
 
@@ -1154,12 +1154,13 @@ static inline bool IsHookDefined(const char *s) {
 static void CallSimpleHook(const char *s) {
 #ifndef STATIC
   lua_State *L = GL;
+  int n = lua_gettop(L);
   lua_getglobal(L, s);
   if (LuaCallWithTrace(L, 0, 0, NULL) != LUA_OK) {
     LogLuaError(s, lua_tostring(L, -1));
     lua_pop(L, 1);  // pop error
   }
-  AssertLuaStackIsEmpty(L);
+  AssertLuaStackIsAt(L, n);
 #endif
 }
 


### PR DESCRIPTION
Some hooks (for example, `OnWorkerStop`) can be called after `OnHttpRequest`, which may leave an anchored item on Lua stack, so this have to be taken into account to avoid spurious reports.