### PR TITLE
Add redbean GetResponseBody

### DIFF
--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -1027,6 +1027,10 @@ FUNCTIONS
           IsPrivateIp or IsLoopbackIp return true. When multiple addresses
           are present in the header, the last/right-most address is used.
 
+  GetResponseBody() → str
+          Returns the response message body if present or an empty string.
+          Also returns an empty string during streaming.
+
   GetClientAddr() → ip:uint32,port:uint16
           Returns client socket ip4 address and port, e.g. 0x01020304,31337
           would represent 1.2.3.4:31337. Please consider using GetRemoteAddr

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -4398,6 +4398,12 @@ static int LuaGetBody(lua_State *L) {
   return 1;
 }
 
+static int LuaGetResponseBody(lua_State *L) {
+  OnlyCallDuringRequest(L, "GetResponseBody");
+  lua_pushlstring(L, content, contentlength);
+  return 1;
+}
+
 static int LuaGetHeader(lua_State *L) {
   int h;
   const char *key;
@@ -5054,6 +5060,7 @@ static const char *const kDontAutoComplete[] = {
     "GetPayload",                // deprecated
     "GetPort",                   //
     "GetRemoteAddr",             //
+    "GetResponseBody",           //
     "GetScheme",                 //
     "GetServerAddr",             //
     "GetSslIdentity",            //
@@ -5161,6 +5168,7 @@ static const luaL_Reg kLuaFuncs[] = {
     {"GetRandomBytes", LuaGetRandomBytes},                      //
     {"GetRedbeanVersion", LuaGetRedbeanVersion},                //
     {"GetRemoteAddr", LuaGetRemoteAddr},                        //
+    {"GetResponseBody", LuaGetResponseBody},                    //
     {"GetScheme", LuaGetScheme},                                //
     {"GetServerAddr", LuaGetServerAddr},                        //
     {"GetStatus", LuaGetStatus},                                //

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -3365,7 +3365,7 @@ static int LuaSetStatus(lua_State *L) {
 
 static int LuaGetStatus(lua_State *L) {
   OnlyCallDuringRequest(L, "GetStatus");
-  if (!luaheaderp) {
+  if (!statuscode) {
     lua_pushnil(L);
   } else {
     lua_pushinteger(L, statuscode);
@@ -6360,8 +6360,9 @@ static void InitRequest(void) {
   msgsize = 0;
   loops.n = 0;
   generator = 0;
-  luaheaderp = 0;
   isyielding = 0;
+  luaheaderp = 0;
+  statuscode = 0;
   contentlength = 0;
   referrerpolicy = 0;
   gotcachecontrol = 0;


### PR DESCRIPTION
@jart, this also includes a small fix for `GetStatus` that previously only worked for statuses sent from Lua code, but not for redbean-set statuses.