### PR TITLE
Fix stderr being improperly closed during daemonization

### DIFF
--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -7305,11 +7305,10 @@ void RedBean(int argc, char *argv[]) {
                           -1, 0)));
   if (daemonize) {
     for (int i = 0; i < 256; ++i) {
-      if (!IsServerFd(i)) {
-        close(i);
-      }
+      close(i);
     }
     open("/dev/null", O_RDONLY);
+    open("/dev/null", O_WRONLY);
     open("/dev/null", O_WRONLY);
   }
   zpath = GetProgramExecutableName();


### PR DESCRIPTION
This may happen when ProgramLogPath is used after a file descriptor is already used by an earlier call (for example, to open an SQLite file).

@jart, this is a simple patch, but I'd appreciate your review. This should fix the scenario when ProgramLogPath is set some time after *another* file descriptor is open (thus occupying slot 2) *and* daemonization is requested, so that when ProgramLogPath is used, it will close and open it to redirect the log file.

I also removed the `IsServerFd`, as none should be allocated yet before `Listen` is done.