### PR TITLE
printimage: keep aspect ratio with `-w` xor `-h`

### DIFF
--- a/tool/viz/printimage.c
+++ b/tool/viz/printimage.c
@@ -394,7 +394,7 @@ void WithImageFile(const char *path,
       dxn = dyn * xn * (1 + !g_flags.half) / yn;
     }
     if (dxn && !dyn) {
-      dyn = g_flags.width * yn / (xn * (1 + !g_flags.half));
+      dyn = dxn * yn / (xn * (1 + !g_flags.half));
     }
     if (g_flags.magikarp) {
       while (HALF(syn) > dyn || HALF(sxn) > dxn) {

--- a/tool/viz/printimage.c
+++ b/tool/viz/printimage.c
@@ -169,7 +169,7 @@ static void GetOpts(int *argc, char *argv[]) {
         PrintUsage(EX_USAGE, stderr);
     }
   }
-  if (!g_flags.full && (!g_flags.width || !g_flags.width)) {
+  if (!g_flags.full && (!g_flags.width && !g_flags.height)) {
     ws.ws_col = 80;
     ws.ws_row = 24;
     if (ioctl(STDIN_FILENO, TIOCGWINSZ, &ws) != -1 ||
@@ -385,11 +385,17 @@ void WithImageFile(const char *path,
                          data, 0, yn, 0, xn);
     cn = 3;
   }
-  if (g_flags.height && g_flags.width) {
+  if (g_flags.height || g_flags.width) {
     syn = yn;
     sxn = xn;
     dyn = g_flags.height;
     dxn = g_flags.width;
+    if (dyn && !dxn) {
+      dxn = dyn * xn * (1 + !g_flags.half) / yn;
+    }
+    if (dxn && !dyn) {
+      dyn = g_flags.width * yn / (xn * (1 + !g_flags.half));
+    }
     if (g_flags.magikarp) {
       while (HALF(syn) > dyn || HALF(sxn) > dxn) {
         if (HALF(sxn) > dxn) {


### PR DESCRIPTION
Previously, `printimage` honored the `-w` and `-h` flags only if both of
them were passed, else falling back to window size. Now, if exactly one
of `-w` or `-h` is passed, the other is inferred for each image based on
the aspect ratio.

Demo of basic scaling based on both `-w` and `-h`:

![Screenshot of `printimage` invoked separately with `-w75`, `-w150`,
`-h20`, and `-h40` on a single image file.][ss1]

Demo of multiple images with different aspect ratios:

![Screenshot of `printimage -m -w100 lemurs.png longcat.png lemurs.png`,
where `lemurs.png` is wide and `longcat.png` is tall.][ss2]

[ss1]: https://user-images.githubusercontent.com/4317806/178094405-871de4c3-01ea-4e8e-8a2a-2cf2ca948615.png
[ss2]: https://user-images.githubusercontent.com/4317806/178094415-721c36df-877c-45c6-8dec-2feb0d2fb11e.png

wchargin-branch: printimage-keep-aspect
