### PR TITLE
Redbean shutdown upd

### DIFF
--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -1044,15 +1044,10 @@ static void ChangeUser(void) {
 
 static void Daemonize(void) {
   char ibuf[21];
-  int i, fd, pid;
-  for (i = 0; i < 256; ++i) {
-    if (!IsServerFd(i)) {
-      close(i);
-    }
-  }
-  if ((pid = fork()) > 0) exit(0);
+  int fd;
+  if (fork() > 0) exit(0);
   setsid();
-  if ((pid = fork()) > 0) _exit(0);
+  if (fork() > 0) _exit(0);
   umask(0);
   if (pidpath) {
     fd = open(pidpath, O_CREAT | O_WRONLY, 0644);
@@ -7309,6 +7304,13 @@ void RedBean(int argc, char *argv[]) {
            (shared = mmap(NULL, ROUNDUP(sizeof(struct Shared), FRAMESIZE),
                           PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS,
                           -1, 0)));
+  if (daemonize) {
+    for (int i = 0; i < 256; ++i) {
+      if (!IsServerFd(i)) {
+        close(i);
+      }
+    }
+  }
   zpath = GetProgramExecutableName();
   CHECK_NE(-1, (zfd = open(zpath, O_RDONLY)));
   CHECK_NE(-1, fstat(zfd, &zst));

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -1045,17 +1045,10 @@ static void ChangeUser(void) {
 }
 
 static void Daemonize(void) {
-  char ibuf[21];
-  int fd;
   if (fork() > 0) exit(0);
   setsid();
   if (fork() > 0) _exit(0);
   umask(0);
-  if (pidpath) {
-    fd = open(pidpath, O_CREAT | O_WRONLY, 0644);
-    WRITE(fd, ibuf, FormatInt32(ibuf, getpid()) - ibuf);
-    close(fd);
-  }
 }
 
 static void LogLuaError(char *hook, char *err) {
@@ -7287,6 +7280,8 @@ static void GetOpts(int argc, char *argv[]) {
 }
 
 void RedBean(int argc, char *argv[]) {
+  char ibuf[21];
+  int fd;
   if (IsLinux()) {
     // disable sneak privilege since we don't use them
     // seccomp will fail later if this fails
@@ -7339,6 +7334,11 @@ void RedBean(int argc, char *argv[]) {
   }
   if (daemonize) {
     Daemonize();
+  }
+  if (pidpath) {
+    fd = open(pidpath, O_CREAT | O_WRONLY, 0644);
+    WRITE(fd, ibuf, FormatInt32(ibuf, getpid()) - ibuf);
+    close(fd);
   }
   ChangeUser();
   UpdateCurrentDate(nowl());

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -7058,6 +7058,7 @@ static void HandleShutdown(void) {
     KillGroup();
   }
   WaitAll();
+  INFOF("(srvr) shutdown complete");
 }
 
 // this function coroutines with linenoise
@@ -7372,15 +7373,6 @@ void RedBean(int argc, char *argv[]) {
   }
 #endif
   if (!isexitingworker) {
-    HandleShutdown();
-    CallSimpleHookIfDefined("OnServerStop");
-  }
-  if (!IsTiny()) {
-    LuaDestroy();
-    TlsDestroy();
-    MemDestroy();
-  }
-  if (!isexitingworker) {
     if (!IsTiny()) {
       terminatemonitor = true;
       _join(&monitorth);
@@ -7388,9 +7380,13 @@ void RedBean(int argc, char *argv[]) {
 #ifndef STATIC
     _join(&replth);
 #endif
+    HandleShutdown();
+    CallSimpleHookIfDefined("OnServerStop");
   }
-  if (!isexitingworker) {
-    INFOF("(srvr) shutdown complete");
+  if (!IsTiny()) {
+    LuaDestroy();
+    TlsDestroy();
+    MemDestroy();
   }
 }
 


### PR DESCRIPTION
@jart, here are the shutdown and daemonize changes we discussed.

I decided  not to remove the pid file, as it may be reused by the new copy of the executable (updated with a new pid), so the removal will be breaking the handling. It's not ideal, but I didn't want to add checks for timestamp or content before removing it.