### PR TITLE
Add max worker processing to redbean

### DIFF
--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -1403,6 +1403,12 @@ FUNCTIONS
           increased to 1450, since that's the size of ethernet frames.
           This function can only be called from .init.lua.
 
+  ProgramMaxWorkers(int)
+          Limits the number of workers forked by redbean. If that number
+          is reached, the server continues polling until the number of
+          workers is reduced or the value is updated. Setting it to 0
+          removes the limit (this is the default).
+
   ProgramPrivateKey(pem:str)
           Same as the -K flag if called from .init.lua, e.g.
           ProgramPrivateKey(LoadAsset("/.sign.key")) for zip loading or

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -411,6 +411,7 @@ static int sandboxed;
 static int changeuid;
 static int changegid;
 static int isyielding;
+static int maxworkers;
 static int statuscode;
 static int shutdownsig;
 static int sslpskindex;
@@ -4747,6 +4748,15 @@ static int LuaProgramHeartbeatInterval(lua_State *L) {
   return 1;
 }
 
+static int LuaProgramMaxWorkers(lua_State *L) {
+  if (!lua_isinteger(L, 1) && !lua_isnoneornil(L, 1)) {
+    return luaL_argerror(L, 1, "invalid number of workers; integer expected");
+  }
+  lua_pushinteger(L, maxworkers);
+  if (lua_isinteger(L, 1)) maxworkers = lua_tointeger(L, 1);
+  return 1;
+}
+
 static int LuaProgramAddr(lua_State *L) {
   uint32_t ip;
   OnlyCallFromInitLua(L, "ProgramAddr");
@@ -5239,6 +5249,7 @@ static const luaL_Reg kLuaFuncs[] = {
     {"ProgramTimeout", LuaProgramTimeout},                      //
     {"ProgramUid", LuaProgramUid},                              //
     {"ProgramUniprocess", LuaProgramUniprocess},                //
+    {"ProgramMaxWorkers", LuaProgramMaxWorkers},                //
     {"Rand64", LuaRand64},                                      //
     {"Rdrand", LuaRdrand},                                      //
     {"Rdseed", LuaRdseed},                                      //
@@ -6927,6 +6938,7 @@ static int HandlePoll(int ms) {
         if (!polls[pollid].revents) continue;
         if (polls[pollid].fd < 0) continue;
         if (polls[pollid].fd) {
+          if (maxworkers && shared->workers >= maxworkers) continue;
           // handle listen socket
           lua_repl_lock();
           serverid = pollid - 1;

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -4749,6 +4749,7 @@ static int LuaProgramHeartbeatInterval(lua_State *L) {
 }
 
 static int LuaProgramMaxWorkers(lua_State *L) {
+  OnlyCallFromMainProcess(L, "ProgramMaxWorkers");
   if (!lua_isinteger(L, 1) && !lua_isnoneornil(L, 1)) {
     return luaL_argerror(L, 1, "invalid number of workers; integer expected");
   }


### PR DESCRIPTION
@jart, this adds ability to set a limit for the number of workers. It's difficult to come up with a scenario where this beats the default configuration (performance-wise), but the main goal is to allow the number of workers to be limited without going into the meltdown mode when the system runs out of memory. I allowed it to be changed at any time, so it can be called from any server hook. It may be possible to combine this setting with `ProgramUniprocess`, but I thought it may be cleaner to keep them separate (although maybe `ProgramMaxWorkers(1)` should be the same as `ProgramUniprocess(true)`?). I also didn't add any command line options, as I don't think it may be worth setting from the command line (and it is possible to do with a Lua call anyway).