### PR TITLE
Implement inet_pton for AF_INET6

### DIFF
--- a/libc/sock/inet_pton.c
+++ b/libc/sock/inet_pton.c
@@ -24,10 +24,131 @@
 #include "libc/sysv/consts/inaddr.h"
 #include "libc/sysv/errfuns.h"
 
+static inline void add_set(unsigned __int128 *pResTemp, uint16_t *pCurrentSet,
+                           unsigned *pDigitsLeft) {
+  *pDigitsLeft -= *pDigitsLeft % 4;
+  *pResTemp = (*pResTemp << 16) | *pCurrentSet;
+  *pCurrentSet = 0;
+}
+
+static int inet_pton_inet6_impl(const char *src, uint8_t *dst) {
+  enum STATES {
+    COLON_OK = 1 << 0,
+    COLON_WAS = 1 << 1,
+    DIGIT_OK = 1 << 2,
+    COLON_OR_DIGIT = COLON_OK | DIGIT_OK,
+  };
+
+  unsigned __int128 res = 0;
+  unsigned __int128 resTemp = 0;
+  char c;
+  enum STATES state = COLON_OR_DIGIT;
+  unsigned digitsLeft = 32;
+  bool zeroFound = false;
+  uint16_t currentSet = 0;
+  while (c = *src++) {
+    if (digitsLeft == 0) {
+      return 0;
+    }
+
+    if (state & COLON_OK) {
+      if (c == ':') {
+        if (state & COLON_WAS) {
+          if (zeroFound) {
+            return 0;
+          }
+          res = resTemp << (4 * digitsLeft);
+          resTemp = 0;
+          digitsLeft -= 4;
+          zeroFound = true;
+          state = DIGIT_OK;
+        } else {
+          if (digitsLeft % 4) {
+            add_set(&resTemp, &currentSet, &digitsLeft);
+          } else if (digitsLeft == 32) {
+            state = COLON_OK;
+          } else {
+            state = COLON_OR_DIGIT;
+          }
+          state |= COLON_WAS;
+        }
+        continue;
+      }
+    }
+
+    if (state & DIGIT_OK) {
+      if ((c >= '0') && ((c < ':') || ((c >= 'A') && (c < 'G')) ||
+                         ((c >= 'a') && (c < 'g')))) {
+        state &= (~COLON_WAS);
+        uint8_t digit;
+        if (c < ':') {
+          digit = c - '0';
+        } else if (c < 'G') {
+          digit = c - 'A' + 10;
+        } else {
+          digit = c - 'a' + 10;
+        }
+        currentSet = (currentSet << 4) | digit;
+        digitsLeft--;
+        if (!(digitsLeft % 4)) {
+          state = COLON_OK;
+          add_set(&resTemp, &currentSet, &digitsLeft);
+        } else if ((state == DIGIT_OK) && (digitsLeft > 4)) {
+          state = COLON_OR_DIGIT;
+        }
+        continue;
+      } else if ((c == '.') && (digitsLeft >= 5) && (digitsLeft <= 27) &&
+                 (digitsLeft % 4)) {
+        uint8_t ipv4[4];
+        const unsigned digitsRead = 4 - digitsLeft % 4;
+        if (inet_pton(AF_INET, src - (1 + digitsRead), &ipv4) == 1) {
+          state &= (~COLON_WAS);
+          digitsLeft += digitsRead;
+          currentSet = (ipv4[0] << 8) | ipv4[1];
+          digitsLeft -= 4;
+          add_set(&resTemp, &currentSet, &digitsLeft);
+          currentSet = (ipv4[2] << 8) | ipv4[3];
+          digitsLeft -= 4;
+          add_set(&resTemp, &currentSet, &digitsLeft);
+          break;
+        }
+      }
+    }
+    return 0;
+  }
+  if (state & COLON_WAS) {
+    return 0;
+  } else if (digitsLeft % 4) {
+    add_set(&resTemp, &currentSet, &digitsLeft);
+  }
+  if (!zeroFound && (digitsLeft != 0)) {
+    return 0;
+  }
+
+  res |= resTemp;
+  dst[0] = res >> (15 * 8);
+  dst[1] = res >> (14 * 8);
+  dst[2] = res >> (13 * 8);
+  dst[3] = res >> (12 * 8);
+  dst[4] = res >> (11 * 8);
+  dst[5] = res >> (10 * 8);
+  dst[6] = res >> (9 * 8);
+  dst[7] = res >> (8 * 8);
+  dst[8] = res >> (7 * 8);
+  dst[9] = res >> (6 * 8);
+  dst[10] = res >> (5 * 8);
+  dst[11] = res >> (4 * 8);
+  dst[12] = res >> (3 * 8);
+  dst[13] = res >> (2 * 8);
+  dst[14] = res >> (1 * 8);
+  dst[15] = res >> (0 * 8);
+  return 1;
+}
+
 /**
  * Converts internet address string to binary.
  *
- * @param af can be AF_INET
+ * @param af can be AF_INET or AF_INET6
  * @param src is the ASCII-encoded address
  * @param dst is where the binary-encoded net-order address goes
  * @return 1 on success, 0 on src malformed, or -1 w/ errno
@@ -35,6 +156,7 @@
 int inet_pton(int af, const char *src, void *dst) {
   uint8_t *p;
   int b, c, j;
+  if (af == AF_INET6) return inet_pton_inet6_impl(src, dst);
   if (af != AF_INET) return eafnosupport();
   j = 0;
   p = dst;

--- a/test/libc/sock/inet_pton_test.c
+++ b/test/libc/sock/inet_pton_test.c
@@ -29,6 +29,46 @@ TEST(inet_pton, testLocalhost) {
   EXPECT_EQ(0, addr[1]);
   EXPECT_EQ(0, addr[2]);
   EXPECT_EQ(1, addr[3]);
+
+  uint8_t addrv6[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                        255, 255, 255, 255, 255, 255, 255, 255};
+  EXPECT_EQ(1, inet_pton(AF_INET6, "::1", &addrv6));
+  EXPECT_EQ(0, addrv6[0]);
+  EXPECT_EQ(0, addrv6[1]);
+  EXPECT_EQ(0, addrv6[2]);
+  EXPECT_EQ(0, addrv6[3]);
+  EXPECT_EQ(0, addrv6[4]);
+  EXPECT_EQ(0, addrv6[5]);
+  EXPECT_EQ(0, addrv6[6]);
+  EXPECT_EQ(0, addrv6[7]);
+  EXPECT_EQ(0, addrv6[8]);
+  EXPECT_EQ(0, addrv6[9]);
+  EXPECT_EQ(0, addrv6[10]);
+  EXPECT_EQ(0, addrv6[11]);
+  EXPECT_EQ(0, addrv6[12]);
+  EXPECT_EQ(0, addrv6[13]);
+  EXPECT_EQ(0, addrv6[14]);
+  EXPECT_EQ(1, addrv6[15]);
+
+  uint8_t addrv6_second[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                               255, 255, 255, 255, 255, 255, 255, 255};
+  EXPECT_EQ(1, inet_pton(AF_INET6, "0:0:0:0:0:0:0:1", &addrv6_second));
+  EXPECT_EQ(0, addrv6_second[0]);
+  EXPECT_EQ(0, addrv6_second[1]);
+  EXPECT_EQ(0, addrv6_second[2]);
+  EXPECT_EQ(0, addrv6_second[3]);
+  EXPECT_EQ(0, addrv6_second[4]);
+  EXPECT_EQ(0, addrv6_second[5]);
+  EXPECT_EQ(0, addrv6_second[6]);
+  EXPECT_EQ(0, addrv6_second[7]);
+  EXPECT_EQ(0, addrv6_second[8]);
+  EXPECT_EQ(0, addrv6_second[9]);
+  EXPECT_EQ(0, addrv6_second[10]);
+  EXPECT_EQ(0, addrv6_second[11]);
+  EXPECT_EQ(0, addrv6_second[12]);
+  EXPECT_EQ(0, addrv6_second[13]);
+  EXPECT_EQ(0, addrv6_second[14]);
+  EXPECT_EQ(1, addrv6_second[15]);
 }
 
 TEST(inet_pton, testAny) {
@@ -38,6 +78,46 @@ TEST(inet_pton, testAny) {
   EXPECT_EQ(0, addr[1]);
   EXPECT_EQ(0, addr[2]);
   EXPECT_EQ(0, addr[3]);
+
+  uint8_t addrv6[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                        255, 255, 255, 255, 255, 255, 255, 255};
+  EXPECT_EQ(1, inet_pton(AF_INET6, "::", &addrv6));
+  EXPECT_EQ(0, addrv6[0]);
+  EXPECT_EQ(0, addrv6[1]);
+  EXPECT_EQ(0, addrv6[2]);
+  EXPECT_EQ(0, addrv6[3]);
+  EXPECT_EQ(0, addrv6[4]);
+  EXPECT_EQ(0, addrv6[5]);
+  EXPECT_EQ(0, addrv6[6]);
+  EXPECT_EQ(0, addrv6[7]);
+  EXPECT_EQ(0, addrv6[8]);
+  EXPECT_EQ(0, addrv6[9]);
+  EXPECT_EQ(0, addrv6[10]);
+  EXPECT_EQ(0, addrv6[11]);
+  EXPECT_EQ(0, addrv6[12]);
+  EXPECT_EQ(0, addrv6[13]);
+  EXPECT_EQ(0, addrv6[14]);
+  EXPECT_EQ(0, addrv6[15]);
+
+  uint8_t addrv6_second[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                               255, 255, 255, 255, 255, 255, 255, 255};
+  EXPECT_EQ(1, inet_pton(AF_INET6, "0:0:0:0:0:0:0:0", &addrv6_second));
+  EXPECT_EQ(0, addrv6_second[0]);
+  EXPECT_EQ(0, addrv6_second[1]);
+  EXPECT_EQ(0, addrv6_second[2]);
+  EXPECT_EQ(0, addrv6_second[3]);
+  EXPECT_EQ(0, addrv6_second[4]);
+  EXPECT_EQ(0, addrv6_second[5]);
+  EXPECT_EQ(0, addrv6_second[6]);
+  EXPECT_EQ(0, addrv6_second[7]);
+  EXPECT_EQ(0, addrv6_second[8]);
+  EXPECT_EQ(0, addrv6_second[9]);
+  EXPECT_EQ(0, addrv6_second[10]);
+  EXPECT_EQ(0, addrv6_second[11]);
+  EXPECT_EQ(0, addrv6_second[12]);
+  EXPECT_EQ(0, addrv6_second[13]);
+  EXPECT_EQ(0, addrv6_second[14]);
+  EXPECT_EQ(0, addrv6_second[15]);
 }
 
 TEST(inet_pton, testShortAddress_doesntFillFullValue) {
@@ -47,6 +127,10 @@ TEST(inet_pton, testShortAddress_doesntFillFullValue) {
   EXPECT_EQ(0, addr[1]);
   EXPECT_EQ(0, addr[2]);
   EXPECT_EQ(255, addr[3]);
+
+  uint8_t addrv6[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                        255, 255, 255, 255, 255, 255, 255, 255};
+  EXPECT_EQ(0, inet_pton(AF_INET6, "0:0:0:0:0:0:0", &addrv6));
 }
 
 TEST(inet_pton, testOverflow_stopsParsing) {
@@ -65,6 +149,10 @@ TEST(inet_pton, testBadChar_stopsParsing) {
   EXPECT_EQ(255, addr[1]);
   EXPECT_EQ(255, addr[2]);
   EXPECT_EQ(255, addr[3]);
+
+  uint8_t addrv6[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                        255, 255, 255, 255, 255, 255, 255, 255};
+  EXPECT_EQ(0, inet_pton(AF_INET6, "0:0:0:0-0:0:0:0", &addrv6));
 }
 
 TEST(inet_pton, testBadFamily_returnsNegAndChangesNothing) {
@@ -74,4 +162,238 @@ TEST(inet_pton, testBadFamily_returnsNegAndChangesNothing) {
   EXPECT_EQ(255, addr[1]);
   EXPECT_EQ(255, addr[2]);
   EXPECT_EQ(255, addr[3]);
+}
+
+TEST(inet_pton, testIPv6BadColon_fails) {
+  uint8_t addrv6[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                        255, 255, 255, 255, 255, 255, 255, 255};
+  EXPECT_EQ(0, inet_pton(AF_INET6, "0:0:0:0:0:0:0:0:", &addrv6));
+
+  uint8_t addrv6_second[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                               255, 255, 255, 255, 255, 255, 255, 255};
+  EXPECT_EQ(0, inet_pton(AF_INET6, "0:0:0:0:0:0:0:0:0", &addrv6_second));
+}
+
+TEST(inet_pton, testMappedIPv4inIPv6) {
+  uint8_t addrv6[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                        255, 255, 255, 255, 255, 255, 255, 255};
+  EXPECT_EQ(1, inet_pton(AF_INET6, "::FFFF:204.152.189.116", &addrv6));
+  EXPECT_EQ(0, addrv6[0]);
+  EXPECT_EQ(0, addrv6[1]);
+  EXPECT_EQ(0, addrv6[2]);
+  EXPECT_EQ(0, addrv6[3]);
+  EXPECT_EQ(0, addrv6[4]);
+  EXPECT_EQ(0, addrv6[5]);
+  EXPECT_EQ(0, addrv6[6]);
+  EXPECT_EQ(0, addrv6[7]);
+  EXPECT_EQ(0, addrv6[8]);
+  EXPECT_EQ(0, addrv6[9]);
+  EXPECT_EQ(0xFF, addrv6[10]);
+  EXPECT_EQ(0xFF, addrv6[11]);
+  EXPECT_EQ(0xCC, addrv6[12]);
+  EXPECT_EQ(0x98, addrv6[13]);
+  EXPECT_EQ(0xBD, addrv6[14]);
+  EXPECT_EQ(0x74, addrv6[15]);
+
+  uint8_t addrv6_second[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                               255, 255, 255, 255, 255, 255, 255, 255};
+  EXPECT_EQ(1, inet_pton(AF_INET6, "1:2:3:4::5.6.7.8", &addrv6_second));
+  EXPECT_EQ(0, addrv6_second[0]);
+  EXPECT_EQ(1, addrv6_second[1]);
+  EXPECT_EQ(0, addrv6_second[2]);
+  EXPECT_EQ(2, addrv6_second[3]);
+  EXPECT_EQ(0, addrv6_second[4]);
+  EXPECT_EQ(3, addrv6_second[5]);
+  EXPECT_EQ(0, addrv6_second[6]);
+  EXPECT_EQ(4, addrv6_second[7]);
+  EXPECT_EQ(0, addrv6_second[8]);
+  EXPECT_EQ(0, addrv6_second[9]);
+  EXPECT_EQ(0, addrv6_second[10]);
+  EXPECT_EQ(0, addrv6_second[11]);
+  EXPECT_EQ(0x5, addrv6_second[12]);
+  EXPECT_EQ(0x6, addrv6_second[13]);
+  EXPECT_EQ(0x7, addrv6_second[14]);
+  EXPECT_EQ(0x8, addrv6_second[15]);
+
+  uint8_t addrv6_third[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                              255, 255, 255, 255, 255, 255, 255, 255};
+  EXPECT_EQ(1, inet_pton(AF_INET6, "1:2:3:4::56.6.7.8", &addrv6_third));
+  EXPECT_EQ(0, addrv6_third[0]);
+  EXPECT_EQ(1, addrv6_third[1]);
+  EXPECT_EQ(0, addrv6_third[2]);
+  EXPECT_EQ(2, addrv6_third[3]);
+  EXPECT_EQ(0, addrv6_third[4]);
+  EXPECT_EQ(3, addrv6_third[5]);
+  EXPECT_EQ(0, addrv6_third[6]);
+  EXPECT_EQ(4, addrv6_third[7]);
+  EXPECT_EQ(0, addrv6_third[8]);
+  EXPECT_EQ(0, addrv6_third[9]);
+  EXPECT_EQ(0, addrv6_third[10]);
+  EXPECT_EQ(0, addrv6_third[11]);
+  EXPECT_EQ(56, addrv6_third[12]);
+  EXPECT_EQ(0x6, addrv6_third[13]);
+  EXPECT_EQ(0x7, addrv6_third[14]);
+  EXPECT_EQ(0x8, addrv6_third[15]);
+
+  uint8_t addrv6_forth[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                              255, 255, 255, 255, 255, 255, 255, 255};
+  EXPECT_EQ(1, inet_pton(AF_INET6, "1:2:3:4:5:6:7.8.9.10", &addrv6_forth));
+  EXPECT_EQ(0, addrv6_forth[0]);
+  EXPECT_EQ(1, addrv6_forth[1]);
+  EXPECT_EQ(0, addrv6_forth[2]);
+  EXPECT_EQ(2, addrv6_forth[3]);
+  EXPECT_EQ(0, addrv6_forth[4]);
+  EXPECT_EQ(3, addrv6_forth[5]);
+  EXPECT_EQ(0, addrv6_forth[6]);
+  EXPECT_EQ(4, addrv6_forth[7]);
+  EXPECT_EQ(0, addrv6_forth[8]);
+  EXPECT_EQ(5, addrv6_forth[9]);
+  EXPECT_EQ(0, addrv6_forth[10]);
+  EXPECT_EQ(6, addrv6_forth[11]);
+  EXPECT_EQ(7, addrv6_forth[12]);
+  EXPECT_EQ(8, addrv6_forth[13]);
+  EXPECT_EQ(9, addrv6_forth[14]);
+  EXPECT_EQ(10, addrv6_forth[15]);
+}
+
+TEST(inet_pton, testVariousIPv6) {
+  uint8_t addrv6[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                        255, 255, 255, 255, 255, 255, 255, 255};
+  EXPECT_EQ(1, inet_pton(AF_INET6, "1:0:0:0:0:0:0:8", &addrv6));
+  EXPECT_EQ(0, addrv6[0]);
+  EXPECT_EQ(1, addrv6[1]);
+  EXPECT_EQ(0, addrv6[2]);
+  EXPECT_EQ(0, addrv6[3]);
+  EXPECT_EQ(0, addrv6[4]);
+  EXPECT_EQ(0, addrv6[5]);
+  EXPECT_EQ(0, addrv6[6]);
+  EXPECT_EQ(0, addrv6[7]);
+  EXPECT_EQ(0, addrv6[8]);
+  EXPECT_EQ(0, addrv6[9]);
+  EXPECT_EQ(0, addrv6[10]);
+  EXPECT_EQ(0, addrv6[11]);
+  EXPECT_EQ(0, addrv6[12]);
+  EXPECT_EQ(0, addrv6[13]);
+  EXPECT_EQ(0, addrv6[14]);
+  EXPECT_EQ(8, addrv6[15]);
+
+  uint8_t addrv6_second[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                               255, 255, 255, 255, 255, 255, 255, 255};
+  EXPECT_EQ(1, inet_pton(AF_INET6, "1::8", &addrv6_second));
+  EXPECT_EQ(0, addrv6_second[0]);
+  EXPECT_EQ(1, addrv6_second[1]);
+  EXPECT_EQ(0, addrv6_second[2]);
+  EXPECT_EQ(0, addrv6_second[3]);
+  EXPECT_EQ(0, addrv6_second[4]);
+  EXPECT_EQ(0, addrv6_second[5]);
+  EXPECT_EQ(0, addrv6_second[6]);
+  EXPECT_EQ(0, addrv6_second[7]);
+  EXPECT_EQ(0, addrv6_second[8]);
+  EXPECT_EQ(0, addrv6_second[9]);
+  EXPECT_EQ(0, addrv6_second[10]);
+  EXPECT_EQ(0, addrv6_second[11]);
+  EXPECT_EQ(0, addrv6_second[12]);
+  EXPECT_EQ(0, addrv6_second[13]);
+  EXPECT_EQ(0, addrv6_second[14]);
+  EXPECT_EQ(8, addrv6_second[15]);
+
+  uint8_t addrv6_third[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                              255, 255, 255, 255, 255, 255, 255, 255};
+  EXPECT_EQ(1, inet_pton(AF_INET6, "1::1:2:3:4", &addrv6_third));
+  EXPECT_EQ(0, addrv6_third[0]);
+  EXPECT_EQ(1, addrv6_third[1]);
+  EXPECT_EQ(0, addrv6_third[2]);
+  EXPECT_EQ(0, addrv6_third[3]);
+  EXPECT_EQ(0, addrv6_third[4]);
+  EXPECT_EQ(0, addrv6_third[5]);
+  EXPECT_EQ(0, addrv6_third[6]);
+  EXPECT_EQ(0, addrv6_third[7]);
+  EXPECT_EQ(0, addrv6_third[8]);
+  EXPECT_EQ(1, addrv6_third[9]);
+  EXPECT_EQ(0, addrv6_third[10]);
+  EXPECT_EQ(2, addrv6_third[11]);
+  EXPECT_EQ(0, addrv6_third[12]);
+  EXPECT_EQ(3, addrv6_third[13]);
+  EXPECT_EQ(0, addrv6_third[14]);
+  EXPECT_EQ(4, addrv6_third[15]);
+
+  uint8_t addrv6_forth[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                              255, 255, 255, 255, 255, 255, 255, 255};
+  EXPECT_EQ(1, inet_pton(AF_INET6, "1:2:3:4::1", &addrv6_forth));
+  EXPECT_EQ(0, addrv6_forth[0]);
+  EXPECT_EQ(1, addrv6_forth[1]);
+  EXPECT_EQ(0, addrv6_forth[2]);
+  EXPECT_EQ(2, addrv6_forth[3]);
+  EXPECT_EQ(0, addrv6_forth[4]);
+  EXPECT_EQ(3, addrv6_forth[5]);
+  EXPECT_EQ(0, addrv6_forth[6]);
+  EXPECT_EQ(4, addrv6_forth[7]);
+  EXPECT_EQ(0, addrv6_forth[8]);
+  EXPECT_EQ(0, addrv6_forth[9]);
+  EXPECT_EQ(0, addrv6_forth[10]);
+  EXPECT_EQ(0, addrv6_forth[11]);
+  EXPECT_EQ(0, addrv6_forth[12]);
+  EXPECT_EQ(0, addrv6_forth[13]);
+  EXPECT_EQ(0, addrv6_forth[14]);
+  EXPECT_EQ(1, addrv6_forth[15]);
+
+  uint8_t addrv6_fifth[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                              255, 255, 255, 255, 255, 255, 255, 255};
+  EXPECT_EQ(1, inet_pton(AF_INET6, "1:2F3D:4::1", &addrv6_fifth));
+  EXPECT_EQ(0, addrv6_fifth[0]);
+  EXPECT_EQ(1, addrv6_fifth[1]);
+  EXPECT_EQ(0x2F, addrv6_fifth[2]);
+  EXPECT_EQ(0x3D, addrv6_fifth[3]);
+  EXPECT_EQ(0, addrv6_fifth[4]);
+  EXPECT_EQ(4, addrv6_fifth[5]);
+  EXPECT_EQ(0, addrv6_fifth[6]);
+  EXPECT_EQ(0, addrv6_fifth[7]);
+  EXPECT_EQ(0, addrv6_fifth[8]);
+  EXPECT_EQ(0, addrv6_fifth[9]);
+  EXPECT_EQ(0, addrv6_fifth[10]);
+  EXPECT_EQ(0, addrv6_fifth[11]);
+  EXPECT_EQ(0, addrv6_fifth[12]);
+  EXPECT_EQ(0, addrv6_fifth[13]);
+  EXPECT_EQ(0, addrv6_fifth[14]);
+  EXPECT_EQ(1, addrv6_fifth[15]);
+
+  uint8_t addrv6_sixth[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                              255, 255, 255, 255, 255, 255, 255, 255};
+  EXPECT_EQ(1, inet_pton(AF_INET6, "AAAA:2:3:4::DDDD", &addrv6_sixth));
+  EXPECT_EQ(0xAA, addrv6_sixth[0]);
+  EXPECT_EQ(0xAA, addrv6_sixth[1]);
+  EXPECT_EQ(0, addrv6_sixth[2]);
+  EXPECT_EQ(2, addrv6_sixth[3]);
+  EXPECT_EQ(0, addrv6_sixth[4]);
+  EXPECT_EQ(3, addrv6_sixth[5]);
+  EXPECT_EQ(0, addrv6_sixth[6]);
+  EXPECT_EQ(4, addrv6_sixth[7]);
+  EXPECT_EQ(0, addrv6_sixth[8]);
+  EXPECT_EQ(0, addrv6_sixth[9]);
+  EXPECT_EQ(0, addrv6_sixth[10]);
+  EXPECT_EQ(0, addrv6_sixth[11]);
+  EXPECT_EQ(0, addrv6_sixth[12]);
+  EXPECT_EQ(0, addrv6_sixth[13]);
+  EXPECT_EQ(0xDD, addrv6_sixth[14]);
+  EXPECT_EQ(0xDD, addrv6_sixth[15]);
+
+  uint8_t addrv6_seventh[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                                255, 255, 255, 255, 255, 255, 255, 255};
+  EXPECT_EQ(1, inet_pton(AF_INET6, "aaaa:2:3:4CDE::DDDD", &addrv6_seventh));
+  EXPECT_EQ(0xAA, addrv6_seventh[0]);
+  EXPECT_EQ(0xAA, addrv6_seventh[1]);
+  EXPECT_EQ(0, addrv6_seventh[2]);
+  EXPECT_EQ(2, addrv6_seventh[3]);
+  EXPECT_EQ(0, addrv6_seventh[4]);
+  EXPECT_EQ(3, addrv6_seventh[5]);
+  EXPECT_EQ(0x4C, addrv6_seventh[6]);
+  EXPECT_EQ(0xDE, addrv6_seventh[7]);
+  EXPECT_EQ(0, addrv6_seventh[8]);
+  EXPECT_EQ(0, addrv6_seventh[9]);
+  EXPECT_EQ(0, addrv6_seventh[10]);
+  EXPECT_EQ(0, addrv6_seventh[11]);
+  EXPECT_EQ(0, addrv6_seventh[12]);
+  EXPECT_EQ(0, addrv6_seventh[13]);
+  EXPECT_EQ(0xDD, addrv6_seventh[14]);
+  EXPECT_EQ(0xDD, addrv6_seventh[15]);
 }


### PR DESCRIPTION
Uses `unsigned __int128` for simplicity.