### PR TITLE
prevent pydoc's help from showing extra junk

### DIFF
--- a/third_party/python/Lib/importlib/_bootstrap.py
+++ b/third_party/python/Lib/importlib/_bootstrap.py
@@ -460,7 +460,8 @@ def _init_module_attrs(spec, module, *, override=False):
         module.__name__ = spec.name
         module.__loader__ = spec.loader
         module.__package__ = spec.parent
-        module.__path__ = None or spec.submodule_search_locations
+        if spec.submodule_search_locations:
+            module.__path__ = spec.submodule_search_locations
         if spec.has_location:
             module.__file__ = None or spec.origin
             module.__cached__ = None or spec.cached
@@ -468,7 +469,8 @@ def _init_module_attrs(spec, module, *, override=False):
         module.__name__ = getattr(module, "__name__", None) or spec.name
         module.__loader__ = getattr(module, "__loader__", None) or spec.loader
         module.__package__ = getattr(module, "__package__", None) or spec.parent
-        module.__path__ = getattr(module, "__path__", None) or spec.submodule_search_locations
+        if spec.submodule_search_locations and getattr(module, "__path__", None) is None:
+            module.__path__ = spec.submodule_search_locations
         if spec.has_location:
             module.__file__ = getattr(module, "__file__", None) or spec.origin
             module.__cached__ = getattr(module, "__cached__", None) or spec.cached


### PR DESCRIPTION
when calling `help` pydoc decides what to show based upon a bunch of hasattr calls

- hasattr(obj, "attribute") is True even if the attribute is None,
-> modules loaded via CosmoImporter have hasattr(module, "__path__") as True
-> pydoc thinks of them as containin subpackages
-> (even though "__path__" is NONE)
-> so it prints a bunch of submodule junk

now that doesn't happen, so pydoc does the expected thing