### PR TITLE
Fix re.NOSUB memory error

### DIFF
--- a/tool/net/lre.c
+++ b/tool/net/lre.c
@@ -62,6 +62,8 @@ static int LuaReSearchImpl(lua_State *L, regex_t *r, const char *s, int f) {
   luaL_Buffer tmp;
   n = 1 + r->re_nsub;
   m = (regmatch_t *)luaL_buffinitsize(L, &tmp, n * sizeof(regmatch_t));
+  m->rm_so = 0;
+  m->rm_eo = 0;
   if ((rc = regexec(r, s, n, m, f >> 8)) == REG_OK) {
     for (i = 0; i < n; ++i) {
       lua_pushlstring(L, s + m[i].rm_so, m[i].rm_eo - m[i].rm_so);


### PR DESCRIPTION
This change fixes the following error.

```bash
[dan@mainpc cosmo]$ o/tool/net/redbean.com -i
>: re.search(" ", " ", re.NOSUB)
redbean: memory allocation error: block too big
stack traceback:
[C]: in function 're.search'
stdin:1: in main chunk
```