### PR TITLE
Redbean fetch headers

### DIFF
--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -682,23 +682,26 @@ FUNCTIONS
   EscapeUser(str) → str
           Escapes URL username. See kescapeauthority.c.
 
-  Fetch(url:str[,body:str|{method=value:str,body=value:str,...}])
+  Fetch(url:str[,body:str|{method=value:str,body=value:str,headers=table,...}])
       → status:int,{header:str=value:str,...},body:str
           Sends an HTTP/HTTPS request to the specified URL. If only the URL is
           provided, then a GET request is sent. If both URL and body parameters
           are specified, then a POST request is sent. If any other method needs
           to be specified (for example, PUT or DELETE), then passing a table as
-          the second value allows setting method and body values as well other
-          options:
+          the second value allows setting request method, body, and headers, as
+          well as some other options:
             - method (default = "GET"): sets the method to be used for the
               request. The specified method is converted to uppercase.
             - body (default = ""): sets the body value to be sent.
+            - headers: sets headers for the request using the key/value pairs
+              from this table. Only string keys are used and all the values are
+              converted to strings.
             - followredirect (default = true): forces temporary and permanent
               redirects to be followed. This behavior can be disabled by
               passing `false`.
             - maxredirects (default = 5): sets the number of allowed redirects
               to minimize looping due to misconfigured servers. When the number
-              is exceeded, the result of the last redirect is returned.
+              is exceeded, the last response is returned.
           When the redirect is being followed, the same method and body values
           are being sent in all cases except when 303 status is returned. In
           that case the method is set to GET and the body is removed before the

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -3805,10 +3805,11 @@ static int LuaFetch(lua_State *L) {
       port = usessl ? "443" : "80";
     }
   } else {
-    ip = ntohl(servers.p[0].addr.sin_addr.s_addr);
+    ip = servers.n ? ntohl(servers.p[0].addr.sin_addr.s_addr) : INADDR_LOOPBACK;
     host =
         gc(xasprintf("%hhu.%hhu.%hhu.%hhu", ip >> 24, ip >> 16, ip >> 8, ip));
-    port = gc(xasprintf("%d", ntohs(servers.p[0].addr.sin_port)));
+    port =
+        gc(xasprintf("%d", servers.n ? ntohs(servers.p[0].addr.sin_port) : 80));
   }
   if (!IsAcceptableHost(host, -1)) {
     luaL_argerror(L, 1, "invalid host");


### PR DESCRIPTION
The second commit fixes a small issue with redbean crashing if there is no listening socket and no host has been provided (in which case `servers.n` is 0).