### PR TITLE
Make `ape.S` shell script magic less prone to accidental breakage

### DIFF
--- a/ape/ape.S
+++ b/ape/ape.S
@@ -251,7 +251,6 @@ pc:	cld
 	xor	%cx,%cx				# current cylinder
 	xor	%dh,%dh				# current head
 	mov	$v_ape_realsectors,%di		# total sectors
-	sub	$v_ape_realslacksectors,%di
 3:	call	pcread
 	dec	%di
 	jnz	3b
@@ -1587,7 +1586,6 @@ kernel:	movabs	$ape_stack_vaddr,%rsp
 	.ldsvar	_end
 	.ldsvar	_etext
 	.ldsvar	v_ape_realsectors
-	.ldsvar	v_ape_realslacksectors
 	.ldsvar	v_ape_highsectors
 	.ldsvar	ape_idata_ro
 	.ldsvar	ape_pad_rodata

--- a/ape/ape.S
+++ b/ape/ape.S
@@ -125,6 +125,7 @@ ape_mz:	.asciz	"MZqFpD='\n"		# Mark 'Zibo' Joseph Zbikowski
 	.org	0x24			# MZ: bytes reserved for you
 	.ascii	"JT"			# MZ: OEM identifier
 	.short	0			# MZ: OEM information
+	.ascii	"' <<'@'\n"
 	.org	0x40-4			# MZ: bytes reserved for you
 #if SupportsWindows() || SupportsMetal()
 	.long	RVA(ape_pe)		# PE: the new technology
@@ -549,7 +550,7 @@ ape_disk:
 	the bourne executable & linkable format */
 
 #if SupportsWindows() || SupportsMetal() || SupportsXnu()
-apesh:	.ascii	"'\n#'\"\n"			# sixth edition shebang
+apesh:	.ascii	"\n@\n#'\"\n"			# sixth edition shebang
 //	Until all operating systems can be updated to support APE,
 //	we have a beautiful, yet imperfect workaround, which is to
 //	modify the binary to follow the local system's convention.

--- a/ape/ape.lds
+++ b/ape/ape.lds
@@ -565,10 +565,7 @@ SHSTUB2(ape_loader_dd_count,
 #if SupportsMetal()
 HIDDEN(v_ape_realsectors =
            MIN(0x70000 - IMAGE_BASE_REAL,
-               ROUNDUP(RVA(_edata), 4096)) / 512);
-HIDDEN(v_ape_realslacksectors =
-           v_ape_realsectors - MIN(0x70000 - IMAGE_BASE_REAL,
-                                   ROUNDUP(RVA(_edata), 512)) / 512);
+               ROUNDUP(RVA(_edata), 512)) / 512);
 HIDDEN(v_ape_realpages = v_ape_realsectors / (4096 / 512));
 HIDDEN(v_ape_highsectors =
            (ROUNDUP(RVA(_edata), 512) / 512) - v_ape_realsectors);


### PR DESCRIPTION
The metal boot sector code was wrapped in a single-quoted string, like so:
```
MZqFpD='
...MZ HEADER...
...E_LFANEW...
...BIOS BOOT SECTOR...'
```
This might break the shell code loader if the boot sector code contains a 0x27 (single quote) byte.  This patch wraps the boot sector code in a here-document instead:
```
MZqFpD='
...MZ HEADER...' <<'@'
...E_LFANEW...
...BIOS BOOT SECTOR...
@
```
This is harder to break — when interpreted as a shell script, the code can only accidentally terminate the here-document if there is a `"\n@\n"` sequence inside the BIOS boot portion.