### PR TITLE
Work around Rosetta signal handling issue (redbean variant)

### DIFF
--- a/libc/calls/calls.h
+++ b/libc/calls/calls.h
@@ -182,6 +182,7 @@ int symlinkat(const char *, int, const char *);
 int sync_file_range(int, int64_t, int64_t, unsigned);
 int sys_ptrace(int, ...);
 int sysctl(const int *, unsigned, void *, size_t *, void *, size_t);
+int sysctlbyname(const char *, size_t, void *, size_t *, void *, size_t);
 int tgkill(int, int, int);
 int tkill(int, int);
 int tmpfd(void);


### PR DESCRIPTION
Rosetta does something strange to the signal handling registers but setting SA_SIGINFO prevents the issue from happening. Detect Rosetta and set the flag when necessary.

Tested on both M1 and non-M1 and things are fully working on both.

See https://github.com/jart/cosmopolitan/issues/455 for discussion.

@jart This patch is for Redbean only, pull request #553 applies the change to sigaction.c instead to apply globally for  cosmopolitan in general.