### PR TITLE
Add OnServerListen hook to configure listening sockets

### DIFF
--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -501,7 +501,7 @@ HOOKS
   OnClientConnection(ip:int,port:int,serverip:int,serverport:int) → bool
           If this function is defined it'll be called from the main process
           each time redbean accepts a new client connection. If it returns
-          true then redbean will close the connection without calling fork.
+          `true`, redbean will close the connection without calling fork.
 
   OnProcessCreate(pid:int,ip:int,port:int,serverip:int,serverport:int)
           If this function is defined it'll be called from the main process
@@ -516,6 +516,12 @@ HOOKS
           If this function is defined it'll be called from the main process
           each time redbean reaps a child connection process using wait4().
           This won't be called in uniprocess mode.
+
+  OnServerListen(socketdescriptor:int,serverip:int,serverport:int) → bool
+          If this function is defined it'll be called from the main process
+          before redbean starts listening on a port. This hook can be used
+          to modify socket configuration to set `SO_REUSEPORT`, for example.
+          If it returns `true`, redbean will not listen to that ip/port.
 
   OnServerStart()
           If this function is defined it'll be called from the main process

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -1081,8 +1081,8 @@ static bool LuaEvalFile(const char *path) {
 }
 
 static bool LuaOnClientConnection(void) {
+  bool dropit = false;
 #ifndef STATIC
-  bool dropit;
   uint32_t ip, serverip;
   uint16_t port, serverport;
   lua_State *L = GL;
@@ -1097,14 +1097,11 @@ static bool LuaOnClientConnection(void) {
     dropit = lua_toboolean(L, -1);
   } else {
     LogLuaError("OnClientConnection", lua_tostring(L, -1));
-    dropit = false;
   }
   lua_pop(L, 1);  // pop result or error
   AssertLuaStackIsAt(L, 0);
-  return dropit;
-#else
-  return false;
 #endif
+  return dropit;
 }
 
 static void LuaOnProcessCreate(int pid) {
@@ -1126,6 +1123,25 @@ static void LuaOnProcessCreate(int pid) {
   }
   AssertLuaStackIsAt(L, 0);
 #endif
+}
+
+static bool LuaOnServerListen(int fd, uint32_t ip, uint16_t port) {
+  bool nouse = false;
+#ifndef STATIC
+  lua_State *L = GL;
+  lua_getglobal(L, "OnServerListen");
+  lua_pushinteger(L, fd);
+  lua_pushinteger(L, ip);
+  lua_pushinteger(L, port);
+  if (LuaCallWithTrace(L, 3, 1, NULL) == LUA_OK) {
+    nouse = lua_toboolean(L, -1);
+  } else {
+    LogLuaError("OnServerListen", lua_tostring(L, -1));
+  }
+  lua_pop(L, 1);  // pop result or error
+  AssertLuaStackIsAt(L, 0);
+#endif
+  return nouse;
 }
 
 static void LuaOnProcessDestroy(int pid) {
@@ -6914,6 +6930,7 @@ static void Listen(void) {
   char ipbuf[16];
   size_t i, j, n;
   uint32_t ip, port, addrsize, *ifs, *ifp;
+  bool hasonserverlisten = IsHookDefined("OnServerListen");
   if (!ports.n) {
     ProgramPort(8080);
   }
@@ -6940,6 +6957,12 @@ static void Listen(void) {
                                         IPPROTO_TCP, true, &timeout)) == -1) {
         DIEF("(srvr) socket: %m");
       }
+      if (hasonserverlisten &&
+          LuaOnServerListen(servers.p[n].fd, ips.p[i], ports.p[j])) {
+        n--;  // skip this server instance
+        continue;
+      }
+
       if (bind(servers.p[n].fd, &servers.p[n].addr,
                sizeof(servers.p[n].addr)) == -1) {
         DIEF("(srvr) bind error: %m: %hhu.%hhu.%hhu.%hhu:%hu", ips.p[i] >> 24,


### PR DESCRIPTION
@jart, the rationale for this change is two-fold:
1. To provide a way to set `SO_REUSEPORT`, which needs to be set *before* `bind`, which only leaves a tight window between the socket is created and `bind` is called. I considered using `GetServerFd` and then applying `setsockopt` from `OnServerStart`, but this obviously doesn't work for this case, as it's too late and also adding `Program` call to set socket options, but this is a bit too limiting, so ended up implementing this new hook
2. To allow the user to skip ips/ports. Redbean binds to everything available by default and I sometimes only want localhost ports to be listened on. This provides a way to do that (the hook returns a boolean value similar to `OnClientConnection`).

My only suggestion is to use `false` for both `OnServerListen` and `OnClientConnection` to signal that it needs to be dropped instead of the current `true` result. I modeled `OnServerListen` after `OnClientConnection`, but using `false` looks much more natural (ServerListen => `false` or ClientConnection => `false` means dropping it in either case). I understand that the reason may be to make it dissimilar to returning `nil`, but `nil` is still different from `false` and we can explicitly check for `false` returned.

I understand that it may be difficult to change this now, but would recommend to consider this.
