### PR TITLE
Fix redbean to check for file read result when -F option is used

### DIFF
--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -1076,7 +1076,9 @@ static bool LuaEvalCode(const char *code) {
 }
 
 static bool LuaEvalFile(const char *path) {
-  return LuaEvalCode(gc(xslurp(path, 0)));
+  char *f = gc(xslurp(path, 0));
+  if (!f) FATALF("(cfg) error: failed to read file %`'s", path);
+  return LuaEvalCode(f);
 }
 
 static bool LuaOnClientConnection(void) {


### PR DESCRIPTION
This avoids a crash on non-existing file.