### PR TITLE
Gh actions disable failing python ioctl test

### DIFF
--- a/third_party/python/Lib/test/test_ioctl.py
+++ b/third_party/python/Lib/test/test_ioctl.py
@@ -3,11 +3,11 @@ import unittest
 from test.support import import_module, get_attribute
 import os, struct
 
-fcntl = import_module("fcntl")
-termios = import_module("termios")
-get_attribute(termios, "TIOCGPGRP")  # Can't run tests without this feature
+fcntl = import_module('fcntl')
+termios = import_module('termios')
+get_attribute(termios, 'TIOCGPGRP') #Can't run tests without this feature
 
-if __name__ == "PYOBJ.COM":
+if __name__ == 'PYOBJ.COM':
     import fcntl
     import termios
 
@@ -24,16 +24,14 @@ else:
     tty.close()
     rpgrp = struct.unpack("i", r)[0]
     if rpgrp not in (os.getpgrp(), os.getsid(0)):
-        raise unittest.SkipTest(
-            "Neither the process group nor the session " "are attached to /dev/tty"
-        )
+        raise unittest.SkipTest("Neither the process group nor the session "
+                                "are attached to /dev/tty")
     del tty, r, rpgrp
 
 try:
     import pty
 except ImportError:
     pty = None
-
 
 class IoctlTests(unittest.TestCase):
     def test_ioctl(self):
@@ -46,7 +44,7 @@ class IoctlTests(unittest.TestCase):
             self.assertIn(rpgrp, ids)
 
     def _check_ioctl_mutate_len(self, nbytes=None):
-        buf = array.array("i")
+        buf = array.array('i')
         intsize = buf.itemsize
         ids = (os.getpgrp(), os.getsid(0))
         # A fill value unlikely to be in `ids`
@@ -54,7 +52,7 @@ class IoctlTests(unittest.TestCase):
         if nbytes is not None:
             # Extend the buffer so that it is exactly `nbytes` bytes long
             buf.extend([fill] * (nbytes // intsize))
-            self.assertEqual(len(buf) * intsize, nbytes)  # sanity check
+            self.assertEqual(len(buf) * intsize, nbytes)   # sanity check
         else:
             buf.append(fill)
         with open("/dev/tty", "rb") as tty:
@@ -76,19 +74,18 @@ class IoctlTests(unittest.TestCase):
         self._check_ioctl_mutate_len(2048)
 
     def test_ioctl_signed_unsigned_code_param(self):
-        if not pty or not hasattr(os, "openpty"):
-            raise unittest.SkipTest("pty module required")
+        if not pty or not hasattr(os, 'openpty'):
+            raise unittest.SkipTest('pty module required')
         mfd, sfd = pty.openpty()
         try:
             if termios.TIOCSWINSZ < 0:
                 set_winsz_opcode_maybe_neg = termios.TIOCSWINSZ
-                set_winsz_opcode_pos = termios.TIOCSWINSZ & 0xFFFFFFFF
+                set_winsz_opcode_pos = termios.TIOCSWINSZ & 0xffffffff
             else:
                 set_winsz_opcode_pos = termios.TIOCSWINSZ
-                (set_winsz_opcode_maybe_neg,) = struct.unpack(
-                    "i", struct.pack("I", termios.TIOCSWINSZ)
-                )
-            our_winsz = struct.pack("HHHH", 80, 25, 0, 0)
+                set_winsz_opcode_maybe_neg, = struct.unpack("i",
+                        struct.pack("I", termios.TIOCSWINSZ))
+            our_winsz = struct.pack("HHHH",80,25,0,0)
             # test both with a positive and potentially negative ioctl code
             new_winsz = fcntl.ioctl(mfd, set_winsz_opcode_pos, our_winsz)
             new_winsz = fcntl.ioctl(mfd, set_winsz_opcode_maybe_neg, our_winsz)

--- a/third_party/python/Lib/test/test_ioctl.py
+++ b/third_party/python/Lib/test/test_ioctl.py
@@ -3,17 +3,20 @@ import unittest
 from test.support import import_module, get_attribute
 import os, struct
 
-fcntl = import_module('fcntl')
-termios = import_module('termios')
-get_attribute(termios, 'TIOCGPGRP') #Can't run tests without this feature
+fcntl = import_module("fcntl")
+termios = import_module("termios")
+get_attribute(termios, "TIOCGPGRP")  # Can't run tests without this feature
 
-if __name__ == 'PYOBJ.COM':
+if __name__ == "PYOBJ.COM":
     import fcntl
     import termios
 
 try:
     tty = open("/dev/tty", "rb")
 except OSError:
+    # todo: gh-runners fail on skiptest cosmo issue #431
+    import sys
+    sys.exit()
     raise unittest.SkipTest("Unable to open /dev/tty")
 else:
     # Skip if another process is in foreground
@@ -21,14 +24,16 @@ else:
     tty.close()
     rpgrp = struct.unpack("i", r)[0]
     if rpgrp not in (os.getpgrp(), os.getsid(0)):
-        raise unittest.SkipTest("Neither the process group nor the session "
-                                "are attached to /dev/tty")
+        raise unittest.SkipTest(
+            "Neither the process group nor the session " "are attached to /dev/tty"
+        )
     del tty, r, rpgrp
 
 try:
     import pty
 except ImportError:
     pty = None
+
 
 class IoctlTests(unittest.TestCase):
     def test_ioctl(self):
@@ -41,7 +46,7 @@ class IoctlTests(unittest.TestCase):
             self.assertIn(rpgrp, ids)
 
     def _check_ioctl_mutate_len(self, nbytes=None):
-        buf = array.array('i')
+        buf = array.array("i")
         intsize = buf.itemsize
         ids = (os.getpgrp(), os.getsid(0))
         # A fill value unlikely to be in `ids`
@@ -49,7 +54,7 @@ class IoctlTests(unittest.TestCase):
         if nbytes is not None:
             # Extend the buffer so that it is exactly `nbytes` bytes long
             buf.extend([fill] * (nbytes // intsize))
-            self.assertEqual(len(buf) * intsize, nbytes)   # sanity check
+            self.assertEqual(len(buf) * intsize, nbytes)  # sanity check
         else:
             buf.append(fill)
         with open("/dev/tty", "rb") as tty:
@@ -71,18 +76,19 @@ class IoctlTests(unittest.TestCase):
         self._check_ioctl_mutate_len(2048)
 
     def test_ioctl_signed_unsigned_code_param(self):
-        if not pty or not hasattr(os, 'openpty'):
-            raise unittest.SkipTest('pty module required')
+        if not pty or not hasattr(os, "openpty"):
+            raise unittest.SkipTest("pty module required")
         mfd, sfd = pty.openpty()
         try:
             if termios.TIOCSWINSZ < 0:
                 set_winsz_opcode_maybe_neg = termios.TIOCSWINSZ
-                set_winsz_opcode_pos = termios.TIOCSWINSZ & 0xffffffff
+                set_winsz_opcode_pos = termios.TIOCSWINSZ & 0xFFFFFFFF
             else:
                 set_winsz_opcode_pos = termios.TIOCSWINSZ
-                set_winsz_opcode_maybe_neg, = struct.unpack("i",
-                        struct.pack("I", termios.TIOCSWINSZ))
-            our_winsz = struct.pack("HHHH",80,25,0,0)
+                (set_winsz_opcode_maybe_neg,) = struct.unpack(
+                    "i", struct.pack("I", termios.TIOCSWINSZ)
+                )
+            our_winsz = struct.pack("HHHH", 80, 25, 0, 0)
             # test both with a positive and potentially negative ioctl code
             new_winsz = fcntl.ioctl(mfd, set_winsz_opcode_pos, our_winsz)
             new_winsz = fcntl.ioctl(mfd, set_winsz_opcode_maybe_neg, our_winsz)


### PR DESCRIPTION
@ahgamut this is the ioctl test issue. it's throwing before it even gets into a test. I guess that's why it's failing even tho it's throwing a SkipTest. Just a guess...