### PR TITLE
Work around Rosetta signal handling issue (sigaction variant)

### DIFF
--- a/libc/calls/sigaction.c
+++ b/libc/calls/sigaction.c
@@ -183,6 +183,10 @@ static int __sigaction(int sig, const struct sigaction *act,
       if (IsXnu()) {
         ap->sa_restorer = (void *)&__sigenter_xnu;
         ap->sa_handler = (void *)&__sigenter_xnu;
+
+        // mitigate Rosetta signal handling strangeness
+        // https://github.com/jart/cosmopolitan/issues/455
+        ap->sa_flags |= SA_SIGINFO;
       } else if (IsLinux()) {
         if (!(ap->sa_flags & SA_RESTORER)) {
           ap->sa_flags |= SA_RESTORER;


### PR DESCRIPTION
This is a twin pull request to #552, but with the changes applied to sigaction globally instead of just to redbean. @jart Feel free to pick your favorite and close the other :)

Rosetta does something strange to the signal handling registers but setting SA_SIGINFO prevents the issue from happening. Detect Rosetta and set the flag when necessary.

Tested on both M1 and non-M1 and things are fully working on both.

See https://github.com/jart/cosmopolitan/issues/455 for discussion.