### PR TITLE
Bare metal: do not use `push`/`pop` in long mode until stack set up

### DIFF
--- a/ape/ape.S
+++ b/ape/ape.S
@@ -1425,8 +1425,8 @@ golong:	cli
 
 //	Long mode is long.
 	.code64
-long:	push	$GDT_LONG_DATA
-	pop	%rax
+long:	xor	%eax,%eax
+	mov	$GDT_LONG_DATA,%al
 	mov	%eax,%ds
 	mov	%eax,%ss
 	mov	%eax,%es


### PR DESCRIPTION
This patch fixes a random problem with text segment corruption that would crop up occasionally.