### PR TITLE
add libc/str/nltypes.h to langinfo.h to match glibc

### DIFF
--- a/libc/isystem/langinfo.h
+++ b/libc/isystem/langinfo.h
@@ -1,5 +1,5 @@
 #ifndef COSMOPOLITAN_LIBC_ISYSTEM_LANGINFO_H_
 #define COSMOPOLITAN_LIBC_ISYSTEM_LANGINFO_H_
 #include "libc/str/langinfo.h"
-
+#include "libc/str/nltypes.h"
 #endif /* COSMOPOLITAN_LIBC_ISYSTEM_LANGINFO_H_ */


### PR DESCRIPTION
glibc `langinfo.h` includes `nl_types.h`.

In the wild perl counts on this as it doesn't include `nl_types.h` anywhere.