### PR TITLE
[metal] Fix sys_mmap_metal() issues for non-MAP_FIXED case

### DIFF
--- a/libc/intrin/directmap-metal.c
+++ b/libc/intrin/directmap-metal.c
@@ -39,8 +39,10 @@ noasan struct DirectMap sys_mmap_metal(void *paddr, size_t size, int prot,
   size = ROUNDUP(size, 4096);
   addr = (uint64_t)paddr;
   if (!(flags & MAP_FIXED)) {
+    if (!addr)
+      addr = 4096;
     for (i = 0; i < size; i += 4096) {
-      pte = __get_virtual(mm, pml4t, addr, false);
+      pte = __get_virtual(mm, pml4t, addr + i, false);
       if (pte && (*pte & PAGE_V)) {
         addr = MAX(addr, sys_mmap_metal_break) + i + 4096;
         i = 0;


### PR DESCRIPTION
- correctly check that virtual region we want to use is unmapped, rather than accidentally clobbering existing pages
- avoid placing `mmap`'d memory at null virtual address