### PR TITLE
ensure libcxx.a is built when providing folder

### DIFF
--- a/third_party/libcxx/libcxx.mk
+++ b/third_party/libcxx/libcxx.mk
@@ -217,5 +217,7 @@ THIRD_PARTY_LIBCXX_CHECKS = $(foreach x,$(THIRD_PARTY_LIBCXX_ARTIFACTS),$($(x)_C
 THIRD_PARTY_LIBCXX_OBJS = $(foreach x,$(THIRD_PARTY_LIBCXX_ARTIFACTS),$($(x)_OBJS))
 
 .PHONY: o/$(MODE)/third_party/libcxx
-o/$(MODE)/third_party/libcxx: $(THIRD_PARTY_LIBCXX_CHECKS)
+o/$(MODE)/third_party/libcxx: \
+	$(THIRD_PARTY_LIBCXX_CHECKS)	\
+	$(THIRD_PARTY_LIBCXX_A)
 


### PR DESCRIPTION
if I provide

    make -j4 o/$(MODE)/third_party/libcxx

I expect libcxx.a to be built, and now it is.

Minimal change, can ignore PR if necessary.