### PR TITLE
Get cosmopolitation working on Vista again

### DIFF
--- a/libc/calls/reservefd.c
+++ b/libc/calls/reservefd.c
@@ -50,8 +50,8 @@ int __ensurefds_unlocked(int fd) {
   bool relocate;
   if (fd < g_fds.n) return fd;
   g_fds.n = fd + 1;
-  g_fds.e =
-      _extend(g_fds.p, g_fds.n * sizeof(*g_fds.p), g_fds.e, 0x6ff000000000);
+  g_fds.e = _extend(g_fds.p, g_fds.n * sizeof(*g_fds.p), g_fds.e,
+                    kMemtrackFdsStart + kMemtrackFdsSize);
   return fd;
 }
 

--- a/libc/intrin/g_fds.c
+++ b/libc/intrin/g_fds.c
@@ -22,6 +22,7 @@
 #include "libc/intrin/pushpop.h"
 #include "libc/intrin/weaken.h"
 #include "libc/nt/runtime.h"
+#include "libc/runtime/memtrack.internal.h"
 #include "libc/sysv/consts/o.h"
 #include "libc/thread/thread.h"
 
@@ -43,10 +44,11 @@ textstartup void InitializeFileDescriptors(void) {
   struct Fds *fds;
   __fds_lock_obj._type = PTHREAD_MUTEX_RECURSIVE;
   fds = VEIL("r", &g_fds);
-  fds->p = fds->e = (void *)0x6fe000040000;
+  fds->p = fds->e = (void *)kMemtrackFdsStart;
   fds->n = 4;
   fds->f = 3;
-  fds->e = _extend(fds->p, fds->n * sizeof(*fds->p), fds->e, 0x6ff000000000);
+  fds->e = _extend(fds->p, fds->n * sizeof(*fds->p), fds->e,
+                   kMemtrackFdsStart + kMemtrackFdsSize);;
   if (IsMetal()) {
     extern const char vga_console[];
     pushmov(&fds->f, 3ull);

--- a/libc/nt/version.h
+++ b/libc/nt/version.h
@@ -9,11 +9,21 @@ bool32 GetVersionEx(struct NtOsVersionInfo *lpVersionInformation);
 
 #if defined(__GCC_ASM_FLAG_OUTPUTS__) && !defined(__STRICT_ANSI__)
 #define IsAtLeastWindows10() (GetNtMajorVersion() >= 10)
+#define IsAtleastWindows8p1() \
+  (GetNtMajorVersion() > 6 || (GetNtMajorVersion() == 6 && GetNtMinorVersion() == 3))
 #define GetNtMajorVersion()    \
   ({                           \
     uintptr_t __x;             \
     asm("mov\t%%gs:96,%q0\r\n" \
         "mov\t280(%q0),%b0"    \
+        : "=q"(__x));          \
+    (unsigned char)__x;        \
+  })
+#define GetNtMinorVersion()    \
+  ({                           \
+    uintptr_t __x;             \
+    asm("mov\t%%gs:96,%q0\r\n" \
+        "mov\t284(%q0),%b0"    \
         : "=q"(__x));          \
     (unsigned char)__x;        \
   })

--- a/libc/runtime/memtrack.internal.h
+++ b/libc/runtime/memtrack.internal.h
@@ -7,7 +7,6 @@
 #include "libc/macros.internal.h"
 #include "libc/thread/tls.h"
 #include "libc/nt/version.h"
-#include "libc/nt/enum/version.h"
 #include "libc/runtime/stack.h"
 #include "libc/sysv/consts/ss.h"
 #if !(__ASSEMBLER__ + __LINKER__ + 0)
@@ -39,7 +38,7 @@ COSMOPOLITAN_C_START_
 #define _kMem(NORMAL, WIN7) \
   (!IsWindows() || IsAtLeastWindows10() ? NORMAL : WIN7)
 #define _kMemVista(NORMAL, WINVISTA) \
-  (!IsWindows() || NtGetVersion() >= kNtVersionWindows81 ? NORMAL : WINVISTA)
+  (!IsWindows() || IsAtleastWindows8p1() ? NORMAL : WINVISTA)
 
 struct MemoryInterval {
   int x;

--- a/libc/runtime/memtrack.internal.h
+++ b/libc/runtime/memtrack.internal.h
@@ -32,6 +32,9 @@ COSMOPOLITAN_C_START_
 #define kMemtrackZiposStart _kMemVista(0x6fd000040000, 0x5d000040000)
 #define kMemtrackZiposSize \
   (_kMemVista(0x6fdffffc0000, 0x5dffffc0000) - kMemtrackZiposStart)
+#define kMemtrackNsyncStart _kMemVista(0x6fc000040000, 0x5c000040000)
+#define kMemtrackNsyncSize \
+  (_kMemVista(0x6fcffffc0000, 0x5cffffc0000 - kMemtrackNsyncStart)
 #define _kMmi(VSPACE)                                                   \
   ROUNDUP(VSPACE / FRAMESIZE * (intptr_t)sizeof(struct MemoryInterval), \
           FRAMESIZE)

--- a/libc/runtime/memtrack.internal.h
+++ b/libc/runtime/memtrack.internal.h
@@ -7,6 +7,7 @@
 #include "libc/macros.internal.h"
 #include "libc/thread/tls.h"
 #include "libc/nt/version.h"
+#include "libc/nt/enum/version.h"
 #include "libc/runtime/stack.h"
 #include "libc/sysv/consts/ss.h"
 #if !(__ASSEMBLER__ + __LINKER__ + 0)
@@ -26,17 +27,19 @@ COSMOPOLITAN_C_START_
 #define kFixedmapStart _kMem(0x300000000000, 0x000040000000)
 #define kFixedmapSize \
   _kMem(0x400000000000 - 0x300000000000, 0x000070000000 - 0x000040000000)
-#define kMemtrackFdsStart \
-  (ROUNDDOWN(_kMem(0x6fe000000000, 0x68000000), FRAMESIZE * 8) - 0x8000 * 8)
-#define kMemtrackFdsSize _kMem(0x001000000000, 0x04000000)
-#define kMemtrackZiposStart \
-  (ROUNDDOWN(_kMem(0x6fd000000000, 0x6c000000), FRAMESIZE * 8) - 0x8000 * 8)
-#define kMemtrackZiposSize _kMem(0x001000000000, 0x10000000)
+#define kMemtrackFdsStart _kMemVista(0x6fe000040000, 0x5e000040000)
+#define kMemtrackFdsSize  \
+  (_kMemVista(0x6feffffc0000, 0x5effffc0000) - kMemtrackFdsStart)
+#define kMemtrackZiposStart _kMemVista(0x6fd000040000, 0x5d000040000)
+#define kMemtrackZiposSize \
+  (_kMemVista(0x6fdffffc0000, 0x5dffffc0000) - kMemtrackZiposStart)
 #define _kMmi(VSPACE)                                                   \
   ROUNDUP(VSPACE / FRAMESIZE * (intptr_t)sizeof(struct MemoryInterval), \
           FRAMESIZE)
 #define _kMem(NORMAL, WIN7) \
   (!IsWindows() || IsAtLeastWindows10() ? NORMAL : WIN7)
+#define _kMemVista(NORMAL, WINVISTA) \
+  (!IsWindows() || NtGetVersion() >= kNtVersionWindows81 ? NORMAL : WINVISTA)
 
 struct MemoryInterval {
   int x;

--- a/libc/zipos/open.c
+++ b/libc/zipos/open.c
@@ -52,9 +52,10 @@ static void *__zipos_mmap(size_t mapsize) {
   assert(mapsize);
   offset = maptotal;
   maptotal += mapsize;
-  start = (char *)0x6fd000040000;
+  start = (char *)kMemtrackZiposStart;
   if (!mapend) mapend = start;
-  mapend = _extend(start, maptotal, mapend, 0x6fdfffff0000);
+    mapend = _extend(start, maptotal, mapend,
+                   kMemtrackZiposStart + kMemtrackZiposSize);;
   return start + offset;
 }
 


### PR DESCRIPTION
Ideally the fixed size array would be removed on Vista/7 as well but I am not entirely sure how. If it's truly related to older versions of Windows having smaller virtual address spaces then perhaps using a smaller address would be enough.