### PR TITLE
vista: fix langinfo SIGSEGV

### DIFF
--- a/libc/calls/getdtablesize.c
+++ b/libc/calls/getdtablesize.c
@@ -1,0 +1,29 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│vi: set net ft=c ts=2 sts=2 sw=2 fenc=utf-8                                :vi│
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ Copyright 2022 Justine Alexandra Roberts Tunney                              │
+│                                                                              │
+│ Permission to use, copy, modify, and/or distribute this software for         │
+│ any purpose with or without fee is hereby granted, provided that the         │
+│ above copyright notice and this permission notice appear in all copies.      │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL                │
+│ WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED                │
+│ WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE             │
+│ AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL         │
+│ DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR        │
+│ PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER               │
+│ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR             │
+│ PERFORMANCE OF THIS SOFTWARE.                                                │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "libc/calls/calls.h"
+#include "libc/calls/internal.h"
+
+/**
+ * Gets file descriptor table size.
+ *
+ * @return current limit on the number of open files per process
+ */
+int getdtablesize(void) {
+  return g_fds.n;
+}

--- a/libc/fmt/imaxdiv.c
+++ b/libc/fmt/imaxdiv.c
@@ -1,0 +1,32 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│vi: set net ft=c ts=2 sts=2 sw=2 fenc=utf-8                                :vi│
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ Copyright 2022 Justine Alexandra Roberts Tunney                              │
+│                                                                              │
+│ Permission to use, copy, modify, and/or distribute this software for         │
+│ any purpose with or without fee is hereby granted, provided that the         │
+│ above copyright notice and this permission notice appear in all copies.      │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL                │
+│ WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED                │
+│ WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE             │
+│ AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL         │
+│ DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR        │
+│ PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER               │
+│ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR             │
+│ PERFORMANCE OF THIS SOFTWARE.                                                │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "libc/fmt/conv.h"
+
+imaxdiv_t imaxdiv(intmax_t n, intmax_t d) {
+  imaxdiv_t retval;
+
+  retval.quot = n / d;
+  retval.rem = n % d;
+  // satisfy quot*denominator+rem == numerator
+  if (n > 0 && retval.rem < 0) {
+    retval.quot += 1;
+    retval.rem -= d;
+  }
+  return (retval);
+}

--- a/libc/fmt/wcscoll.c
+++ b/libc/fmt/wcscoll.c
@@ -1,0 +1,25 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│vi: set net ft=c ts=2 sts=2 sw=2 fenc=utf-8                                :vi│
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ Copyright 2022 Justine Alexandra Roberts Tunney                              │
+│                                                                              │
+│ Permission to use, copy, modify, and/or distribute this software for         │
+│ any purpose with or without fee is hereby granted, provided that the         │
+│ above copyright notice and this permission notice appear in all copies.      │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL                │
+│ WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED                │
+│ WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE             │
+│ AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL         │
+│ DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR        │
+│ PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER               │
+│ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR             │
+│ PERFORMANCE OF THIS SOFTWARE.                                                │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "libc/str/locale.h"
+#include "libc/str/str.h"
+#include "libc/thread/tls.h"
+
+int wcscoll(const wchar_t *p, const wchar_t *q) {
+  return wcscoll_l(p, q, (locale_t)__get_tls()->tib_locale);
+}

--- a/libc/str/langinfo.c
+++ b/libc/str/langinfo.c
@@ -66,6 +66,9 @@ char *nl_langinfo_l(nl_item item, locale_t loc)
 	int idx = item & 65535;
 	const char *str;
 
+	if (!loc)
+		return "";
+
 	if (item == CODESET) return loc->cat[LC_CTYPE] ? "UTF-8" : "ASCII";
 
 	/* _NL_LOCALE_NAME extension */

--- a/test/libc/fmt/imaxdiv_test.c
+++ b/test/libc/fmt/imaxdiv_test.c
@@ -1,0 +1,65 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│vi: set net ft=c ts=2 sts=2 sw=2 fenc=utf-8                                :vi│
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ Copyright 2022 Hugues Morisset                                               │
+│                                                                              │
+│ Permission to use, copy, modify, and/or distribute this software for         │
+│ any purpose with or without fee is hereby granted, provided that the         │
+│ above copyright notice and this permission notice appear in all copies.      │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL                │
+│ WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED                │
+│ WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE             │
+│ AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL         │
+│ DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR        │
+│ PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER               │
+│ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR             │
+│ PERFORMANCE OF THIS SOFTWARE.                                                │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "libc/fmt/conv.h"
+#include "libc/limits.h"
+#include "libc/testlib/testlib.h"
+
+TEST(imaxdiv, test) {
+  imaxdiv_t res;
+
+  res = imaxdiv(-5, 3);
+  EXPECT_EQ(-1, res.quot);
+  EXPECT_EQ(-2, res.rem);
+
+  res = imaxdiv(1, 1);
+  EXPECT_EQ(1, res.quot);
+  EXPECT_EQ(0, res.rem);
+
+  res = imaxdiv(20, 10);
+  EXPECT_EQ(2, res.quot);
+  EXPECT_EQ(0, res.rem);
+
+  res = imaxdiv(20, 11);
+  EXPECT_EQ(1, res.quot);
+  EXPECT_EQ(9, res.rem);
+
+  res = imaxdiv(-20, -11);
+  EXPECT_EQ(1, res.quot);
+  EXPECT_EQ(-9, res.rem);
+
+  res = imaxdiv(0, -11);
+  EXPECT_EQ(0, res.quot);
+  EXPECT_EQ(0, res.rem);
+
+  res = imaxdiv(0, 11);
+  EXPECT_EQ(0, res.quot);
+  EXPECT_EQ(0, res.rem);
+
+  res = imaxdiv(INT64_MIN, 1);
+  EXPECT_EQ(INT64_MIN, res.quot);
+  EXPECT_EQ(0, res.rem);
+
+  res = imaxdiv(INT64_MAX, -1);
+  EXPECT_EQ(-(INT64_MAX), res.quot);
+  EXPECT_EQ(0, res.rem);
+
+  res = imaxdiv(2387, 348);
+  EXPECT_EQ(6, res.quot);
+  EXPECT_EQ(299, res.rem);
+}


### PR DESCRIPTION
Add #639 to `vista`.

Perl's `ExtUtils::MakeMaker` triggers the crash.