### PR TITLE
Redbean more docs

### DIFF
--- a/tool/net/demo/redbean.lua
+++ b/tool/net/demo/redbean.lua
@@ -317,7 +317,7 @@ local function main()
          if not IsAcceptablePath(paths[i]) then
             Write(' <small>[BLOCKED]</small>')
          end
-         if not IsCompressed(paths[i]) then
+         if not IsAssetCompressed(paths[i]) then
             Write(' <small>[UNCOMPRESSED]</small>')
          end
          if (GetAssetMode(paths[i]) & 0xF000) == 0x4000 then
@@ -325,7 +325,7 @@ local function main()
          end
          Write('<br>\r\n')
          Write('Modified: ')
-         Write(FormatHttpDateTime(GetLastModifiedTime(paths[i])))
+         Write(FormatHttpDateTime(GetAssetLastModifiedTime(paths[i])))
          Write('<br>\r\n')
          Write('Mode: ')
          Write("0%o" % {GetAssetMode(paths[i])})

--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -769,13 +769,21 @@ FUNCTIONS
           directory.
           Also available as GetComment (deprecated).
 
+  GetAssetLastModifiedTime(path:str) → seconds:number
+          Returns UNIX timestamp for modification time of a ZIP asset (or
+          local file if the -D flag is used).
+          If both a file and a ZIP asset are present, then the file is used.
+          Also available as GetLastModifiedTime (deprecated).
+
   GetAssetMode(path:str) → int
           Returns UNIX-style octal mode for ZIP asset (or local file if the
-          -D flag is used)
+          -D flag is used).
+          If both a file and a ZIP asset are present, then the file is used.
 
   GetAssetSize(path:str) → int
           Returns byte size of uncompressed contents of ZIP asset (or local
-          file if the -D flag is used)
+          file if the -D flag is used).
+          If both a file and a ZIP asset are present, then the file is used.
 
   GetBody() → str
           Returns the request message body if present or an empty string.
@@ -971,9 +979,10 @@ v          See khttprepeatable.c. Those headers will not be folded. Standard
           Returns true if IP address is part of the localhost network
           (127.0.0.0/8).
 
-  IsCompressed(path:str) → bool
+  IsAssetCompressed(path:str) → bool
           Returns true if ZIP artifact at path is stored on disk using
           DEFLATE compression.
+          Also available as IsCompressed (deprecated).
 
   IndentLines(str[,int]) → str
           Adds spaces to beginnings of multiline string. If the int

--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -766,7 +766,8 @@ FUNCTIONS
 
   GetAssetComment(path:str) → str
           Returns comment text associated with asset in the ZIP central
-          directory. Also available as GetComment (deprecated).
+          directory.
+          Also available as GetComment (deprecated).
 
   GetAssetMode(path:str) → int
           Returns UNIX-style octal mode for ZIP asset (or local file if the
@@ -932,8 +933,8 @@ v          See khttprepeatable.c. Those headers will not be folded. Standard
 
   GetHttpVersion() → int
           Returns the request HTTP protocol version, which can be 9 for
-          HTTP/0.9, 10 for HTTP/1.0, or 11 for HTTP/1.1. Also available
-          as GetVersion (deprecated).
+          HTTP/0.9, 10 for HTTP/1.0, or 11 for HTTP/1.1.
+          Also available as GetVersion (deprecated).
 
   GetRandomBytes([length:int]) → str
           Returns string with the specified number of random bytes (1..256).

--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -725,6 +725,11 @@ FUNCTIONS
   EscapeUser(str) → str
           Escapes URL username. See kescapeauthority.c.
 
+  EvadeDragnetSurveillance(bool)
+          If this option is programmed then redbean will not transmit a
+          Server Name Indicator (SNI) when performing Fetch() requests.
+          This function is not available in unsecure mode.
+
   Fetch(url:str[,body:str|{method=value:str,body=value:str,headers=table,...}])
       → status:int,{header:str=value:str,...},body:str
           Sends an HTTP/HTTPS request to the specified URL. If only the URL is
@@ -1112,11 +1117,6 @@ v          See khttprepeatable.c. Those headers will not be folded. Standard
           Defaults to 86400 (24 hours). This may be set to ≤0 to disable
           SSL tickets. It's a good idea to use these since it increases
           handshake performance 10x and eliminates a network round trip.
-          This function is not available in unsecure mode.
-
-  EvadeDragnetSurveillance(bool)
-          If this option is programmed then redbean will not transmit a
-          Server Name Indicator (SNI) when performing Fetch() requests.
           This function is not available in unsecure mode.
 
   ProgramSslPresharedKey(key:str,identity:str)

--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -2659,8 +2659,8 @@ UNIX MODULE
 
     Tunes networking parameters.
 
-    `level` and `optname` may be one of the following. The ellipses type
-    signature above changes depending on which options are used.
+    `level` and `optname` may be one of the following pairs. The ellipses
+    type signature above changes depending on which options are used.
 
     unix.getsockopt(fd:int, level:int, optname:int)
         ├─→ value:int
@@ -2669,20 +2669,20 @@ UNIX MODULE
         ├─→ true
         └─→ nil, unix.Errno
 
-    - `SOL_SOCKET` + `SO_TYPE`
-    - `SOL_SOCKET` + `SO_DEBUG`
-    - `SOL_SOCKET` + `SO_ACCEPTCONN`
-    - `SOL_SOCKET` + `SO_BROADCAST`
-    - `SOL_SOCKET` + `SO_REUSEADDR`
-    - `SOL_SOCKET` + `SO_REUSEPORT`
-    - `SOL_SOCKET` + `SO_KEEPALIVE`
-    - `SOL_SOCKET` + `SO_DONTROUTE`
-    - `SOL_TCP` + `TCP_NODELAY`
-    - `SOL_TCP` + `TCP_CORK`
-    - `SOL_TCP` + `TCP_QUICKACK`
-    - `SOL_TCP` + `TCP_FASTOPEN_CONNECT`
-    - `SOL_TCP` + `TCP_DEFER_ACCEPT`
-    - `SOL_IP` + `IP_HDRINCL`
+    - `SOL_SOCKET`, `SO_TYPE`
+    - `SOL_SOCKET`, `SO_DEBUG`
+    - `SOL_SOCKET`, `SO_ACCEPTCONN`
+    - `SOL_SOCKET`, `SO_BROADCAST`
+    - `SOL_SOCKET`, `SO_REUSEADDR`
+    - `SOL_SOCKET`, `SO_REUSEPORT`
+    - `SOL_SOCKET`, `SO_KEEPALIVE`
+    - `SOL_SOCKET`, `SO_DONTROUTE`
+    - `SOL_TCP`, `TCP_NODELAY`
+    - `SOL_TCP`, `TCP_CORK`
+    - `SOL_TCP`, `TCP_QUICKACK`
+    - `SOL_TCP`, `TCP_FASTOPEN_CONNECT`
+    - `SOL_TCP`, `TCP_DEFER_ACCEPT`
+    - `SOL_IP`, `IP_HDRINCL`
 
     unix.getsockopt(fd:int, level:int, optname:int)
         ├─→ value:int
@@ -2691,21 +2691,21 @@ UNIX MODULE
         ├─→ true
         └─→ nil, unix.Errno
 
-    - `SOL_SOCKET` + `SO_SNDBUF`
-    - `SOL_SOCKET` + `SO_RCVBUF`
-    - `SOL_SOCKET` + `SO_RCVLOWAT`
-    - `SOL_SOCKET` + `SO_SNDLOWAT`
-    - `SOL_TCP` + `TCP_KEEPIDLE`
-    - `SOL_TCP` + `TCP_KEEPINTVL`
-    - `SOL_TCP` + `TCP_FASTOPEN`
-    - `SOL_TCP` + `TCP_KEEPCNT`
-    - `SOL_TCP` + `TCP_MAXSEG`
-    - `SOL_TCP` + `TCP_SYNCNT`
-    - `SOL_TCP` + `TCP_NOTSENT_LOWAT`
-    - `SOL_TCP` + `TCP_WINDOW_CLAMP`
-    - `SOL_IP` + `IP_TOS`
-    - `SOL_IP` + `IP_MTU`
-    - `SOL_IP` + `IP_TTL`
+    - `SOL_SOCKET`, `SO_SNDBUF`
+    - `SOL_SOCKET`, `SO_RCVBUF`
+    - `SOL_SOCKET`, `SO_RCVLOWAT`
+    - `SOL_SOCKET`, `SO_SNDLOWAT`
+    - `SOL_TCP`, `TCP_KEEPIDLE`
+    - `SOL_TCP`, `TCP_KEEPINTVL`
+    - `SOL_TCP`, `TCP_FASTOPEN`
+    - `SOL_TCP`, `TCP_KEEPCNT`
+    - `SOL_TCP`, `TCP_MAXSEG`
+    - `SOL_TCP`, `TCP_SYNCNT`
+    - `SOL_TCP`, `TCP_NOTSENT_LOWAT`
+    - `SOL_TCP`, `TCP_WINDOW_CLAMP`
+    - `SOL_IP`, `IP_TOS`
+    - `SOL_IP`, `IP_MTU`
+    - `SOL_IP`, `IP_TTL`
 
     unix.getsockopt(fd:int, level:int, optname:int)
         ├─→ secs:int, nsecs:int
@@ -2714,14 +2714,14 @@ UNIX MODULE
         ├─→ true
         └─→ nil, unix.Errno
 
-    - `SOL_SOCKET` + `SO_RCVTIMEO`: If this option is specified then
+    - `SOL_SOCKET`, `SO_RCVTIMEO`: If this option is specified then
       your stream socket will have a read() / recv() timeout. If the
       specified interval elapses without receiving data, then EAGAIN
       shall be returned by read. If this option is used on listening
       sockets, it'll be inherited by accepted sockets. Your redbean
       already does this for GetClientFd() based on the `-t` flag.
 
-    - `SOL_SOCKET` + `SO_SNDTIMEO`: This is the same as `SO_RCVTIMEO`
+    - `SOL_SOCKET`, `SO_SNDTIMEO`: This is the same as `SO_RCVTIMEO`
       but it applies to the write() / send() functions.
 
     unix.getsockopt(fd:int, unix.SOL_SOCKET, unix.SO_LINGER)

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -4948,6 +4948,7 @@ static const char *const kDontAutoComplete[] = {
     "GetBody",                   //
     "GetClientAddr",             //
     "GetClientFd",               //
+    "GetComment",                // deprecated
     "GetCookie",                 //
     "GetEffectivePath",          //
     "GetFragment",               //
@@ -4955,11 +4956,13 @@ static const char *const kDontAutoComplete[] = {
     "GetHeaders",                //
     "GetHost",                   //
     "GetHttpVersion",            //
+    "GetLastModifiedTime",       // deprecated
     "GetMethod",                 //
     "GetParam",                  //
     "GetParams",                 //
     "GetPass",                   //
     "GetPath",                   //
+    "GetPayload",                // deprecated
     "GetPort",                   //
     "GetRemoteAddr",             //
     "GetScheme",                 //
@@ -4968,8 +4971,10 @@ static const char *const kDontAutoComplete[] = {
     "GetStatus",                 //
     "GetUrl",                    //
     "GetUser",                   //
+    "GetVersion",                // deprecated
     "HasParam",                  //
     "IsClientUsingSsl",          //
+    "IsCompressed",              // deprecated
     "LaunchBrowser",             //
     "LuaProgramSslRequired",     // TODO
     "ProgramAddr",               // TODO

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -4841,7 +4841,7 @@ static int LuaGetAssetMode(lua_State *L) {
   return 1;
 }
 
-static int LuaGetLastModifiedTime(lua_State *L) {
+static int LuaGetAssetLastModifiedTime(lua_State *L) {
   size_t pathlen;
   struct Asset *a;
   const char *path;
@@ -4879,7 +4879,7 @@ static int LuaGetAssetSize(lua_State *L) {
   return 1;
 }
 
-static int LuaIsCompressed(lua_State *L) {
+static int LuaIsAssetCompressed(lua_State *L) {
   size_t pathlen;
   struct Asset *a;
   const char *path;
@@ -5033,6 +5033,7 @@ static const luaL_Reg kLuaFuncs[] = {
     {"FormatHttpDateTime", LuaFormatHttpDateTime},        //
     {"FormatIp", LuaFormatIp},                            //
     {"GetAssetComment", LuaGetAssetComment},              //
+    {"GetAssetLastModifiedTime", LuaGetAssetLastModifiedTime},  //
     {"GetAssetMode", LuaGetAssetMode},                    //
     {"GetAssetSize", LuaGetAssetSize},                    //
     {"GetBody", LuaGetBody},                              //
@@ -5052,7 +5053,6 @@ static const luaL_Reg kLuaFuncs[] = {
     {"GetHostOs", LuaGetHostOs},                          //
     {"GetHttpReason", LuaGetHttpReason},                  //
     {"GetHttpVersion", LuaGetHttpVersion},                //
-    {"GetLastModifiedTime", LuaGetLastModifiedTime},      //
     {"GetLogLevel", LuaGetLogLevel},                      //
     {"GetMethod", LuaGetMethod},                          //
     {"GetMonospaceWidth", LuaGetMonospaceWidth},          //
@@ -5079,7 +5079,7 @@ static const luaL_Reg kLuaFuncs[] = {
     {"IsAcceptablePath", LuaIsAcceptablePath},            //
     {"IsAcceptablePort", LuaIsAcceptablePort},            //
     {"IsClientUsingSsl", LuaIsClientUsingSsl},            //
-    {"IsCompressed", LuaIsCompressed},                    //
+    {"IsAssetCompressed", LuaIsAssetCompressed},          //
     {"IsDaemon", LuaIsDaemon},                            //
     {"IsHeaderRepeatable", LuaIsHeaderRepeatable},        //
     {"IsHiddenPath", LuaIsHiddenPath},                    //
@@ -5166,7 +5166,8 @@ static const luaL_Reg kLuaFuncs[] = {
     {"GetPayload", LuaGetBody},                           //
     {"GetComment", LuaGetAssetComment},                   //
     {"GetVersion", LuaGetHttpVersion},                    //
-
+    {"IsCompressed", LuaIsAssetCompressed},               //
+    {"GetLastModifiedTime", LuaGetAssetLastModifiedTime}, //
 };
 
 static const luaL_Reg kLuaLibs[] = {

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -5038,7 +5038,6 @@ static const luaL_Reg kLuaFuncs[] = {
     {"GetBody", LuaGetBody},                              //
     {"GetClientAddr", LuaGetClientAddr},                  //
     {"GetClientFd", LuaGetClientFd},                      //
-    {"GetComment", LuaGetAssetComment},                   //
     {"GetCookie", LuaGetCookie},                          //
     {"GetCpuCore", LuaGetCpuCore},                        //
     {"GetCpuCount", LuaGetCpuCount},                      //
@@ -5061,7 +5060,6 @@ static const luaL_Reg kLuaFuncs[] = {
     {"GetParams", LuaGetParams},                          //
     {"GetPass", LuaGetPass},                              //
     {"GetPath", LuaGetPath},                              //
-    {"GetPayload", LuaGetBody},                           //
     {"GetPort", LuaGetPort},                              //
     {"GetRandomBytes", LuaGetRandomBytes},                //
     {"GetRedbeanVersion", LuaGetRedbeanVersion},          //
@@ -5072,7 +5070,6 @@ static const luaL_Reg kLuaFuncs[] = {
     {"GetTime", LuaGetTime},                              //
     {"GetUrl", LuaGetUrl},                                //
     {"GetUser", LuaGetUser},                              //
-    {"GetVersion", LuaGetHttpVersion},                    //
     {"GetZipPaths", LuaGetZipPaths},                      //
     {"HasControlCodes", LuaHasControlCodes},              //
     {"HasParam", LuaHasParam},                            //
@@ -5165,6 +5162,11 @@ static const luaL_Reg kLuaFuncs[] = {
     {"ProgramSslRequired", LuaProgramSslRequired},              //
     {"ProgramSslTicketLifetime", LuaProgramSslTicketLifetime},  //
 #endif
+    // deprecated
+    {"GetPayload", LuaGetBody},                           //
+    {"GetComment", LuaGetAssetComment},                   //
+    {"GetVersion", LuaGetHttpVersion},                    //
+
 };
 
 static const luaL_Reg kLuaLibs[] = {

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -4791,17 +4791,6 @@ static int LuaEvadeDragnetSurveillance(lua_State *L) {
   return LuaProgramBool(L, &evadedragnetsurveillance);
 }
 
-static int LuaProgramSslCompression(lua_State *L) {
-#ifndef UNSECURE
-  if (!unsecure) {
-    OnlyCallFromInitLua(L, "ProgramSslCompression");
-    conf.disable_compression = confcli.disable_compression =
-        !lua_toboolean(L, 1);
-  }
-#endif
-  return 0;
-}
-
 static int LuaHidePath(lua_State *L) {
   size_t pathlen;
   const char *path;
@@ -4994,7 +4983,6 @@ static const char *const kDontAutoComplete[] = {
     "ProgramPrivateKey",         // TODO
     "ProgramSslCiphersuite",     // TODO
     "ProgramSslClientVerify",    // TODO
-    "ProgramSslCompression",     //
     "ProgramSslTicketLifetime",  //
     "ProgramTimeout",            // TODO
     "ProgramUid",                //
@@ -5171,7 +5159,6 @@ static const luaL_Reg kLuaFuncs[] = {
     {"ProgramPrivateKey", LuaProgramPrivateKey},                //
     {"ProgramSslCiphersuite", LuaProgramSslCiphersuite},        //
     {"ProgramSslClientVerify", LuaProgramSslClientVerify},      //
-    {"ProgramSslCompression", LuaProgramSslCompression},        //
     {"ProgramSslFetchVerify", LuaProgramSslFetchVerify},        //
     {"ProgramSslInit", LuaProgramSslInit},                      //
     {"ProgramSslPresharedKey", LuaProgramSslPresharedKey},      //


### PR DESCRIPTION
@jart, this updates all deprecated functions we discussed (including REPL and example updates). I also took the liberty of updating get/setsockopt documentation to use `SOL_SOCKET`, `SO_TYPE` instead of `SOL_SOCKET` + `SO_TYPE`, as it looks a bit more clear to me (since these are two different parameters), but feel free to skip that commit if you disagree.