### PR TITLE
Bare metal VGA: minor improvements

### DIFF
--- a/libc/vga/tty.c
+++ b/libc/vga/tty.c
@@ -270,7 +270,11 @@ static void TtySetCodepage(struct Tty *tty, char id) {
  */
 static uint8_t TtyGetVgaAttr(struct Tty *tty)
 {
-  uint8_t attr = tty->fg | tty->bg << 4;
+  uint8_t attr;
+  if ((tty->pr & kTtyFlip) == 0)
+    attr = tty->fg | tty->bg << 4;
+  else
+    attr = tty->bg | tty->fg << 4;
 #ifdef VGA_USE_BLINK
   /*
    * If blinking is enabled, we can only have the 8 dark background color

--- a/libc/vga/tty.c
+++ b/libc/vga/tty.c
@@ -146,66 +146,27 @@ static wchar_t *GetXlatLineDrawing(void) {
   return xlat;
 }
 
-static void XlatAlphabet(wchar_t xlat[128], int a, int b) {
-  unsigned i;
-  for (i = 0; i < 128; ++i) {
-    if ('a' <= i && i <= 'z') {
-      xlat[i] = i - 'a' + a;
-    } else if ('A' <= i && i <= 'Z') {
-      xlat[i] = i - 'A' + b;
-    } else {
-      xlat[i] = i;
-    }
-  }
-}
-
 static wchar_t *GetXlatItalic(void) {
-  static bool once;
-  static wchar_t xlat[128];
-  if (!once) {
-    XlatAlphabet(xlat, L'𝑎', L'𝐴');
-    once = true;
-  }
-  return xlat;
+  /* Unimplemented.  Simply output normal non-italicized characters for now. */
+  return GetXlatAscii();
 }
 
 static wchar_t *GetXlatBoldItalic(void) {
-  static bool once;
-  static wchar_t xlat[128];
-  if (!once) {
-    XlatAlphabet(xlat, L'𝒂', L'𝑨');
-    once = true;
-  }
-  return xlat;
+  /*
+   * Unimplemented.  Simply output high-intensity non-italicized characters
+   * for now.
+   */
+  return GetXlatAscii();
 }
 
 static wchar_t *GetXlatBoldFraktur(void) {
-  static bool once;
-  static wchar_t xlat[128];
-  if (!once) {
-    XlatAlphabet(xlat, L'𝖆', L'𝕬');
-    once = true;
-  }
-  return xlat;
+  /* Unimplemented. */
+  return GetXlatAscii();
 }
 
 static wchar_t *GetXlatFraktur(void) {
-  unsigned i;
-  static bool once;
-  static wchar_t xlat[128];
-  if (!once) {
-    for (i = 0; i < ARRAYLEN(xlat); ++i) {
-      if ('A' <= i && i <= 'Z') {
-        xlat[i] = L"𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ"[i - 'A'];
-      } else if ('a' <= i && i <= 'z') {
-        xlat[i] = i - 'a' + L'𝔞';
-      } else {
-        xlat[i] = i;
-      }
-    }
-    once = true;
-  }
-  return xlat;
+  /* Unimplemented. */
+  return GetXlatAscii();
 }
 
 static wchar_t *GetXlatDoubleWidth(void) {

--- a/libc/vga/vga.internal.h
+++ b/libc/vga/vga.internal.h
@@ -109,7 +109,7 @@ struct Tty {
   uint32_t u8;
   uint32_t n8;
   uint32_t pr;
-  uint8_t fg, bg;
+  uint8_t fg, bg, chr_ht;
   uint32_t conf;
   unsigned short savey, savex;
   struct VgaTextCharCell *ccs;
@@ -134,7 +134,8 @@ struct Tty {
 };
 
 void _StartTty(struct Tty *, unsigned short, unsigned short,
-               unsigned short, unsigned short, void *, wchar_t *);
+               unsigned short, unsigned short, unsigned char,
+               void *, wchar_t *);
 ssize_t _TtyRead(struct Tty *, void *, size_t);
 ssize_t _TtyWrite(struct Tty *, const void *, size_t);
 ssize_t _TtyWriteInput(struct Tty *, const void *, size_t);

--- a/libc/vga/writev-vga.c
+++ b/libc/vga/writev-vga.c
@@ -58,15 +58,23 @@ ssize_t sys_writev_vga(struct Fd *fd, const struct iovec *iov, int iovlen) {
 
 __attribute__((__constructor__)) static textstartup void _vga_init(void) {
   void * const vid_buf = (void *)(BANE + 0xb8000ull);
-  /* Get the initial cursor position from the BIOS data area. */
+  /*
+   * Get the initial cursor position from the BIOS data area.  Also get
+   * the height (in scan lines) of each character; this is used to set the
+   * cursor shape.
+   */
   typedef struct {
     unsigned char col, row;
   } bios_curs_pos_t;
   bios_curs_pos_t pos = *(bios_curs_pos_t *)(BANE + 0x0450ull);
+  uint8_t chr_ht = *(uint8_t *)(BANE + 0x0485ull),
+          chr_ht_hi = *(uint8_t *)(BANE + 0x0486ull);
+  if (chr_ht_hi != 0 || chr_ht > 32)
+    chr_ht = 32;
   /*
-   * Initialize our tty structure from the current screen contents & current
-   * cursor position.
+   * Initialize our tty structure from the current screen contents, current
+   * cursor position, & character height.
    */
   _StartTty(&vga_tty, VGA_TTY_HEIGHT, VGA_TTY_WIDTH, pos.row, pos.col,
-            vid_buf, vga_wcs);
+            chr_ht, vid_buf, vga_wcs);
 }


### PR DESCRIPTION
To do:
 * [x] Implement the "make cursor invisible" (`\e[?25l`) escape sequence. (✓ https://github.com/tkchia/cosmopolitan/commit/5886678ad7dbdedafdfc81721d17295a2d47a359)
 * [ ] Properly implement answers to "status report" escape sequences, e.g. `\e[0n` in reply to `\e[5n`.  Allow a `read(`...`)` on a tty descriptor to return these status reports to the caller.
 * [x] Make e.g. "set bold" + "set italic" (`\e[1;3m`) do something sane.  The VGA teletypewriter code currently implements this by mapping ASCII letters to Unicode [mathematical symbols](https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols) &mdash; but it then fails to render these letters. (✓ https://github.com/tkchia/cosmopolitan/commit/036e07ef4aa3e18bbbe0d2552da920ef2e4b3594)
 * [x] Implement the "reverse video" (`\e[7m`) escape code. (✓ https://github.com/tkchia/cosmopolitan/commit/26712247add19a54d4671f2c0e50234905c2c608, https://github.com/tkchia/cosmopolitan/commit/fa82b5710357b78b227da38bf0a7913f281c15a0)