### PR TITLE
Allow optional double quotes in dd parameters on macOS

### DIFF
--- a/tool/build/assimilate.c
+++ b/tool/build/assimilate.c
@@ -160,8 +160,8 @@ void GetMachoPayload(const char *image, size_t imagesize, int *out_offset,
   script += 6;
   DCHECK_EQ(REG_OK, regcomp(&rx,
                             "bs=([ [:digit:]]+) "
-                            "skip=\"([ [:digit:]]+)\" "
-                            "count=\"([ [:digit:]]+)\"",
+                            "skip=\"?([ [:digit:]]+)\"? "
+                            "count=\"?([ [:digit:]]+)\"?",
                             REG_EXTENDED));
   rc = regexec(&rx, script, 4, rm, 0);
   if (rc != REG_OK) {


### PR DESCRIPTION
This fixes an issue with ape.S using skip/count parameters without doublequotes on macOS thus breaking macho payload parsing.