### PR TITLE
[metal] Push forward timing of VGA TTY initialization

### DIFF
--- a/libc/vga/rlinit-init-vga.S
+++ b/libc/vga/rlinit-init-vga.S
@@ -91,5 +91,12 @@
 vga_console:
 	.endobj	vga_console,globl,hidden
 	.previous
+	.init.start 305,_init_vga
+	push	%rdi
+	push	%rsi
+	call	_vga_init
+	pop	%rsi
+	pop	%rdi
+	.init.end 305,_init_vga
 	.yoink	sys_writev_vga
 	.yoink	sys_readv_vga

--- a/libc/vga/vga-init.greg.c
+++ b/libc/vga/vga-init.greg.c
@@ -60,7 +60,7 @@ void _vga_reinit(struct Tty *tty, unsigned short starty, unsigned short startx,
             chr_ht, chr_wid, vid_buf, init_flags);
 }
 
-__attribute__((__constructor__)) static textstartup void _vga_init(void) {
+textstartup void _vga_init(void) {
   if (IsMetal()) {
     struct mman *mm = (struct mman *)(BANE + 0x0500);
     unsigned short starty = mm->pc_video_curs_info.y,


### PR DESCRIPTION
- arrange to initialize the default VGA TTY data structure, at about the same time as the console stdin, stdout, & stderr descriptors are set up, rather than much later
- ~~tweak the text mode console code to rely less on `unbing()` to convert from Unicode to CP437~~