### PR TITLE
sigaction: Discard ignored signals on New Technology

### DIFF
--- a/libc/calls/sig.internal.h
+++ b/libc/calls/sig.internal.h
@@ -31,6 +31,7 @@ bool __sig_handle(bool, int, int, ucontext_t *) hidden;
 int __sig_add(int, int) hidden;
 int __sig_mask(int, const sigset_t *, sigset_t *) hidden;
 int __sig_raise(int, int) hidden;
+void __sig_check_ignore(const int, const unsigned) hidden;
 
 COSMOPOLITAN_C_END_
 #endif /* !(__ASSEMBLER__ + __LINKER__ + 0) */

--- a/libc/calls/sigaction.c
+++ b/libc/calls/sigaction.c
@@ -258,6 +258,7 @@ static int __sigaction(int sig, const struct sigaction *act,
     if (act) {
       __sighandrvas[sig] = rva;
       __sighandflags[sig] = act->sa_flags;
+      __sig_check_ignore(sig, rva);
     }
   }
   return rc;


### PR DESCRIPTION
When a signal handler is set to `SIG_IGN` or `SIG_DFL` for signal with it's default behavior to ignore, the existing signal instances should be discarded even if they're blocked.

The new test added already passed on `sysv`, but failed on New Technology. This was discovered attempting to implement sigpending (WIP).

Thanks for all the recent reviews!