### PR TITLE
Fix GDT limit in GetDescriptor

### DIFF
--- a/tool/build/lib/machine.c
+++ b/tool/build/lib/machine.c
@@ -210,7 +210,7 @@ static relegated int GetDescriptor(struct Machine *m, int selector,
   uint8_t buf[8];
   DCHECK(m->gdt_base + m->gdt_limit <= m->real.n);
   selector &= -8;
-  if (8 <= selector && selector + 8 <= m->gdt_limit) {
+  if (8 <= selector && selector + 8 <= m->gdt_limit + 1) {
     SetReadAddr(m, m->gdt_base + selector, 8);
     *out_descriptor = Read64(m->real.p + m->gdt_base + selector);
     return 0;


### PR DESCRIPTION
The GDT limit field should be 8N - 1 where N is the number of segment descriptors. So if you have 3 descriptors, the total size is 24 bytes but should be stored as 23 bytes:

From Intel SDM Vol. 3 Section 3.5.1:

> Because segment descriptors are always 8 bytes long, the GDT limit should always be one less than an integral multiple of eight (that is, 8N – 1)

This fixes a protection fault I got when using the third descriptor which should range from 16 to 24 bytes offset but GetDescriptor returns -1 because 24 bytes is greater than the 23 byte limit. So a quick fix is to just compare with limit + 1.

BTW, thanks for the library! 
