### PR TITLE
fix MODE=dbg build

### DIFF
--- a/third_party/python/launch.c
+++ b/third_party/python/launch.c
@@ -5,6 +5,8 @@
 │ https://docs.python.org/3/license.html                                       │
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #include "libc/calls/calls.h"
+#include "libc/calls/struct/siginfo.h"
+#include "libc/calls/ucontext.h"
 #include "libc/dce.h"
 #include "libc/intrin/kprintf.h"
 #include "libc/log/libfatal.internal.h"


### PR DESCRIPTION
https://github.com/jart/cosmopolitan/commit/6f7d0cb1c3962f7cb474b04de75df7cd82a3e5d3 broke `MODE=dbg` builds due to missing declarations in `third_party/python/launch.c`