### PR TITLE
accept: switch 2nd param to take struct sockaddr *

### DIFF
--- a/examples/greenbean.c
+++ b/examples/greenbean.c
@@ -167,7 +167,7 @@ void *Worker(void *id) {
 
     // wait for client connection
     clientaddrsize = sizeof(clientaddr);
-    client = accept(server, &clientaddr, &clientaddrsize);
+    client = accept(server, (struct sockaddr *)&clientaddr, &clientaddrsize);
 
     // accept() can raise a very diverse number of errors but none of
     // them are really true showstoppers that would necessitate us to

--- a/libc/sock/accept.c
+++ b/libc/sock/accept.c
@@ -28,6 +28,6 @@
  * @asyncsignalsafe
  * @restartable (unless SO_RCVTIMEO)
  */
-int accept(int fd, void *out_addr, uint32_t *inout_addrsize) {
+int accept(int fd, struct sockaddr *out_addr, uint32_t *inout_addrsize) {
   return accept4(fd, out_addr, inout_addrsize, 0);
 }

--- a/libc/sock/sock.h
+++ b/libc/sock/sock.h
@@ -1,5 +1,6 @@
 #ifndef COSMOPOLITAN_LIBC_SOCK_SOCK_H_
 #define COSMOPOLITAN_LIBC_SOCK_SOCK_H_
+#include "libc/sock/struct/sockaddr.h"
 #if !(__ASSEMBLER__ + __LINKER__ + 0)
 COSMOPOLITAN_C_START_
 /*───────────────────────────────────────────────────────────────────────────│─╗
@@ -29,7 +30,7 @@ uint32_t *GetHostIps(void);
 
 int nointernet(void);
 int socket(int, int, int);
-int accept(int, void *, uint32_t *);
+int accept(int, struct sockaddr *, uint32_t *);
 int accept4(int, void *, uint32_t *, int);
 int bind(int, const void *, uint32_t);
 int connect(int, const void *, uint32_t);

--- a/test/libc/sock/sendfile_test.c
+++ b/test/libc/sock/sendfile_test.c
@@ -69,7 +69,7 @@ TEST(sendfile, testSeeking) {
   ASSERT_SYS(0, 0, getsockname(3, &addr, &addrsize));
   ASSERT_SYS(0, 0, listen(3, 1));
   if (!fork()) {
-    ASSERT_SYS(0, 4, accept(3, &addr, &addrsize));
+    ASSERT_SYS(0, 4, accept(3, (struct sockaddr *)&addr, &addrsize));
     ASSERT_SYS(0, 5, open("hyperion.txt", O_RDONLY));
     ASSERT_SYS(0, 12, sendfile(4, 5, &inoffset, 12));
     ASSERT_EQ(0, GetFileOffset(5));
@@ -116,7 +116,7 @@ TEST(sendfile, testPositioning) {
   ASSERT_SYS(0, 0, listen(3, 1));
   if (!fork()) {
     signal(SIGPIPE, SIG_IGN);
-    ASSERT_SYS(0, 4, accept(3, &addr, &addrsize));
+    ASSERT_SYS(0, 4, accept(3, (struct sockaddr *)&addr, &addrsize));
     ASSERT_SYS(0, 5, open("hyperion.txt", O_RDONLY));
     ASSERT_SYS(0, 6, sendfile(4, 5, 0, 6));
     ASSERT_EQ(6, GetFileOffset(5));

--- a/test/libc/sock/socket_test.c
+++ b/test/libc/sock/socket_test.c
@@ -41,7 +41,7 @@ TEST(ipv4, test) {
   ASSERT_SYS(0, 0, listen(3, SOMAXCONN));
   ASSERT_NE(-1, (pid = fork()));
   if (!pid) {
-    ASSERT_SYS(0, 4, accept(3, &addr, &addrsize));
+    ASSERT_SYS(0, 4, accept(3, (struct sockaddr *)&addr, &addrsize));
     ASSERT_SYS(0, 5, send(4, "hello", 5, 0));
     ASSERT_SYS(0, 0, close(4));
     ASSERT_SYS(0, 0, close(3));
@@ -75,7 +75,7 @@ TEST(ipv6, test) {
   ASSERT_SYS(0, 0, listen(3, SOMAXCONN));
   ASSERT_NE(-1, (pid = fork()));
   if (!pid) {
-    ASSERT_SYS(0, 4, accept(3, &addr, &addrsize));
+    ASSERT_SYS(0, 4, accept(3, (struct sockaddr *)&addr, &addrsize));
     ASSERT_SYS(0, 5, send(4, "hello", 5, 0));
     ASSERT_SYS(0, 0, close(4));
     ASSERT_SYS(0, 0, close(3));

--- a/test/libc/sock/unix_test.c
+++ b/test/libc/sock/unix_test.c
@@ -89,7 +89,7 @@ void StreamServer(void) {
   ASSERT_SYS(0, 0, listen(3, 10));
   bzero(&addr, sizeof(addr));
   len = sizeof(addr);
-  ASSERT_SYS(0, 4, accept(3, &addr, &len));
+  ASSERT_SYS(0, 4, accept(3, (struct sockaddr *)&addr, &len));
   ASSERT_EQ(AF_UNIX, addr.sun_family);
   EXPECT_STREQ("", addr.sun_path);
   ASSERT_SYS(0, 5, read(4, buf, 256));

--- a/tool/net/echo.c
+++ b/tool/net/echo.c
@@ -20,10 +20,10 @@
 #include "libc/fmt/conv.h"
 #include "libc/intrin/kprintf.h"
 #include "libc/log/check.h"
-#include "libc/stdio/rand.h"
 #include "libc/runtime/runtime.h"
 #include "libc/sock/sock.h"
 #include "libc/sock/struct/sockaddr.h"
+#include "libc/stdio/rand.h"
 #include "libc/str/str.h"
 #include "libc/sysv/consts/af.h"
 #include "libc/sysv/consts/ipproto.h"
@@ -89,7 +89,8 @@ void TcpServer(void) {
           ip, ntohs(addr2.sin_port));
   for (;;) {
     addrsize2 = sizeof(struct sockaddr_in);
-    CHECK_NE(-1, (client = accept(sock, &addr2, &addrsize2)));
+    CHECK_NE(-1,
+             (client = accept(sock, (struct sockaddr *)&addr2, &addrsize2)));
     ip = ntohl(addr2.sin_addr.s_addr);
     kprintf("got client %hhu.%hhu.%hhu.%hhu %hu%n", ip >> 24, ip >> 16, ip >> 8,
             ip, ntohs(addr2.sin_port));


### PR DESCRIPTION
Fixes perl's `Configure` last arg of `accept` detection.

`accept4` was left alone as a change was not needed.
