### PR TITLE
[metal] Show "screen of death" on VGA console upon program crash

### DIFF
--- a/examples/vga2.c
+++ b/examples/vga2.c
@@ -1,0 +1,33 @@
+#if 0
+/*─────────────────────────────────────────────────────────────────╗
+│ To the extent possible under law, Justine Tunney has waived      │
+│ all copyright and related or neighboring rights to this file,    │
+│ as it is written in the following disclaimers:                   │
+│   • http://unlicense.org/                                        │
+│   • http://creativecommons.org/publicdomain/zero/1.0/            │
+╚─────────────────────────────────────────────────────────────────*/
+#endif
+#include "libc/calls/calls.h"
+#include "libc/calls/termios.h"
+#include "libc/isystem/unistd.h"
+#include "libc/math.h"
+#include "libc/stdio/stdio.h"
+#include "libc/str/str.h"
+#include "libc/sysv/consts/termios.h"
+
+/**
+ * @fileoverview Demo of program crash reporting with Bare Metal VGA TTY.
+ *
+ *     make -j8 o//examples/vga2.com
+ *     qemu-system-x86_64 -hda o//examples/vga2.com -serial stdio
+ */
+
+STATIC_YOINK("vga_console");
+STATIC_YOINK("_idt");
+
+int main(int argc, char *argv[]) {
+  volatile int x = 1;
+  volatile int y = 2;
+  printf("\e[92;44mHello World!\e[0m %d\n", 1 / (x + y - 3));
+  for (;;);
+}

--- a/libc/intrin/interrupts.S
+++ b/libc/intrin/interrupts.S
@@ -70,9 +70,11 @@ __excep0_isr:
 	push	%rcx			# preserve registers which we will
 	push	%rdx			# use to call kprintf
 	push	%r8
-	mov	40(%rsp),%rcx		# edx:rcx = "caller" cs:rip
-	mov	48(%rsp),%edx
-	mov	32(%rsp),%r8		# r8 = error code
+	push	%r9
+	mov	48(%rsp),%rcx		# edx:rcx = "caller" cs:rip
+	mov	56(%rsp),%edx
+	mov	40(%rsp),%r8		# r8 = error code
+	mov	%cr2,%r9		# r9 = cr2, in case it is useful
 	push	%rax			# preserve other call-used registers
 	push	%rdi
 	push	%r9
@@ -141,7 +143,8 @@ isr_init:
 //	String constants.
 	.rodata.str1.1
 .excep_msg:
-	.asciz	"CPU exception %d @ %#llx:%#llx err code %#llx\n"
+	.ascii	"\033[1;31mCPU exception %d @ %#llx:%#llx err code %#llx "
+	.asciz	"cr2 %#llx\33[0m\n"
 	.previous
 
 //	IDTR value.

--- a/libc/intrin/kprintf.greg.c
+++ b/libc/intrin/kprintf.greg.c
@@ -55,6 +55,7 @@
 #include "libc/sysv/consts/prot.h"
 #include "libc/thread/tls.h"
 #include "libc/thread/tls2.h"
+#include "libc/vga/vga.internal.h"
 
 extern hidden struct SymbolTable *__symtab;
 
@@ -188,6 +189,7 @@ privileged static void klog(const char *b, size_t n) {
                    : /* no inputs */
                    : "a"(b[i]), "dN"(dx));
     }
+    if (_weaken(_klog_vga)) _weaken(_klog_vga)(b, n);
   } else {
     asm volatile("syscall"
                  : "=a"(rax), "=D"(rdi), "=S"(rsi), "=d"(rdx)

--- a/libc/intrin/mman.greg.c
+++ b/libc/intrin/mman.greg.c
@@ -169,6 +169,8 @@ noasan textreal void __setup_mman(struct mman *mm, uint64_t *pml4t) {
   export_offsetof(struct mman, pc_video_height);
   export_offsetof(struct mman, pc_video_framebuffer);
   export_offsetof(struct mman, pc_video_framebuffer_size);
+  export_offsetof(struct mman, pc_video_curs_info);
+  export_offsetof(struct mman, pc_video_char_height);
   __normalize_e820(mm);
   __invert_memory(mm, pml4t);
 }

--- a/libc/runtime/mman.internal.h
+++ b/libc/runtime/mman.internal.h
@@ -29,6 +29,12 @@ struct mman {
   uint64_t pc_video_framebuffer;         /* 0x1d30 — physical address of
                                                      video frame buffer */
   uint64_t pc_video_framebuffer_size;    /* 0x1d38 */
+  struct {                               /* 0x1d40 — starting cursor pos. */
+    unsigned short y, x;
+  } pc_video_curs_info;
+  unsigned short pc_video_char_height;   /* 0x1d44 — character height (useful
+                                                     for setting cursor shape
+                                                     in text mode) */
 };
 
 COSMOPOLITAN_C_END_

--- a/libc/vga/rlinit-vga.S
+++ b/libc/vga/rlinit-vga.S
@@ -78,7 +78,13 @@
 	xor	%bx,%bx
 #endif
 	int	$0x10
-9:
+9:	mov	0x0450,%dx		# note down cursor position
+	movzbw	%dh,%ax
+	mov	%ax,mm+"struct mman::pc_video_curs_info"
+	mov	%dl,%al
+	mov	%ax,mm+"struct mman::pc_video_curs_info"+2
+	mov	0x0486,%ax		# ...& character height
+	mov	%ax,mm+"struct mman::pc_video_char_height"
 	.previous
 	.code64
 	.section .rodata,"a",@progbits

--- a/libc/vga/tty-graph.c
+++ b/libc/vga/tty-graph.c
@@ -37,6 +37,7 @@
  */
 
 #undef KLOGTTY
+#define MAYUNROLLLOOPS unrollloops
 
 #define COLOR          TtyCanvasColor
 #define BPP            32

--- a/libc/vga/tty-graph.inc
+++ b/libc/vga/tty-graph.inc
@@ -1,0 +1,329 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│vi: set net ft=c ts=2 sts=2 sw=2 fenc=utf-8                                :vi│
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ This is free and unencumbered software released into the public domain.      │
+│                                                                              │
+│ Anyone is free to copy, modify, publish, use, compile, sell, or              │
+│ distribute this software, either in source code form or as a compiled        │
+│ binary, for any purpose, commercial or non-commercial, and by any            │
+│ means.                                                                       │
+│                                                                              │
+│ In jurisdictions that recognize copyright laws, the author or authors        │
+│ of this software dedicate any and all copyright interest in the              │
+│ software to the public domain. We make this dedication for the benefit       │
+│ of the public at large and to the detriment of our heirs and                 │
+│ successors. We intend this dedication to be an overt act of                  │
+│ relinquishment in perpetuity of all present and future rights to this        │
+│ software under copyright law.                                                │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,              │
+│ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF           │
+│ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.       │
+│ IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR            │
+│ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,        │
+│ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR        │
+│ OTHER DEALINGS IN THE SOFTWARE.                                              │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "libc/intrin/newbie.h"
+#include "libc/macros.internal.h"
+#include "libc/str/str.h"
+#include "libc/vga/vga.internal.h"
+
+/**
+ * @fileoverview Template for routines to support output in graphical video
+ * modes for bare metal VGA.
+ *
+ * If KLOGTTY is undefined, this file expands to code that writes to a
+ * separate off-screen canvas buffer — which should be allocated beforehand
+ * — before drawing to the actual video memory.
+ *
+ * If KLOGTTY is defined, this file instead expands to code that can
+ * implement an emergency console.  The graphics routines will directly write
+ * to video memory.  This may result in slower output, but will work even if
+ * we cannot allocate an off-screen canvas for whatever reason.
+ *
+ * @see libc/vga/tty.greg.c
+ * @see libc/vga/tty-graph.c
+ * @see libc/vga/tty-klog.greg.c
+ */
+
+#ifndef KLOGTTY
+
+static COLOR MAPCOLOR(struct Tty *tty, TtyCanvasColor ic) {
+  return ic;
+}
+
+static void DIRTY(struct Tty *tty, size_t gy1, size_t gx1,
+                                   size_t gy2, size_t gx2) {
+  if (tty->updy1 > gy1) tty->updy1 = gy1;
+  if (tty->updx1 > gx1) tty->updx1 = gx1;
+  if (tty->updy2 < gy2) tty->updy2 = gy2;
+  if (tty->updx2 < gx2) tty->updx2 = gx2;
+}
+
+static void RESETDIRTY(struct Tty *tty) {
+  tty->updy1 = tty->updx1 = tty->updy2 = tty->updx2 = 0;
+}
+
+unrollloops void _TtyBgr565Update(struct Tty *tty) {
+  size_t gy1 = tty->updy1, gy2 = tty->updy2,
+         gx1 = tty->updx1, gx2 = tty->updx2,
+         xsfb = tty->xsfb, xs = tty->xs;
+  if (gy1 < gy2 && gx1 < gx2) {
+    size_t yleft = gy2 - gy1, xleft;
+    char *cplotter = tty->fb + gy1 * xsfb + gx1 * sizeof(TtyBgr565Color);
+    const char *creader = tty->canvas + gy1 * xs
+                                      + gx1 * sizeof(TtyCanvasColor);
+    RESETDIRTY(tty);
+    while (yleft-- != 0) {
+      TtyBgr565Color *plotter = (TtyBgr565Color *)cplotter;
+      const TtyCanvasColor *reader = (const TtyCanvasColor *)creader;
+      TtyCanvasColor c;
+      xleft = gx2 - gx1;
+      while (xleft-- != 0) {
+        uint16_t w;
+        c.w = reader->w;
+        ++reader;
+        w = htole16(c.bgr.b >> 3 | c.bgr.g >> 2 << 5 | c.bgr.r >> 3 << 11);
+        *plotter++ = (TtyBgr565Color){w};
+      }
+      cplotter += xsfb;
+      creader += xs;
+    }
+  }
+}
+
+unrollloops void _TtyBgr555Update(struct Tty *tty) {
+  size_t gy1 = tty->updy1, gy2 = tty->updy2,
+         gx1 = tty->updx1, gx2 = tty->updx2,
+         xsfb = tty->xsfb, xs = tty->xs;
+  if (gy1 < gy2 && gx1 < gx2) {
+    size_t yleft = gy2 - gy1, xleft;
+    char *cplotter = tty->fb + gy1 * xsfb + gx1 * sizeof(TtyBgr555Color);
+    const char *creader = tty->canvas + gy1 * xs
+                                      + gx1 * sizeof(TtyCanvasColor);
+    RESETDIRTY(tty);
+    while (yleft-- != 0) {
+      TtyBgr555Color *plotter = (TtyBgr555Color *)cplotter;
+      const TtyCanvasColor *reader = (const TtyCanvasColor *)creader;
+      TtyCanvasColor c;
+      xleft = gx2 - gx1;
+      while (xleft-- != 0) {
+        uint16_t w;
+        c.w = reader->w;
+        ++reader;
+        w = htole16(c.bgr.b >> 3 | c.bgr.g >> 3 << 5 | c.bgr.r >> 3 << 10);
+        *plotter++ = (TtyBgr555Color){w};
+      }
+      cplotter += xsfb;
+      creader += xs;
+    }
+  }
+}
+
+unrollloops void _TtyBgrxUpdate(struct Tty *tty) {
+  size_t gy1 = tty->updy1, gy2 = tty->updy2,
+         gx1 = tty->updx1, gx2 = tty->updx2,
+         xsfb = tty->xsfb, xs = tty->xs;
+  if (gy1 < gy2 && gx1 < gx2) {
+    size_t yleft = gy2 - gy1, xleft;
+    char *cplotter = tty->fb + gy1 * xsfb + gx1 * sizeof(TtyBgrxColor);
+    const char *creader = tty->canvas + gy1 * xs
+                                      + gx1 * sizeof(TtyCanvasColor);
+    RESETDIRTY(tty);
+    while (yleft-- != 0) {
+      TtyBgrxColor *plotter = (TtyBgrxColor *)cplotter;
+      const TtyCanvasColor *reader = (const TtyCanvasColor *)creader;
+      xleft = gx2 - gx1;
+      while (xleft-- != 0) {
+        TtyCanvasColor c = *reader++;
+        c.bgr.x = 0xff;
+        *plotter++ = c;
+      }
+      cplotter += xsfb;
+      creader += xs;
+    }
+  }
+}
+
+unrollloops void _TtyRgbxUpdate(struct Tty *tty) {
+  size_t gy1 = tty->updy1, gy2 = tty->updy2,
+         gx1 = tty->updx1, gx2 = tty->updx2,
+         xsfb = tty->xsfb, xs = tty->xs;
+  if (gy1 < gy2 && gx1 < gx2) {
+    size_t yleft = gy2 - gy1, xleft;
+    char *cplotter = tty->fb + gy1 * xsfb + gx1 * sizeof(TtyRgbxColor);
+    const char *creader = tty->canvas + gy1 * xs
+                                      + gx1 * sizeof(TtyCanvasColor);
+    RESETDIRTY(tty);
+    while (yleft-- != 0) {
+      TtyRgbxColor *plotter = (TtyRgbxColor *)cplotter;
+      const TtyCanvasColor *reader = (const TtyCanvasColor *)creader;
+      TtyCanvasColor ic;
+      TtyRgbxColor oc;
+      xleft = gx2 - gx1;
+      while (xleft-- != 0) {
+        ic.w = reader->w;
+        ++reader;
+        oc = (TtyRgbxColor){.rgb.r = ic.bgr.r, .rgb.g = ic.bgr.g,
+                            .rgb.b = ic.bgr.b, .rgb.x = 0xff};
+        plotter->w = oc.w;
+        ++plotter;
+      }
+      cplotter += xsfb;
+      creader += xs;
+    }
+  }
+}
+
+#else /* KLOGTTY */
+
+static COLOR MAPCOLOR(struct Tty *tty, TtyCanvasColor ic) {
+#if BPP == 16
+  if (tty->type == PC_VIDEO_BGR565)
+    return htole16(ic.bgr.b >> 3 | ic.bgr.g >> 2 << 5 | ic.bgr.r >> 3 << 11);
+  else
+    return htole16(ic.bgr.b >> 3 | ic.bgr.g >> 3 << 5 | ic.bgr.r >> 3 << 10);
+#else
+  if (tty->type == PC_VIDEO_BGRX8888)
+    return ic.w;
+  else {
+    TtyRgbxColor oc = (TtyRgbxColor){.rgb.r = ic.bgr.r, .rgb.g = ic.bgr.g,
+                                     .rgb.b = ic.bgr.b, .rgb.x = 0xff};
+    return oc.w;
+  }
+#endif
+}
+
+static void DIRTY(struct Tty *tty, size_t gy1, size_t gx1,
+                                   size_t gy2, size_t gx2) {
+}
+
+static void RESETDIRTY(struct Tty *tty) {
+}
+
+void UPDATE(struct Tty *tty) {
+}
+
+#endif /* KLOGTTY */
+
+static void DRAWBITMAP(struct Tty *tty, size_t gy, size_t gx,
+                       COLOR fg, COLOR bg, const uint8_t *bitmap,
+                       size_t bm_ht, size_t bm_wid) {
+  size_t xs = tty->xs;
+  char *cplotter = tty->canvas + gy * xs + gx * sizeof(COLOR);
+  size_t yleft = bm_ht, xleft;
+  while (yleft-- != 0) {
+    COLOR *plotter = (COLOR *)cplotter;
+    xleft = bm_wid;
+    while (xleft >= 8) {
+      uint8_t bits = *bitmap++;
+      *plotter++ = __builtin_add_overflow(bits, bits, &bits) ? fg : bg;
+      *plotter++ = __builtin_add_overflow(bits, bits, &bits) ? fg : bg;
+      *plotter++ = __builtin_add_overflow(bits, bits, &bits) ? fg : bg;
+      *plotter++ = __builtin_add_overflow(bits, bits, &bits) ? fg : bg;
+      *plotter++ = __builtin_add_overflow(bits, bits, &bits) ? fg : bg;
+      *plotter++ = __builtin_add_overflow(bits, bits, &bits) ? fg : bg;
+      *plotter++ = __builtin_add_overflow(bits, bits, &bits) ? fg : bg;
+      *plotter++ = __builtin_add_overflow(bits, bits, &bits) ? fg : bg;
+      xleft -= 8;
+    }
+    if (xleft) {
+      uint8_t bits = *bitmap++;
+      switch (xleft) {
+        default:
+          *plotter++ = __builtin_add_overflow(bits, bits, &bits) ? fg : bg;
+          /* fall through */
+        case 6:
+          *plotter++ = __builtin_add_overflow(bits, bits, &bits) ? fg : bg;
+          /* fall through */
+        case 5:
+          *plotter++ = __builtin_add_overflow(bits, bits, &bits) ? fg : bg;
+          /* fall through */
+        case 4:
+          *plotter++ = __builtin_add_overflow(bits, bits, &bits) ? fg : bg;
+          /* fall through */
+        case 3:
+          *plotter++ = __builtin_add_overflow(bits, bits, &bits) ? fg : bg;
+          /* fall through */
+        case 2:
+          *plotter++ = __builtin_add_overflow(bits, bits, &bits) ? fg : bg;
+          /* fall through */
+        case 1:
+          *plotter++ = __builtin_add_overflow(bits, bits, &bits) ? fg : bg;
+      }
+    }
+    cplotter += xs;
+  }
+  DIRTY(tty, gy, gx, gy + bm_ht, gx + bm_wid);
+}
+
+static unrollloops void FILLRECT(struct Tty *tty, size_t gy, size_t gx,
+                                 size_t fill_ht, size_t fill_wid, COLOR bg) {
+  size_t xs = tty->xs;
+  char *cplotter = tty->canvas + gy * xs + gx * sizeof(COLOR);
+  size_t yleft = fill_ht, xleft;
+  while (yleft-- != 0) {
+    COLOR *plotter = (COLOR *)cplotter;
+    size_t i;
+    for (i = 0; i < fill_wid; ++i)
+      *plotter++ = bg;
+    cplotter += xs;
+  }
+  DIRTY(tty, gy, gx, gy + fill_ht, gx + fill_wid);
+}
+
+static void MOVERECT(struct Tty *tty, size_t dgy, size_t dgx,
+                     size_t sgy, size_t sgx, size_t ht, size_t wid) {
+  size_t xs = tty->xs, xm = wid * sizeof(COLOR);
+  char *canvas = tty->canvas;
+  DIRTY(tty, dgy, dgx, dgy + ht, dgx + wid);
+  if (dgy < sgy) {
+    while (ht-- != 0) {
+      memmove(canvas + dgy * xs + dgx * sizeof(COLOR),
+              canvas + sgy * xs + sgx * sizeof(COLOR), xm);
+      ++dgy;
+      ++sgy;
+    }
+  } else if (dgy > sgy) {
+    while (ht-- != 0)
+      memmove(canvas + (dgy + ht) * xs + dgx * sizeof(COLOR),
+              canvas + (sgy + ht) * xs + sgx * sizeof(COLOR), xm);
+  }
+}
+
+void DRAWCHAR(struct Tty *tty, size_t y, size_t x, wchar_t wc) {
+  /* TODO: allow configuring a different font later. */
+  const uint8_t *glyph;
+  const size_t glyph_ht = ARRAYLEN(_vga_font_default_direct[0]);
+  COLOR fg = MAPCOLOR(tty, tty->fg), bg = MAPCOLOR(tty, tty->bg);
+  if ((tty->pr & kTtyFlip) != 0)
+    fg = bg, bg = MAPCOLOR(tty, tty->fg);
+  if (wc < L' ' || wc >= L' ' + ARRAYLEN(_vga_font_default_direct))
+    glyph = _vga_font_default_direct[0];
+  else
+    glyph = _vga_font_default_direct[wc - L' '];
+  if (glyph_ht >= VGA_ASSUME_CHAR_HEIGHT_PX)
+    DRAWBITMAP(tty, y * tty->yc, x * tty->xc, fg, bg, glyph,
+               VGA_ASSUME_CHAR_HEIGHT_PX, 8);
+  else {
+    /*
+     * Glyph is not tall enough.  Draw it out, then pad the bottom of the
+     * character cell with the background color.
+     */
+    DRAWBITMAP(tty, y * tty->yc, x * tty->xc, fg, bg, glyph, glyph_ht, 8);
+    FILLRECT(tty, y * tty->yc + glyph_ht, x * tty->xc,
+             VGA_ASSUME_CHAR_HEIGHT_PX - glyph_ht, 8, bg);
+  }
+}
+
+void ERASELINECELLS(struct Tty *tty, size_t y, size_t x, size_t n) {
+  size_t yc = tty->yc, xc = tty->xc;
+  FILLRECT(tty, y * yc, x * xc, yc, n * xc, MAPCOLOR(tty, tty->bg));
+}
+
+void MOVELINECELLS(struct Tty *tty, size_t dsty, size_t dstx,
+                   size_t srcy, size_t srcx, size_t n) {
+  size_t yc = tty->yc, xc = tty->xc;
+  MOVERECT(tty, dsty * yc, dstx * xc, srcy * yc, srcx * xc, yc, n * xc);
+}

--- a/libc/vga/tty-graph.inc
+++ b/libc/vga/tty-graph.inc
@@ -258,8 +258,9 @@ static void DRAWBITMAP(struct Tty *tty, size_t gy, size_t gx,
   DIRTY(tty, gy, gx, gy + bm_ht, gx + bm_wid);
 }
 
-static unrollloops void FILLRECT(struct Tty *tty, size_t gy, size_t gx,
-                                 size_t fill_ht, size_t fill_wid, COLOR bg) {
+static MAYUNROLLLOOPS void FILLRECT(struct Tty *tty, size_t gy, size_t gx,
+                                    size_t fill_ht, size_t fill_wid,
+                                    COLOR bg) {
   size_t xs = tty->xs;
   char *cplotter = tty->canvas + gy * xs + gx * sizeof(COLOR);
   size_t yleft = fill_ht, xleft;

--- a/libc/vga/tty-klog.greg.c
+++ b/libc/vga/tty-klog.greg.c
@@ -37,7 +37,10 @@
  * @see libc/vga/tty-graph.inc
  */
 
+#pragma GCC optimize("s")
+
 #define KLOGTTY
+#define MAYUNROLLLOOPS /* do not unroll loops; keep the code small! */
 
 /* Instantiate output routines for 16-bit pixel formats. */
 #define COLOR          uint16_t

--- a/libc/vga/vga-init.c
+++ b/libc/vga/vga-init.c
@@ -24,26 +24,47 @@
 │ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR        │
 │ OTHER DEALINGS IN THE SOFTWARE.                                              │
 ╚─────────────────────────────────────────────────────────────────────────────*/
-#include "libc/calls/struct/fd.internal.h"
-#include "libc/calls/struct/iovec.h"
-#include "libc/calls/struct/iovec.internal.h"
 #include "libc/dce.h"
 #include "libc/vga/vga.internal.h"
+#include "libc/runtime/pc.internal.h"
+#include "libc/str/str.h"
 
-ssize_t sys_writev_vga(struct Fd *fd, const struct iovec *iov, int iovlen) {
-  size_t i, wrote = 0;
-  ssize_t res = 0;
-  for (i = 0; i < iovlen; ++i) {
-    void *output = iov[i].iov_base;
-    size_t len = iov[i].iov_len;
-    res = _TtyWrite(&_vga_tty, output, len);
-    if (res < 0)
-      break;
-    wrote += res;
-    if (res != len)
-      return wrote;
+struct Tty _vga_tty;
+
+__attribute__((__constructor__)) static textstartup void _vga_init(void) {
+  if (IsMetal()) {
+    struct mman *mm = (struct mman *)(BANE + 0x0500);
+    unsigned char vid_type = mm->pc_video_type;
+    unsigned short height = mm->pc_video_height, width = mm->pc_video_width,
+                   stride = mm->pc_video_stride;
+    uint64_t vid_buf_phy = mm->pc_video_framebuffer;
+    void *vid_buf = (void *)(BANE + vid_buf_phy);
+    size_t vid_buf_sz = mm->pc_video_framebuffer_size;
+    /*
+     * Get the initial cursor position from the BIOS data area.  Also get
+     * the height (in scan lines) of each character; this is used to set the
+     * cursor shape.
+     */
+    typedef struct {
+      unsigned char col, row;
+    } bios_curs_pos_t;
+    bios_curs_pos_t pos = *(bios_curs_pos_t *)(BANE + 0x0450ull);
+    uint8_t chr_ht, chr_ht_hi, chr_wid;
+    if (vid_type == PC_VIDEO_TEXT) {
+      chr_ht = *(uint8_t *)(BANE + 0x0485ull),
+      chr_ht_hi = *(uint8_t *)(BANE + 0x0486ull);
+      if (chr_ht_hi != 0 || chr_ht > 32 || chr_ht < 2)
+        chr_ht = VGA_ASSUME_CHAR_HEIGHT_PX;
+    } else
+      chr_ht = VGA_ASSUME_CHAR_HEIGHT_PX;
+    chr_wid = VGA_ASSUME_CHAR_WIDTH_PX;
+    /* Make sure the video buffer is mapped into virtual memory. */
+    __invert_memory_area(mm, __get_pml4t(), vid_buf_phy, vid_buf_sz, PAGE_RW);
+    /*
+     * Initialize our tty structure from the current screen geometry,
+     * screen contents, cursor position, & character dimensions.
+     */
+    _StartTty(&_vga_tty, vid_type, height, width, stride, pos.row, pos.col,
+              chr_ht, chr_wid, vid_buf, false);
   }
-  if (!wrote)
-    return res;
-  return wrote;
 }

--- a/libc/vga/vga-init.c
+++ b/libc/vga/vga-init.c
@@ -40,21 +40,15 @@ __attribute__((__constructor__)) static textstartup void _vga_init(void) {
     uint64_t vid_buf_phy = mm->pc_video_framebuffer;
     void *vid_buf = (void *)(BANE + vid_buf_phy);
     size_t vid_buf_sz = mm->pc_video_framebuffer_size;
-    /*
-     * Get the initial cursor position from the BIOS data area.  Also get
-     * the height (in scan lines) of each character; this is used to set the
-     * cursor shape.
-     */
-    typedef struct {
-      unsigned char col, row;
-    } bios_curs_pos_t;
-    bios_curs_pos_t pos = *(bios_curs_pos_t *)(BANE + 0x0450ull);
-    uint8_t chr_ht, chr_ht_hi, chr_wid;
+    unsigned short starty = mm->pc_video_curs_info.y,
+                   startx = mm->pc_video_curs_info.x;
+    uint8_t chr_ht, chr_wid;
     if (vid_type == PC_VIDEO_TEXT) {
-      chr_ht = *(uint8_t *)(BANE + 0x0485ull),
-      chr_ht_hi = *(uint8_t *)(BANE + 0x0486ull);
-      if (chr_ht_hi != 0 || chr_ht > 32 || chr_ht < 2)
+      unsigned short chr_ht_val = mm->pc_video_char_height;
+      if (chr_ht_val > 32 || chr_ht_val < 2)
         chr_ht = VGA_ASSUME_CHAR_HEIGHT_PX;
+      else
+        chr_ht = chr_ht_val;
     } else
       chr_ht = VGA_ASSUME_CHAR_HEIGHT_PX;
     chr_wid = VGA_ASSUME_CHAR_WIDTH_PX;
@@ -64,7 +58,7 @@ __attribute__((__constructor__)) static textstartup void _vga_init(void) {
      * Initialize our tty structure from the current screen geometry,
      * screen contents, cursor position, & character dimensions.
      */
-    _StartTty(&_vga_tty, vid_type, height, width, stride, pos.row, pos.col,
+    _StartTty(&_vga_tty, vid_type, height, width, stride, starty, startx,
               chr_ht, chr_wid, vid_buf, false);
   }
 }


### PR DESCRIPTION
With commit https://github.com/jart/cosmopolitan/commit/5aaadf1162f9d3b7a01ad633b51e05e0ca4fc231, the VGA console code can now display information about program crashes:
![20221005-1](https://user-images.githubusercontent.com/5507843/194131451-b7c32afc-56e6-4c11-b6a1-8760d054bd6c.png)
My aim in implementing a "screen of death" is to make it easier to debug program crashes on actual bare metal setups (where we will not be able to use e.g. QEMU's or Bochs's debugging features).  So yes, I have tested the "screen of death" on a real machine.  And it does work. :slightly_smiling_face: 

I also included a few other less major changes within this PR, namely https://github.com/tkchia/cosmopolitan/commit/9926ed74f11222d4bf0c71a1944c2e717a9552b8, https://github.com/tkchia/cosmopolitan/commit/7059a7109d3a7647ecafc3f7b178b1dd12ec83d8, and https://github.com/tkchia/cosmopolitan/commit/b8cd8a07b48b726fde2c544ea42f715e80d23a04.