### PR TITLE
add depth limit for JSON

### DIFF
--- a/tool/net/net.mk
+++ b/tool/net/net.mk
@@ -210,6 +210,9 @@ o/$(MODE)/tool/net/demo/virtualbean.html.zip.o:					\
 			-Predbean.justine.lol					\
 			-B
 
+o/$(MODE)/tool/net/ljson.o:	\
+		-DSTACK_FRAME_UNLIMITED
+
 o/$(MODE)/tool/net/redbean-demo.com.dbg:					\
 		$(TOOL_NET_DEPS)						\
 		o/$(MODE)/tool/net/redbean.o					\


### PR DESCRIPTION
- json depth limit set as 1024
- STACK_FRAME_UNLIMITED for ljson.c
- every call of Parse checks if the limit will be crossed

alternative: check stack at the start of Parse everytime, and adjust
when necessary.