### PR TITLE
Stop APE bare metal loader from reading beyond program image end

### DIFF
--- a/ape/ape.S
+++ b/ape/ape.S
@@ -250,6 +250,7 @@ pc:	cld
 	xor	%cx,%cx				# current cylinder
 	xor	%dh,%dh				# current head
 	mov	$v_ape_realsectors,%di		# total sectors
+	sub	$v_ape_realslacksectors,%di
 3:	call	pcread
 	dec	%di
 	jnz	3b
@@ -1567,6 +1568,7 @@ kernel:	movabs	$ape_stack_vaddr,%rsp
 	.ldsvar	_end
 	.ldsvar	_etext
 	.ldsvar	v_ape_realsectors
+	.ldsvar	v_ape_realslacksectors
 	.ldsvar	v_ape_highsectors
 	.ldsvar	ape_idata_ro
 	.ldsvar	ape_pad_rodata

--- a/ape/ape.lds
+++ b/ape/ape.lds
@@ -561,6 +561,9 @@ SHSTUB2(ape_loader_dd_count,
 HIDDEN(v_ape_realsectors =
            MIN(0x70000 - IMAGE_BASE_REAL,
                ROUNDUP(RVA(_edata), 4096)) / 512);
+HIDDEN(v_ape_realslacksectors =
+           v_ape_realsectors - MIN(0x70000 - IMAGE_BASE_REAL,
+                                   ROUNDUP(RVA(_edata), 512)) / 512);
 HIDDEN(v_ape_realpages = v_ape_realsectors / (4096 / 512));
 HIDDEN(v_ape_highsectors =
            (ROUNDUP(RVA(_edata), 512) / 512) - v_ape_realsectors);


### PR DESCRIPTION
This allows e.g. `qemu-system-x86_64 -s o/examples/hello.com -serial stdio` to work without having to add extra padding to the end of the `hello.com` "disk image".

(The sector count computation is divided among two instructions in the assembly code.  This is done on purpose, to prevent an ASCII `0x27` (single quote) byte from appearing in the bare metal loader code, which will break the shell script loader.  There is probably a better way.)