### PR TITLE
Update SQLite deserialize to allow resizing restored DB

### DIFF
--- a/tool/net/demo/sql-backup.lua
+++ b/tool/net/demo/sql-backup.lua
@@ -7,6 +7,11 @@ backup = sqlite3.open_memory()
 buffer = LoadAsset("backup.sqlite3")
 backup:deserialize(buffer)
 
+-- insert more values
+for i = 1, 250 do
+  backup:exec("INSERT INTO test (content) VALUES ('Hello more')")
+end
+
 -- See .init.lua for CREATE TABLE setup.
 for row in backup:nrows("SELECT * FROM test") do
    Write(row.id.." "..row.content.."<br>")

--- a/tool/net/lsqlite3.c
+++ b/tool/net/lsqlite3.c
@@ -1812,8 +1812,9 @@ static int db_deserialize(lua_State *L) {
     if (buffer == NULL || size == 0) /* ignore empty database content */
         return 0;
 
-    sqlite3_deserialize(db->db, "main", buffer, size, size, 0);
-    free(buffer);
+    const char *sqlbuf = memcpy(sqlite3_malloc(size), buffer, size);
+    sqlite3_deserialize(db->db, "main", sqlbuf, size, size,
+        SQLITE_DESERIALIZE_FREEONCLOSE + SQLITE_DESERIALIZE_RESIZEABLE);
     return 0;
 }
 


### PR DESCRIPTION
This fixes an issue with deserialize that kept the deserialized DB limited in size (likely about 8KB, so it would only grow to 8k, but not more). Inserting more than 221 rows into the test DB would fail with SQLITE_FULL return code. This patch allows the DB to grow beyond that size and also frees the buffer on closing it.

Using either option (FREEONCLOSE or RESIZEABLE) requires using sqlite3_malloc, so it's being used. Ref. #436