### PR TITLE
Work around Rosetta clobbering startup registers on M1 Macs (issue #429)

### DIFF
--- a/ape/loader-elf.S
+++ b/ape/loader-elf.S
@@ -213,7 +213,18 @@ macho:	.long	0xFEEDFACE+1
 //
 //	@see	APE_LOADER_ENTRY
 //	@see	ape/loader.h
-_start:	mov	%rsp,%rsi
+_start:
+
+//	Hack for detecting M1 Rosetta environment.
+//	https://github.com/jart/cosmopolitan/issues/429#issuecomment-1166704377
+	cmp	$-1,%ebx
+	jne	0f
+	cmp	$+1,%edx
+	jne	0f
+	mov	$XNU,%dl
+	mov	$0,%rcx
+
+0:	mov	%rsp,%rsi
 	jmp	ApeLoader
 	.endfn	_start,globl
 

--- a/ape/loader-elf.S
+++ b/ape/loader-elf.S
@@ -222,7 +222,7 @@ _start:
 	cmp	$+1,%edx
 	jne	0f
 	mov	$XNU,%dl
-	mov	$0,%rcx
+	xor	%ecx,%ecx
 
 0:	mov	%rsp,%rsi
 	jmp	ApeLoader

--- a/ape/loader-macho.S
+++ b/ape/loader-macho.S
@@ -113,7 +113,18 @@ macho:	.long	0xFEEDFACE+1
 	.endobj	macho,globl
 
 	.align	64
-_start:	mov	%rsp,%rsi
+_start:
+
+//	Hack for detecting M1 Rosetta environment.
+//	https://github.com/jart/cosmopolitan/issues/429#issuecomment-1166704377
+	cmp	$-1,%ebx
+	jne	0f
+	cmp	$+1,%edx
+	jne	0f
+	mov	$XNU,%dl
+	mov	$0,%rcx
+
+0:	mov	%rsp,%rsi
 	jmp	ApeLoader
 	.endfn	_start,globl
 

--- a/ape/loader-macho.S
+++ b/ape/loader-macho.S
@@ -122,7 +122,7 @@ _start:
 	cmp	$+1,%edx
 	jne	0f
 	mov	$XNU,%dl
-	mov	$0,%rcx
+	xor	%ecx,%ecx
 
 0:	mov	%rsp,%rsi
 	jmp	ApeLoader

--- a/ape/loader.c
+++ b/ape/loader.c
@@ -595,11 +595,11 @@ __attribute__((__noreturn__)) void ApeLoader(long di, long *sp, char dl,
   // detect freebsd
   if (handoff) {
     os = handoff->os;
+  } else if (SupportsXnu() && dl == XNU) {
+    os = XNU;
   } else if (SupportsFreebsd() && di) {
     os = FREEBSD;
     sp = (long *)di;
-  } else if (SupportsXnu() && dl == XNU) {
-    os = XNU;
   } else {
     os = 0;
   }

--- a/libc/crt/crt.S
+++ b/libc/crt/crt.S
@@ -39,7 +39,7 @@ _start:
 	cmp	$+1,%edx
 	jne	0f
 	mov	$XNU,%cl
-	mov	$0,%rdi
+	xor	%edi,%edi
 0:
 #endif
 

--- a/libc/crt/crt.S
+++ b/libc/crt/crt.S
@@ -31,6 +31,18 @@
 //	@noreturn
 _start:
 
+#if SupportsXnu()
+//	Hack for detecting M1 Rosetta environment.
+//	https://github.com/jart/cosmopolitan/issues/429#issuecomment-1166704377
+	cmp	$-1,%ebx
+	jne	0f
+	cmp	$+1,%edx
+	jne	0f
+	mov	$XNU,%cl
+	mov	$0,%rdi
+0:
+#endif
+
 #if SupportsFreebsd()
 //	detect free besiyata dishmaya
 	test	%rdi,%rdi


### PR DESCRIPTION
Rosetta doesn't correctly respect the startup registers as defined in LC_UNIXTHREAD
which makes platform detection go awry. But at least Rosetta appears to consistently
set rbx to 0x00000000ffffffff and rdx to 0x0000000000000001 at startup for every
x64 executable I could get my hands on. So we use that to detect Rosetta's presence
and set up the correct registers for XNU.

Thanks to @pkulchenko and @jart for pointers on getting this done :)