### PR TITLE
[metal] Fix bug: do not initialize IDT & TSS if unneeded

### DIFF
--- a/ape/ape.lds
+++ b/ape/ape.lds
@@ -569,8 +569,6 @@ HIDDEN(v_ape_realsectors =
 HIDDEN(v_ape_realpages = v_ape_realsectors / (4096 / 512));
 HIDDEN(v_ape_highsectors =
            (ROUNDUP(RVA(_edata), 512) / 512) - v_ape_realsectors);
-PROVIDE_HIDDEN(_tss = 0);
-PROVIDE_HIDDEN(_tss_end = 0);
 TSSDESCSTUB2(_tss, _tss, _tss_end ? _tss_end - _tss - 1 : 0);
 #endif
 

--- a/ape/macros.internal.h
+++ b/ape/macros.internal.h
@@ -182,6 +182,14 @@
 
 //	Task State Segment Descriptor Entries.
 .macro	.tssdescstub name:req
+ .ifndef \name
+  .weak	\name
+  .set	\name,0
+ .endif
+ .ifndef \name\()_end
+  .weak	\name\()_end
+  .set	\name\()_end,0
+ .endif
  .stub	\name\()_desc_ent0,quad
  .stub	\name\()_desc_ent1,quad
 .endm

--- a/libc/intrin/interrupts.S
+++ b/libc/intrin/interrupts.S
@@ -93,9 +93,9 @@ __excep0_isr:
 	ezlea	.excep_msg,di		# stack should be 16-byte aligned now
 	xor	%eax,%eax		# kprintf is variadic, remember to
 					# pass no. of vector regs. used (= 0)
-	.weak	kprintf			# weakly link kprintf() because this
-	ezlea	kprintf,bx		# module is a mandatory dependency
-	test	%ebx,%ebx		# and we want to keep life.com tiny
+	.weak	kprintf			# weakly link kprintf() because we
+	ezlea	kprintf,bx		# want to keep life.com tiny
+	test	%ebx,%ebx
 	jz	8f
 	call	*%rbx			# print error message
 8:	cli


### PR DESCRIPTION
`libc/intrin/interrupts.S` should not be linked in unless an IDT (or TSS) is explicitly requested somewhere (i.e. it should probably not be a mandatory module).