### PR TITLE
Improve zipos directory support

### DIFF
--- a/libc/zipos/find.c
+++ b/libc/zipos/find.c
@@ -28,6 +28,9 @@
 ssize_t __zipos_find(struct Zipos *zipos, const struct ZiposUri *name) {
   const char *zname;
   size_t i, n, c, znamesize;
+  if (!name->len) {
+    return 0;
+  }
   c = GetZipCdirOffset(zipos->cdir);
   n = GetZipCdirRecords(zipos->cdir);
   for (i = 0; i < n; ++i, c += ZIP_CFILE_HDRSIZE(zipos->map + c)) {
@@ -38,6 +41,13 @@ ssize_t __zipos_find(struct Zipos *zipos, const struct ZiposUri *name) {
         (name->len + 1 == znamesize && !memcmp(name->path, zname, name->len) &&
          zname[name->len] == '/')) {
       return c;
+    } else if ((name->len < znamesize &&
+                !memcmp(name->path, zname, name->len) &&
+                zname[name->len - 1] == '/') ||
+               (name->len + 1 < znamesize &&
+                !memcmp(name->path, zname, name->len) &&
+                zname[name->len] == '/')) {
+      return 0;
     }
   }
   return -1;

--- a/libc/zipos/stat-impl.c
+++ b/libc/zipos/stat-impl.c
@@ -16,9 +16,10 @@
 │ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR             │
 │ PERFORMANCE OF THIS SOFTWARE.                                                │
 ╚─────────────────────────────────────────────────────────────────────────────*/
-#include "libc/intrin/safemacros.internal.h"
 #include "libc/calls/struct/stat.h"
+#include "libc/intrin/safemacros.internal.h"
 #include "libc/str/str.h"
+#include "libc/sysv/consts/s.h"
 #include "libc/sysv/errfuns.h"
 #include "libc/zip.h"
 #include "libc/zipos/zipos.internal.h"
@@ -27,14 +28,18 @@ int __zipos_stat_impl(struct Zipos *zipos, size_t cf, struct stat *st) {
   size_t lf;
   if (zipos && st) {
     bzero(st, sizeof(*st));
-    lf = GetZipCfileOffset(zipos->map + cf);
-    st->st_mode = GetZipCfileMode(zipos->map + cf);
-    st->st_size = GetZipLfileUncompressedSize(zipos->map + lf);
-    st->st_blocks =
-        roundup(GetZipLfileCompressedSize(zipos->map + lf), 512) / 512;
-    GetZipCfileTimestamps(zipos->map + cf, &st->st_mtim, &st->st_atim,
-                          &st->st_ctim, 0);
-    st->st_birthtim = st->st_ctim;
+    if (cf) {
+      lf = GetZipCfileOffset(zipos->map + cf);
+      st->st_mode = GetZipCfileMode(zipos->map + cf);
+      st->st_size = GetZipLfileUncompressedSize(zipos->map + lf);
+      st->st_blocks =
+          roundup(GetZipLfileCompressedSize(zipos->map + lf), 512) / 512;
+      GetZipCfileTimestamps(zipos->map + cf, &st->st_mtim, &st->st_atim,
+                            &st->st_ctim, 0);
+      st->st_birthtim = st->st_ctim;
+    } else {
+      st->st_mode = 0444 | S_IFDIR | 0111;
+    }
     return 0;
   } else {
     return einval();

--- a/test/libc/calls/stat_test.c
+++ b/test/libc/calls/stat_test.c
@@ -64,6 +64,10 @@ TEST(stat, zipos) {
              stat("/zip/.python/test/"
                   "tokenize_tests-latin1-coding-cookie-and-utf8-bom-sig.txt",
                   &st));
+  EXPECT_SYS(0, 0, stat("/zip", &st));
+  EXPECT_SYS(0, 0, stat("/zip/", &st));
+  EXPECT_SYS(0, 0, stat("/zip/.python", &st));
+  EXPECT_SYS(0, 0, stat("/zip/.python/", &st));
 }
 
 static long Stat(const char *path, struct stat *st) {

--- a/test/libc/stdio/dirstream_test.c
+++ b/test/libc/stdio/dirstream_test.c
@@ -20,9 +20,9 @@
 #include "libc/calls/struct/dirent.h"
 #include "libc/dce.h"
 #include "libc/errno.h"
-#include "libc/stdio/rand.h"
 #include "libc/runtime/gc.internal.h"
 #include "libc/runtime/runtime.h"
+#include "libc/stdio/rand.h"
 #include "libc/str/str.h"
 #include "libc/sysv/consts/dt.h"
 #include "libc/testlib/testlib.h"
@@ -55,6 +55,35 @@ TEST(opendir, enoent) {
 TEST(opendir, enotdir) {
   ASSERT_SYS(0, 0, close(creat("yo", 0644)));
   ASSERT_SYS(ENOTDIR, NULL, opendir("yo/there"));
+}
+
+TEST(opendir, zipTest_fake) {
+  ASSERT_NE(NULL, (dir = opendir("/zip")));
+  EXPECT_NE(NULL, (ent = readdir(dir)));
+  EXPECT_STREQ("echo", ent->d_name);
+  EXPECT_NE(NULL, (ent = readdir(dir)));
+  EXPECT_STREQ("usr", ent->d_name);
+  EXPECT_EQ(NULL, (ent = readdir(dir)));
+  EXPECT_EQ(0, closedir(dir));
+  ASSERT_NE(NULL, (dir = opendir("/zip/")));
+  EXPECT_NE(NULL, (ent = readdir(dir)));
+  EXPECT_STREQ("echo", ent->d_name);
+  EXPECT_NE(NULL, (ent = readdir(dir)));
+  EXPECT_STREQ("usr", ent->d_name);
+  EXPECT_EQ(NULL, (ent = readdir(dir)));
+  EXPECT_EQ(0, closedir(dir));
+  ASSERT_NE(NULL, (dir = opendir("/zip/usr")));
+  EXPECT_NE(NULL, (ent = readdir(dir)));
+  EXPECT_STREQ("share", ent->d_name);
+  EXPECT_EQ(NULL, (ent = readdir(dir)));
+  EXPECT_EQ(0, closedir(dir));
+  ASSERT_NE(NULL, (dir = opendir("/zip/usr/")));
+  EXPECT_NE(NULL, (ent = readdir(dir)));
+  EXPECT_STREQ("share", ent->d_name);
+  EXPECT_EQ(NULL, (ent = readdir(dir)));
+  EXPECT_EQ(0, closedir(dir));
+  EXPECT_EQ(NULL, (dir = opendir("/zip/us")));
+  EXPECT_EQ(NULL, (dir = opendir("/zip/us/")));
 }
 
 TEST(dirstream, testDots) {


### PR DESCRIPTION
This patch allows the zipos to behave more like a normal filesystem by adding virtual DIR/dirent capability to zipos `stat`, `opendir`, and `readdir`.

`/zip/` is now treated as a directory, `struct DIR *dir = opendir('/zip/'); struct dirent *ent = readdir(dir);` Can now be used to enumerate the toplevel of the zip file.

In addition, directories that are not explicitly encoded in the zip, but are referenced (parent directories in a path to a directory or file) can be found with `opendir` and `readdir`. However, it is not foolproof; to inexpensively to avoid duplicates in `readdir`, the previous `struct dirent d_name` is compared against to determine if a directory has already been found.

Edit: Looking into that failing test.
