### PR TITLE
Add sigpending to redbean unix.* module

### DIFF
--- a/third_party/lua/lunix.c
+++ b/third_party/lua/lunix.c
@@ -1797,6 +1797,20 @@ static int LuaUnixSigsuspend(lua_State *L) {
   return LuaUnixSysretErrno(L, "sigsuspend", olderr);
 }
 
+// unix.sigpending()
+//     ├─→ mask:unix.Sigset
+//     └─→ nil, unix.Errno
+static int LuaUnixSigpending(lua_State *L) {
+  int olderr = errno;
+  struct sigset mask;
+  if (!sigpending(&mask)) {
+    LuaPushSigset(L, mask);
+    return 1;
+  } else {
+    return LuaUnixSysretErrno(L, "sigpending", olderr);
+  }
+}
+
 // unix.setitimer(which[, intervalsec, intns, valuesec, valuens])
 //     ├─→ intervalsec:int, intervalns:int, valuesec:int, valuens:int
 //     └─→ nil, unix.Errno
@@ -2977,6 +2991,7 @@ static const luaL_Reg kLuaUnix[] = {
     {"shutdown", LuaUnixShutdown},        // make socket half empty or full
     {"sigaction", LuaUnixSigaction},      // install signal handler
     {"sigprocmask", LuaUnixSigprocmask},  // change signal mask
+    {"sigpending", LuaUnixSigpending},    // get pending signals
     {"sigsuspend", LuaUnixSigsuspend},    // wait for signal
     {"siocgifconf", LuaUnixSiocgifconf},  // get list of network interfaces
     {"socket", LuaUnixSocket},            // create network communication fd

--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -3887,6 +3887,12 @@ UNIX MODULE
 
     It's a good idea to not do too much work in a signal handler.
 
+  unix.sigpending()
+      ├─→ mask:unix.Sigset
+      └─→ nil, unix.Errno
+
+    Returns the set of signals that are pending for delivery.
+
   unix.sigsuspend([mask:unix.Sigset])
       └─→ nil, unix.Errno
 


### PR DESCRIPTION
@G4Vi, @jart, this adds `sigpending` to unix.* module (from #597). Everything appears to work, but I'm not sure how to test for pending signals.