### PR TITLE
Add redbean OnLogLatency hook.

### DIFF
--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -534,6 +534,12 @@ HOOKS
           each time redbean accepts a new client connection. If it returns
           `true`, redbean will close the connection without calling fork.
 
+  OnLogLatency(reqtimeus:int,contimeus:int)
+          If this function is defined it'll be called from the main process
+          each time redbean completes handling of a request, but before the
+          response is sent. The handler received the time (in µs) since the
+          request handling and connection handling started.
+
   OnProcessCreate(pid:int,ip:int,port:int,serverip:int,serverport:int)
           If this function is defined it'll be called from the main process
           each time redbean forks a connection handler worker process. The


### PR DESCRIPTION
@jart, this works as discussed, but I'm not totally happy about the `OnLogLatency` hook name. If we're going to add more log-related events, then it may be fine, but if not, then something like `OnHttpRequestDone` may be better, but it's too long, and the request is not really done if it's being streamed to the client. I don't have any better ideas, but am open to suggestions if you prefer to rename it.