### PR TITLE
Implement zipos mmap

### DIFF
--- a/libc/runtime/mmap.c
+++ b/libc/runtime/mmap.c
@@ -50,6 +50,7 @@
 #include "libc/sysv/consts/prot.h"
 #include "libc/sysv/errfuns.h"
 #include "libc/thread/thread.h"
+#include "libc/zipos/zipos.internal.h"
 
 #define MAP_ANONYMOUS_linux   0x00000020
 #define MAP_ANONYMOUS_openbsd 0x00001000
@@ -485,6 +486,9 @@ static noasan inline void *Mmap(void *addr, size_t size, int prot, int flags,
 void *mmap(void *addr, size_t size, int prot, int flags, int fd, int64_t off) {
   void *res;
   size_t toto;
+  if (__isfdkind(fd, kFdZip)) {
+    return _weaken(__zipos_mmap)(addr, size, prot, flags, (struct ZiposHandle *)(intptr_t)g_fds.p[fd].handle, off);
+  }
 #if defined(SYSDEBUG) && (_KERNTRACE || _NTTRACE)
   if (IsWindows()) {
     STRACE("mmap(%p, %'zu, %s, %s, %d, %'ld) → ...", addr, size,

--- a/libc/runtime/mmap.c
+++ b/libc/runtime/mmap.c
@@ -487,7 +487,9 @@ void *mmap(void *addr, size_t size, int prot, int flags, int fd, int64_t off) {
   void *res;
   size_t toto;
   if (__isfdkind(fd, kFdZip)) {
-    return _weaken(__zipos_mmap)(addr, size, prot, flags, (struct ZiposHandle *)(intptr_t)g_fds.p[fd].handle, off);
+    return _weaken(__zipos_mmap)(
+        addr, size, prot, flags,
+        (struct ZiposHandle *)(intptr_t)g_fds.p[fd].handle, off);
   }
 #if defined(SYSDEBUG) && (_KERNTRACE || _NTTRACE)
   if (IsWindows()) {

--- a/libc/zipos/mmap.c
+++ b/libc/zipos/mmap.c
@@ -48,14 +48,17 @@
  */
 void *__zipos_mmap(void *addr, size_t size, int prot, int flags,
                    struct ZiposHandle *h, int64_t off) {
-  if(!(flags & MAP_PRIVATE) || (flags & ~(MAP_PRIVATE | MAP_FILE | MAP_FIXED | MAP_FIXED_NOREPLACE)) ||
-  (!!(flags & MAP_FIXED) ^ !!(flags & MAP_FIXED_NOREPLACE))) {
-    STRACE("zipos mappings currently only support MAP_PRIVATE with select flags");
+  if (!(flags & MAP_PRIVATE) ||
+      (flags & ~(MAP_PRIVATE | MAP_FILE | MAP_FIXED | MAP_FIXED_NOREPLACE)) ||
+      (!!(flags & MAP_FIXED) ^ !!(flags & MAP_FIXED_NOREPLACE))) {
+    STRACE(
+        "zipos mappings currently only support MAP_PRIVATE with select flags");
     return VIP(einval());
   }
 
   const int tempProt = !IsXnu() ? prot | PROT_WRITE : PROT_WRITE;
-  void *outAddr = mmap(addr, size, tempProt, (flags & (~MAP_FILE)) | MAP_ANONYMOUS, -1, 0);
+  void *outAddr =
+      mmap(addr, size, tempProt, (flags & (~MAP_FILE)) | MAP_ANONYMOUS, -1, 0);
   if (outAddr == MAP_FAILED) {
     return MAP_FAILED;
   }

--- a/libc/zipos/mmap.c
+++ b/libc/zipos/mmap.c
@@ -27,8 +27,8 @@
 #include "libc/sysv/errfuns.h"
 #include "libc/zipos/zipos.internal.h"
 
-#define IP(X)      (intptr_t)(X)
-#define VIP(X)     (void *)IP(X)
+#define IP(X)  (intptr_t)(X)
+#define VIP(X) (void *)IP(X)
 
 /**
  * Map zipos file into memory. See mmap.
@@ -46,7 +46,8 @@
  *     it does not need to be 64kb aligned.
  * @return virtual base address of new mapping, or MAP_FAILED w/ errno
  */
-void *__zipos_mmap(void *addr, size_t size, int prot, int flags, struct ZiposHandle *h, int64_t off) {
+void *__zipos_mmap(void *addr, size_t size, int prot, int flags,
+                   struct ZiposHandle *h, int64_t off) {
   if (VERY_UNLIKELY(!!(flags & MAP_ANONYMOUS))) {
     STRACE("MAP_ANONYMOUS zipos mismatch");
     return VIP(einval());
@@ -65,9 +66,10 @@ void *__zipos_mmap(void *addr, size_t size, int prot, int flags, struct ZiposHan
     return MAP_FAILED;
   }
   const int64_t beforeOffset = __zipos_lseek(h, 0, SEEK_CUR);
-  if ((beforeOffset == -1) || (__zipos_read(h, &(struct iovec){outAddr, size}, 1, off) == -1) ||
-  (__zipos_lseek(h, beforeOffset, SEEK_SET) == -1) ||
-  ((prot != tempProt) && (mprotect(outAddr, size, prot) == -1))) {
+  if ((beforeOffset == -1) ||
+      (__zipos_read(h, &(struct iovec){outAddr, size}, 1, off) == -1) ||
+      (__zipos_lseek(h, beforeOffset, SEEK_SET) == -1) ||
+      ((prot != tempProt) && (mprotect(outAddr, size, prot) == -1))) {
     const int e = errno;
     munmap(outAddr, size);
     errno = e;

--- a/libc/zipos/mmap.c
+++ b/libc/zipos/mmap.c
@@ -48,20 +48,14 @@
  */
 void *__zipos_mmap(void *addr, size_t size, int prot, int flags,
                    struct ZiposHandle *h, int64_t off) {
-  if (VERY_UNLIKELY(!!(flags & MAP_ANONYMOUS))) {
-    STRACE("MAP_ANONYMOUS zipos mismatch");
+  if(!(flags & MAP_PRIVATE) || (flags & ~(MAP_PRIVATE | MAP_FILE | MAP_FIXED | MAP_FIXED_NOREPLACE)) ||
+  (!!(flags & MAP_FIXED) ^ !!(flags & MAP_FIXED_NOREPLACE))) {
+    STRACE("zipos mappings currently only support MAP_PRIVATE with select flags");
     return VIP(einval());
   }
 
-  // MAP_SHARED for non-writeable pages could be implemented, but would require
-  // keeping track of zipos pages to prevent mprotect(addr,len,PROT_WRITE)
-  if (VERY_UNLIKELY(!!(flags & MAP_SHARED))) {
-    STRACE("MAP_SHARED on zipos");
-    return VIP(eacces());
-  }
-
   const int tempProt = !IsXnu() ? prot | PROT_WRITE : PROT_WRITE;
-  void *outAddr = mmap(addr, size, tempProt, flags | MAP_ANONYMOUS, -1, 0);
+  void *outAddr = mmap(addr, size, tempProt, (flags & (~MAP_FILE)) | MAP_ANONYMOUS, -1, 0);
   if (outAddr == MAP_FAILED) {
     return MAP_FAILED;
   }

--- a/libc/zipos/open.c
+++ b/libc/zipos/open.c
@@ -48,7 +48,7 @@
 static char *mapend;
 static size_t maptotal;
 
-static void *__zipos_mmap(size_t mapsize) {
+static void *__zipos_mmap_space(size_t mapsize) {
   char *start;
   size_t offset;
   _unassert(mapsize);
@@ -78,7 +78,7 @@ StartOver:
     ph = &h->next;
   }
   if (!h) {
-    h = __zipos_mmap(mapsize);
+    h = __zipos_mmap_space(mapsize);
   }
   __zipos_unlock();
   if (IsAsan()) {

--- a/libc/zipos/zipos.internal.h
+++ b/libc/zipos/zipos.internal.h
@@ -48,7 +48,8 @@ ssize_t __zipos_write(struct ZiposHandle *, const struct iovec *, size_t,
 int64_t __zipos_lseek(struct ZiposHandle *, int64_t, unsigned) _Hide;
 int __zipos_fcntl(int, int, uintptr_t) _Hide;
 int __zipos_notat(int, const char *) _Hide;
-void *__zipos_mmap(void *, uint64_t, int32_t, int32_t, struct ZiposHandle *, int64_t) _Hide;
+void *__zipos_mmap(void *, uint64_t, int32_t, int32_t, struct ZiposHandle *,
+                   int64_t) _Hide;
 
 #ifdef _NOPL0
 #define __zipos_lock()   _NOPL0("__threadcalls", __zipos_lock)

--- a/libc/zipos/zipos.internal.h
+++ b/libc/zipos/zipos.internal.h
@@ -48,6 +48,7 @@ ssize_t __zipos_write(struct ZiposHandle *, const struct iovec *, size_t,
 int64_t __zipos_lseek(struct ZiposHandle *, int64_t, unsigned) _Hide;
 int __zipos_fcntl(int, int, uintptr_t) _Hide;
 int __zipos_notat(int, const char *) _Hide;
+void *__zipos_mmap(void *, uint64_t, int32_t, int32_t, struct ZiposHandle *, int64_t) _Hide;
 
 #ifdef _NOPL0
 #define __zipos_lock()   _NOPL0("__threadcalls", __zipos_lock)

--- a/test/libc/runtime/mmap_test.c
+++ b/test/libc/runtime/mmap_test.c
@@ -226,7 +226,9 @@ TEST(mmap, ziposCannotBeAnonymous) {
   int fd;
   void *p;
   ASSERT_NE(-1, (fd = open(ziposLifePath, O_RDONLY), "%s", ziposLifePath));
-  EXPECT_SYS(EINVAL, MAP_FAILED, (p = mmap(NULL, 0x00010000, PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS, fd, 0)));
+  EXPECT_SYS(EINVAL, MAP_FAILED,
+             (p = mmap(NULL, 0x00010000, PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS,
+                       fd, 0)));
   close(fd);
 }
 
@@ -234,7 +236,8 @@ TEST(mmap, ziposCannotBeShared) {
   int fd;
   void *p;
   ASSERT_NE(-1, (fd = open(ziposLifePath, O_RDONLY), "%s", ziposLifePath));
-  EXPECT_SYS(EACCES, MAP_FAILED, (p = mmap(NULL, 0x00010000, PROT_READ, MAP_SHARED, fd, 0)));
+  EXPECT_SYS(EACCES, MAP_FAILED,
+             (p = mmap(NULL, 0x00010000, PROT_READ, MAP_SHARED, fd, 0)));
   close(fd);
 }
 
@@ -245,8 +248,9 @@ TEST(mmap, ziposCow) {
   int fd;
   void *p;
   ASSERT_NE(-1, (fd = open(ziposLifePath, O_RDONLY), "%s", ziposLifePath));
-  EXPECT_NE(MAP_FAILED, (p = mmap(NULL, 0x00010000, PROT_READ, MAP_PRIVATE, fd, 0)));
-  EXPECT_STREQN("ELF", ((const char *)p)+1, 3);
+  EXPECT_NE(MAP_FAILED,
+            (p = mmap(NULL, 0x00010000, PROT_READ, MAP_PRIVATE, fd, 0)));
+  EXPECT_STREQN("ELF", ((const char *)p) + 1, 3);
   EXPECT_NE(-1, munmap(p, 0x00010000));
   EXPECT_NE(-1, close(fd));
 }
@@ -259,14 +263,14 @@ TEST(mmap, ziposCowFileMapReadonlyFork) {
   void *p;
   ASSERT_NE(-1, (fd = open(ziposLifePath, O_RDONLY), "%s", ziposLifePath));
   EXPECT_NE(MAP_FAILED, (p = mmap(NULL, 4, PROT_READ, MAP_PRIVATE, fd, 0)));
-  EXPECT_STREQN("ELF", ((const char *)p)+1, 3);
+  EXPECT_STREQN("ELF", ((const char *)p) + 1, 3);
   ASSERT_NE(-1, (ws = xspawn(0)));
   if (ws == -2) {
-    ASSERT_STREQN("ELF", ((const char *)p)+1, 3);
+    ASSERT_STREQN("ELF", ((const char *)p) + 1, 3);
     _exit(0);
   }
   EXPECT_EQ(0, ws);
-  EXPECT_STREQN("ELF", ((const char *)p)+1, 3);
+  EXPECT_STREQN("ELF", ((const char *)p) + 1, 3);
   EXPECT_NE(-1, munmap(p, 6));
   EXPECT_NE(-1, close(fd));
 }
@@ -279,7 +283,8 @@ TEST(mmap, ziposCowFileMapFork) {
   void *p;
   char lol[4];
   ASSERT_NE(-1, (fd = open(ziposLifePath, O_RDONLY), "%s", ziposLifePath));
-  EXPECT_NE(MAP_FAILED, (p = mmap(NULL, 6, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0)));
+  EXPECT_NE(MAP_FAILED,
+            (p = mmap(NULL, 6, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0)));
   memcpy(p, "parnt", 6);
   ASSERT_NE(-1, (ws = xspawn(0)));
   if (ws == -2) {
@@ -308,8 +313,7 @@ TEST(mmap, cow) {
             path);
   EXPECT_EQ(5, write(fd, "hello", 5));
   EXPECT_NE(-1, fdatasync(fd));
-  EXPECT_NE(MAP_FAILED,
-            (p = mmap(NULL, 5, PROT_READ, MAP_PRIVATE, fd, 0)));
+  EXPECT_NE(MAP_FAILED, (p = mmap(NULL, 5, PROT_READ, MAP_PRIVATE, fd, 0)));
   EXPECT_STREQN("hello", p, 5);
   EXPECT_NE(-1, munmap(p, 5));
   EXPECT_NE(-1, close(fd));

--- a/test/libc/runtime/mmap_test.c
+++ b/test/libc/runtime/mmap_test.c
@@ -236,7 +236,7 @@ TEST(mmap, ziposCannotBeShared) {
   int fd;
   void *p;
   ASSERT_NE(-1, (fd = open(ziposLifePath, O_RDONLY), "%s", ziposLifePath));
-  EXPECT_SYS(EACCES, MAP_FAILED,
+  EXPECT_SYS(EINVAL, MAP_FAILED,
              (p = mmap(NULL, 0x00010000, PROT_READ, MAP_SHARED, fd, 0)));
   close(fd);
 }

--- a/test/libc/runtime/mmap_test.c
+++ b/test/libc/runtime/mmap_test.c
@@ -309,7 +309,7 @@ TEST(mmap, cow) {
   EXPECT_EQ(5, write(fd, "hello", 5));
   EXPECT_NE(-1, fdatasync(fd));
   EXPECT_NE(MAP_FAILED,
-            (p = mmap(NULL, 5, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0)));
+            (p = mmap(NULL, 5, PROT_READ, MAP_PRIVATE, fd, 0)));
   EXPECT_STREQN("hello", p, 5);
   EXPECT_NE(-1, munmap(p, 5));
   EXPECT_NE(-1, close(fd));
@@ -335,6 +335,7 @@ TEST(mmap, cowFileMapReadonlyFork) {
     ASSERT_STREQN("hello", p, 5);
     _exit(0);
   }
+  EXPECT_EQ(0, ws);
   EXPECT_STREQN("hello", p, 5);
   EXPECT_NE(-1, munmap(p, 6));
   EXPECT_NE(-1, close(fd));
@@ -362,6 +363,7 @@ TEST(mmap, cowFileMapFork) {
     ASSERT_STREQN("child", p, 5);
     _exit(0);
   }
+  EXPECT_EQ(0, ws);
   EXPECT_STREQN("parnt", p, 5);  // child changing memory did not change parent
   EXPECT_EQ(6, pread(fd, lol, 6, 0));
   EXPECT_STREQN("parnt", lol, 5);  // changing memory did not change file
@@ -387,6 +389,7 @@ TEST(mmap, sharedAnonMapFork) {
     ASSERT_STREQN("child", p, 5);
     _exit(0);
   }
+  EXPECT_EQ(0, ws);
   EXPECT_STREQN("child", p, 5);  // boom
   EXPECT_NE(-1, munmap(p, 5));
 }
@@ -413,6 +416,7 @@ TEST(mmap, sharedFileMapFork) {
     ASSERT_NE(-1, msync(p, 6, MS_SYNC | MS_INVALIDATE));
     _exit(0);
   }
+  EXPECT_EQ(0, ws);
   EXPECT_STREQN("child", p, 5);  // child changing memory changed parent memory
   // XXX: RHEL5 has a weird issue where if we read the file into its own
   //      shared memory then corruption occurs!

--- a/test/libc/runtime/mmap_test.c
+++ b/test/libc/runtime/mmap_test.c
@@ -46,6 +46,8 @@
 #include "libc/x/xspawn.h"
 #include "third_party/xed/x86.h"
 
+STATIC_YOINK("zip_uri_support");
+
 char testlib_enable_tmp_setup_teardown;
 
 void SetUpOnce(void) {
@@ -217,6 +219,17 @@ TEST(isheap, emptyMalloc) {
 TEST(isheap, mallocOffset) {
   char *p = _gc(malloc(131072));
   ASSERT_TRUE(_isheap(p + 100000));
+}
+
+TEST(mmap, ziposMapFiles) {
+  int fd;
+  const char *lifepath = "/zip/life.elf";
+  void *p;
+
+  ASSERT_NE(-1, (fd = open(lifepath, O_RDONLY), "%s", lifepath));
+  ASSERT_NE(NULL, (p = mmap(NULL, 0x00010000, PROT_READ, MAP_SHARED, fd, 0)));
+  EXPECT_STREQN("ELF", ((const char *)p)+1, 3);
+  close(fd);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/libc/runtime/test.mk
+++ b/test/libc/runtime/test.mk
@@ -51,6 +51,7 @@ o/$(MODE)/test/libc/runtime/runtime.pkg:			\
 
 o/$(MODE)/test/libc/runtime/%.com.dbg:				\
 		$(TEST_LIBC_RUNTIME_DEPS)			\
+		o/$(MODE)/test/libc/mem/prog/life.elf.zip.o			\
 		o/$(MODE)/test/libc/runtime/%.o			\
 		o/$(MODE)/test/libc/runtime/runtime.pkg		\
 		$(LIBC_TESTMAIN)				\


### PR DESCRIPTION
- Implemented via creating `MAP_ANONYMOUS` map and copying.
- `MAP_SHARED` disallowed for simplicity and because zipos files are read only
- Discovered some `mmap` tests didn't fail when the child process failed, added checks.

