### PR TITLE
Get hello.com working (again) for bare metal target: fix deterministic startup stack setup, implement __enable_tls()

### DIFF
--- a/libc/nexgen32e/gettls.h
+++ b/libc/nexgen32e/gettls.h
@@ -27,7 +27,7 @@ static noasan inline char *__get_tls(void) {
  */
 static noasan inline char *__get_tls_privileged(void) {
   char *tib, *lin = (char *)0x30;
-  if (IsLinux() || IsFreebsd() || IsNetbsd() || IsOpenbsd()) {
+  if (IsLinux() || IsFreebsd() || IsNetbsd() || IsOpenbsd() || IsMetal()) {
     asm("mov\t%%fs:(%1),%0" : "=a"(tib) : "r"(lin) : "memory");
   } else {
     asm("mov\t%%gs:(%1),%0" : "=a"(tib) : "r"(lin) : "memory");

--- a/libc/runtime/cosmo.S
+++ b/libc/runtime/cosmo.S
@@ -99,6 +99,8 @@ cosmo:	push	%rbp
 	.init.start 304,_init_stack
 	testb	IsWindows()
 	jnz	9f
+	testb	IsMetal()
+	jnz	9f
 	push	%rdi
 	push	%rsi
 //	allocate stack
@@ -120,8 +122,9 @@ cosmo:	push	%rbp
 	leave
 	pop	%rcx
 	lea	(%rax,%r8),%rsp
-	sub	$ape_stack_align,%rsp		# openbsd:stackbound
-	mov	%rbp,(%rsp)
+	mov	$ape_stack_align,%eax		# openbsd:stackbound
+	neg	%rax
+	and	%rax,%rsp
 	push	%rcx
 	push	%rbp
 	mov	%rsp,%rbp


### PR DESCRIPTION
This should partly address https://github.com/jart/cosmopolitan/issues/527 .

  * For the bare metal target, there should be no need for `libc/runtime/cosmo.S` to re-setup a stack at `ape_stack_vaddr` &mdash; since `ape/ape.S` has already done that anyway.  (And, `cosmo.S` should not clobber or corrupt any data that had been placed on the stack before.)
  * For other platforms, the code for aligning `%rsp` to a `ape_stack_align`-byte boundary did not look quite correct; so I have changed it.

Thank you!