### PR TITLE
ttyraster: restore colors at start of each line

### DIFF
--- a/dsp/tty/ttyraster.c
+++ b/dsp/tty/ttyraster.c
@@ -775,7 +775,10 @@ char *ttyraster(char *v, const struct TtyRgb *c, size_t yn, size_t xn,
   struct Glyph glyph;
   struct TtyRgb chun[4], lastchunk[4];
   for (y = 0; y < yn; y += 2, c += xn) {
-    if (y) v = stpcpy(v, "\e[0m\r\n");
+    if (y) {
+      v = stpcpy(v, "\e[0m\r\n");
+      v = setbgfg(v, bg, fg);
+    }
     for (x = 0; x < xn; x += 2, c += 2) {
       CopyChunk(chun, c, xn);
       if (ttyquant()->alg == kTtyQuantTrue) {


### PR DESCRIPTION
The patch in #469 was buggy for images where the start of a row matched
the end of the previous row. We don't re-issue the `setbgfg` ANSI codes
when we think that the color hasn't changed. But by sending an `\e[0m`
sequence at the end of the line without updating `bg` or `fg`, we
desynced `bg` and `fg` from the actual ANSI state. Now, we simply follow
that line-terminating `\e[0m` with another `setbgfg` call.

This bug was visible in images with a constant-color matte border:

![Screenshot of `printimage` output before and after this commit when
run on `lemurs.png` and `lemursborder.png`, where `lemursborder.png` has
a thick blue border around the outside of the image. Both versions look
fine for `lemurs.png`. For `lemursborder.png`, the "before" version has
a chess board pattern for the left border (except for the first row) and
the bottom border. The "after" version looks correct.][ss]

[ss]: https://user-images.githubusercontent.com/4317806/178120511-c1b89348-2376-4bf2-a2d3-8723d2663bd4.png

Fixes: 85aecbda676c ("ttyraster: reset ANSI attributes after each line (#469)")
wchargin-branch: ttyraster-restore-each-line
