### PR TITLE
os.realname variable for correct USER_SITE value

### DIFF
--- a/third_party/python/Lib/os.py
+++ b/third_party/python/Lib/os.py
@@ -42,6 +42,7 @@ def _get_exports_list(module):
 
 name = 'posix'
 linesep = '\n'
+realname = "nt" if cosmo.kernel == "nt" else "posix"
 from posix import *
 from posix import _exit
 __all__.append('_exit')

--- a/third_party/python/Lib/site.py
+++ b/third_party/python/Lib/site.py
@@ -240,7 +240,7 @@ def _getuserbase():
     def joinuser(*args):
         return os.path.expanduser(os.path.join(*args))
 
-    if os.name == "nt":
+    if os.realname == "nt":
         base = os.environ.get("APPDATA") or "~"
         if env_base:
             return env_base
@@ -298,7 +298,7 @@ def getusersitepackages():
         "posix_user":'{userbase}/lib/python3.6/site-packages',
         "nt_user": "{userbase}/Python36/site-packages",
     }
-    USER_SITE = purelib_map.get('%s_user' % os.name).format(userbase=user_base)
+    USER_SITE = purelib_map.get('%s_user' % os.realname).format(userbase=user_base)
     return USER_SITE
 
 def addusersitepackages(known_paths):


### PR DESCRIPTION
In site.py, Python uses os.name to decide where the USER_SITE (ie the
folder containing the user's locally installed packages) is located.
With cosmo we have set os.name as "posix" always, so we use a new
os.realname to decide the USER_SITE location.

VirusTotal screenshot showing that `python.com` picks the right `site-packages` location:

![2022-05-20_20-32-59_965x575](https://user-images.githubusercontent.com/41098605/169559351-1c235085-8c4e-4ec6-9248-e95bbe4a2648.png)

