### PR TITLE
tool/build/compile.c add proquota -P assignment

### DIFF
--- a/tool/build/compile.c
+++ b/tool/build/compile.c
@@ -777,7 +777,7 @@ int main(int argc, char *argv[]) {
         ccversion = atoi(optarg);
         break;
       case 'P':
-        fszquota = sizetol(optarg, 1000);
+        proquota = sizetol(optarg, 1024);
         break;
       case 'F':
         fszquota = sizetol(optarg, 1000);


### PR DESCRIPTION
P had the same assignment as F, now fixed so that it is possible to
increase the proquota (e.g. when trying to build on systems where there
may already be more than 1024 processes running).

As is tradition for one line changes, this one took me hours to hunt down because I thought I was in crazy town hitting what appeared to be a 1024 process limit when ulimit -u was returning 128161. Can't very well grep for 1024 in low level code, though in retrospect I probably should have at least given it a shot. Now I know a bit more about the build system.

This is only a temporary fix. I think a full fix for the underlying problem might be to add the quota to the existing number of processes running.

For anyone else who encounters this issue, it will show up with `EAGAIN` and `vfork` failures in the logs. The fix (once this patch is in place) is to add a single line to the `Makefile` with `QUOTA = -P4096` (substitute `4096` for some number larger than the number of processes running as the current user).
