### PR TITLE
Fix ParseHttpMessage failing to store >2 repeatable headers

### DIFF
--- a/net/http/parsehttpmessage.c
+++ b/net/http/parsehttpmessage.c
@@ -236,8 +236,12 @@ int ParseHttpMessage(struct HttpMessage *r, const char *p, size_t n) {
                 unsigned c2;
                 struct HttpHeader *p1, *p2;
                 p1 = r->xheaders.p;
-                c2 = r->xheaders.c + 2;
-                c2 = c2 >> 1;
+                c2 = r->xheaders.c;
+                if (c2 == 0) {
+                  c2 = 1;
+                } else {
+                  c2 = c2 * 2;
+                }
                 if ((p2 = realloc(p1, c2 * sizeof(*p1)))) {
                   r->xheaders.p = p2;
                   r->xheaders.c = c2;


### PR DESCRIPTION
ParseHttpMessage had a bug where `HttpMessage.xheaders` would not exceed a capacity of `1` inside of `ParseHttpMessage`. This resulted in only 2 repeatable headers being stored, the first in `HttpMessage.headers`, and the second in the 1-capacity `HttpMessage.xheaders`.

This pull request implements a unit test to detect this bug and a fix that passes the unit test. Now, when `xheaders` has 0 capacity, it's set to 1, and when it's full, the capacity gets doubled.

Also, `clang-format` rearranged the headers in the test file.