### PR TITLE
Refine `V=0` command logging

### DIFF
--- a/tool/build/compile.c
+++ b/tool/build/compile.c
@@ -333,7 +333,6 @@ int GetTerminalWidth(void) {
   } else {
     ws.ws_col = 0;
     ioctl(2, TIOCGWINSZ, &ws);
-    if (!ws.ws_col) ws.ws_col = 80;
     return ws.ws_col;
   }
 }
@@ -1299,24 +1298,21 @@ int main(int argc, char *argv[]) {
       if (!outpath) outpath = shortened;
       n = strlen(action);
       appends(&command, action);
-      if (n < 15) {
-        while (n++ < 15) {
-          appendw(&command, ' ');
-        }
-      } else {
-        appendw(&command, ' ');
-        ++n;
-      }
+      do appendw(&command, ' '), ++n;
+      while (n < 15);
       appends(&command, outpath);
       n += strlen(outpath);
-      appendw(&command, '\r');
       m = GetTerminalWidth();
       if (m > 3 && n > m) {
         appendd(&output, command, m - 3);
         appendw(&output, READ32LE("..."));
       } else {
+        if (n < m && (__nocolor || !ischardev(2))) {
+          while (n < m) appendw(&command, ' '), ++n;
+        }
         appendd(&output, command, n);
       }
+      appendw(&output, m > 0 ? '\r' : '\n');
     } else {
       n = 0;
       if (verbose >= 3) {


### PR DESCRIPTION
This fixes off-by-one bugs, as well as missing carriage returns caused by command truncation. When the terminal's width is 0 or unknown, line feeds are used instead. Otherwise, the command is padded with spaces to clear the line when the terminal is dumb.

---

from a brief test, it looks like `GetTerminalWidth` returns 0 for GitHub workflows, so its logs *should* be the same, but with `\n` EOLs instead of `\r`. let me know if you have any concerns.

screenshots of the patched bugs:
![image](https://user-images.githubusercontent.com/1459466/189120926-9ef3fbd7-b9e3-46f7-8e7f-681a67c1f4f0.png)
(exaggerated)
![image](https://user-images.githubusercontent.com/1459466/189120368-9a937c88-8a89-4f23-be9b-1684056e22fc.png)
