### PR TITLE
zipos fexecve

### DIFF
--- a/libc/calls/execve-sysv.c
+++ b/libc/calls/execve-sysv.c
@@ -85,6 +85,13 @@ int sys_execve(const char *prog, char *const argv[], char *const envp[]) {
       newprog = alloca(PATH_MAX);
       fd = _weaken(__zipos_uri_to_mem_file)(&uri, newprog);
       prog = newprog;
+      if ((fd != -1) && IsApeBinary(prog)) {
+        flags = fcntl(fd, F_GETFD);
+        if (flags != -1) {
+          fcntl(fd, F_SETFD, flags & (~FD_CLOEXEC));
+          flags = fcntl(fd, F_GETFD);
+        }
+      }
     } else if (IsFreebsd()) {
       if ((fd = _weaken(__zipos_uri_to_mem_file)(&uri, NULL)) != -1) {
         return sys_fexecve(fd, argv, envp);
@@ -104,13 +111,6 @@ int sys_execve(const char *prog, char *const argv[], char *const envp[]) {
     for (i = 0; argv[i];) ++i;
     buf = alloca(PATH_MAX);
     shargs = alloca((i + 4) * sizeof(char *));
-    if (fd != -1) {
-      flags = fcntl(fd, F_GETFD);
-      if (flags != -1) {
-        fcntl(fd, F_SETFD, flags & (~FD_CLOEXEC));
-        flags = fcntl(fd, F_GETFD);
-      }
-    }
     if (IsApeBinary(prog) &&
         (CanExecute((ape = "/usr/bin/ape")) ||
          CanExecute((ape = Join(firstnonnull(getenv("TMPDIR"),

--- a/libc/calls/execve-sysv.c
+++ b/libc/calls/execve-sysv.c
@@ -25,7 +25,6 @@
 #include "libc/errno.h"
 #include "libc/intrin/bits.h"
 #include "libc/intrin/safemacros.internal.h"
-#include "libc/intrin/weaken.h"
 #include "libc/mem/alloca.h"
 #include "libc/paths.h"
 #include "libc/runtime/runtime.h"
@@ -34,7 +33,6 @@
 #include "libc/sysv/consts/o.h"
 #include "libc/sysv/consts/ok.h"
 #include "libc/sysv/errfuns.h"
-#include "libc/zipos/zipos.internal.h"
 
 static bool CanExecute(const char *path) {
   return !sys_faccessat(AT_FDCWD, path, X_OK, 0);
@@ -77,19 +75,6 @@ int sys_execve(const char *prog, char *const argv[], char *const envp[]) {
   char *buf;
   char **shargs;
   const char *ape;
-  struct ZiposUri uri;
-  if (_weaken(__zipos_parseuri) &&
-      (_weaken(__zipos_parseuri)(prog, &uri) != -1)) {
-    rc = _weaken(__zipos_open)(&uri, O_RDONLY | O_CLOEXEC, 0);
-    if (rc != -1) {
-      const int zipFD = rc;
-      strace_enabled(-1);
-      rc = fexecve(zipFD, argv, envp);
-      close(zipFD);
-      strace_enabled(+1);
-    }
-    return rc;
-  }
   e = errno;
   __sys_execve(prog, argv, envp);
   if (errno == ENOEXEC) {

--- a/libc/calls/execve-sysv.c
+++ b/libc/calls/execve-sysv.c
@@ -79,7 +79,7 @@ int sys_execve(const char *prog, char *const argv[], char *const envp[]) {
   const char *ape;
   struct ZiposUri uri;
   if (_weaken(__zipos_parseuri) && (_weaken(__zipos_parseuri)(prog, &uri) != -1)) {
-    rc = _weaken(__zipos_open)(&uri, O_RDONLY, 0);
+    rc = _weaken(__zipos_open)(&uri, O_RDONLY | O_CLOEXEC, 0);
     if (rc != -1) {
       const int zipFD = rc;
       strace_enabled(-1);

--- a/libc/calls/execve-sysv.c
+++ b/libc/calls/execve-sysv.c
@@ -25,14 +25,18 @@
 #include "libc/errno.h"
 #include "libc/intrin/bits.h"
 #include "libc/intrin/safemacros.internal.h"
+#include "libc/intrin/weaken.h"
 #include "libc/mem/alloca.h"
 #include "libc/paths.h"
 #include "libc/runtime/runtime.h"
 #include "libc/str/str.h"
 #include "libc/sysv/consts/at.h"
+#include "libc/sysv/consts/f.h"
+#include "libc/sysv/consts/fd.h"
 #include "libc/sysv/consts/o.h"
 #include "libc/sysv/consts/ok.h"
 #include "libc/sysv/errfuns.h"
+#include "libc/zipos/zipos.internal.h"
 
 static bool CanExecute(const char *path) {
   return !sys_faccessat(AT_FDCWD, path, X_OK, 0);
@@ -71,16 +75,42 @@ static const char *Join(const char *a, const char *b, char buf[PATH_MAX]) {
 
 int sys_execve(const char *prog, char *const argv[], char *const envp[]) {
   size_t i;
-  int e, rc;
-  char *buf;
+  int e, rc, fd, flags;
+  char *buf, *newprog;
   char **shargs;
   const char *ape;
+  struct ZiposUri uri;
+  if (_weaken(__zipos_parseuri)(prog, &uri) != -1) {
+    if (IsLinux()) {
+      newprog = alloca(PATH_MAX);
+      fd = _weaken(__zipos_uri_to_mem_file)(&uri, newprog);
+      prog = newprog;
+    } else if (IsFreebsd()) {
+      if ((fd = _weaken(__zipos_uri_to_mem_file)(&uri, NULL)) != -1) {
+        return sys_fexecve(fd, argv, envp);
+      }
+    } else {
+      return enosys();
+    }
+    if (fd == -1) {
+      return -1;
+    }
+  } else {
+    fd = -1;
+  }
   e = errno;
   __sys_execve(prog, argv, envp);
   if (errno == ENOEXEC) {
     for (i = 0; argv[i];) ++i;
     buf = alloca(PATH_MAX);
     shargs = alloca((i + 4) * sizeof(char *));
+    if (fd != -1) {
+      flags = fcntl(fd, F_GETFD);
+      if (flags != -1) {
+        fcntl(fd, F_SETFD, flags & (~FD_CLOEXEC));
+        flags = fcntl(fd, F_GETFD);
+      }
+    }
     if (IsApeBinary(prog) &&
         (CanExecute((ape = "/usr/bin/ape")) ||
          CanExecute((ape = Join(firstnonnull(getenv("TMPDIR"),

--- a/libc/calls/execve-sysv.c
+++ b/libc/calls/execve-sysv.c
@@ -31,8 +31,6 @@
 #include "libc/runtime/runtime.h"
 #include "libc/str/str.h"
 #include "libc/sysv/consts/at.h"
-#include "libc/sysv/consts/f.h"
-#include "libc/sysv/consts/fd.h"
 #include "libc/sysv/consts/o.h"
 #include "libc/sysv/consts/ok.h"
 #include "libc/sysv/errfuns.h"

--- a/libc/calls/execve-sysv.c
+++ b/libc/calls/execve-sysv.c
@@ -78,7 +78,8 @@ int sys_execve(const char *prog, char *const argv[], char *const envp[]) {
   char **shargs;
   const char *ape;
   struct ZiposUri uri;
-  if (_weaken(__zipos_parseuri) && (_weaken(__zipos_parseuri)(prog, &uri) != -1)) {
+  if (_weaken(__zipos_parseuri) &&
+      (_weaken(__zipos_parseuri)(prog, &uri) != -1)) {
     rc = _weaken(__zipos_open)(&uri, O_RDONLY | O_CLOEXEC, 0);
     if (rc != -1) {
       const int zipFD = rc;

--- a/libc/calls/execve-sysv.c
+++ b/libc/calls/execve-sysv.c
@@ -75,28 +75,21 @@ static const char *Join(const char *a, const char *b, char buf[PATH_MAX]) {
 
 int sys_execve(const char *prog, char *const argv[], char *const envp[]) {
   size_t i;
-  int e, rc, fd, flags;
-  char *buf, *newprog;
+  int e, rc;
+  char *buf;
   char **shargs;
   const char *ape;
   struct ZiposUri uri;
-  if (_weaken(__zipos_parseuri)(prog, &uri) != -1) {
-    if (IsLinux()) {
-      newprog = alloca(PATH_MAX);
-      fd = _weaken(__zipos_uri_to_mem_file)(&uri, newprog);
-      prog = newprog;
-    } else if (IsFreebsd()) {
-      if ((fd = _weaken(__zipos_uri_to_mem_file)(&uri, NULL)) != -1) {
-        return sys_fexecve(fd, argv, envp);
-      }
-    } else {
-      return enosys();
+  if (_weaken(__zipos_parseuri) && (_weaken(__zipos_parseuri)(prog, &uri) != -1)) {
+    rc = _weaken(__zipos_open)(&uri, O_RDONLY, 0);
+    if (rc != -1) {
+      const int zipFD = rc;
+      strace_enabled(-1);
+      rc = fexecve(zipFD, argv, envp);
+      close(zipFD);
+      strace_enabled(+1);
     }
-    if (fd == -1) {
-      return -1;
-    }
-  } else {
-    fd = -1;
+    return rc;
   }
   e = errno;
   __sys_execve(prog, argv, envp);

--- a/libc/calls/execve-sysv.c
+++ b/libc/calls/execve-sysv.c
@@ -85,13 +85,6 @@ int sys_execve(const char *prog, char *const argv[], char *const envp[]) {
       newprog = alloca(PATH_MAX);
       fd = _weaken(__zipos_uri_to_mem_file)(&uri, newprog);
       prog = newprog;
-      if ((fd != -1) && IsApeBinary(prog)) {
-        flags = fcntl(fd, F_GETFD);
-        if (flags != -1) {
-          fcntl(fd, F_SETFD, flags & (~FD_CLOEXEC));
-          flags = fcntl(fd, F_GETFD);
-        }
-      }
     } else if (IsFreebsd()) {
       if ((fd = _weaken(__zipos_uri_to_mem_file)(&uri, NULL)) != -1) {
         return sys_fexecve(fd, argv, envp);

--- a/libc/calls/fexecve.c
+++ b/libc/calls/fexecve.c
@@ -183,16 +183,17 @@ int fexecve(int fd, char *const argv[], char *const envp[]) {
     STRACE("fexecve(%d, %s, %s) → ...", fd, DescribeStringList(argv),
            DescribeStringList(envp));
     do {
-      if(!IsLinux() && !IsFreebsd()) {
-          rc = enosys();
-          break;
+      if (!IsLinux() && !IsFreebsd()) {
+        rc = enosys();
+        break;
       }
-      if(!__isfdkind(fd, kFdZip)) {
+      if (!__isfdkind(fd, kFdZip)) {
         bool memfdReq;
         BEGIN_CANCELLATION_POINT;
         BLOCK_SIGNALS;
         strace_enabled(-1);
-        memfdReq = ((rc = fcntl(fd, F_GETFD)) != -1) && (rc & FD_CLOEXEC) && IsAPEFd(fd);
+        memfdReq = ((rc = fcntl(fd, F_GETFD)) != -1) && (rc & FD_CLOEXEC) &&
+                   IsAPEFd(fd);
         strace_enabled(+1);
         ALLOW_SIGNALS;
         END_CANCELLATION_POINT;

--- a/test/libc/calls/execve_test.c
+++ b/test/libc/calls/execve_test.c
@@ -17,6 +17,8 @@
 │ PERFORMANCE OF THIS SOFTWARE.                                                │
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #include "libc/calls/calls.h"
+#include "libc/dce.h"
+#include "libc/errno.h"
 #include "libc/fmt/conv.h"
 #include "libc/fmt/itoa.h"
 #include "libc/runtime/runtime.h"
@@ -57,4 +59,28 @@ TEST(execve, testArgPassing) {
     notpossible;
     EXITS(0);
   }
+}
+
+TEST(execve, ziposELF) {
+  if (!IsLinux() && !IsFreebsd()) {
+    EXPECT_SYS(ENOSYS, -1,
+               execve("/zip/life.elf", (char *const[]){0}, (char *const[]){0}));
+    return;
+  }
+  SPAWN(fork);
+  execve("/zip/life.elf", (char *const[]){0}, (char *const[]){0});
+  notpossible;
+  EXITS(42);
+}
+
+TEST(execve, ziposAPE) {
+  if (!IsLinux()) {
+    EXPECT_EQ(-1, execve("/zip/life-nomod.com", (char *const[]){0},
+                         (char *const[]){0}));
+    return;
+  }
+  SPAWN(fork);
+  execve("/zip/life-nomod.com", (char *const[]){0}, (char *const[]){0});
+  notpossible;
+  EXITS(42);
 }

--- a/test/libc/calls/execve_test.c
+++ b/test/libc/calls/execve_test.c
@@ -72,15 +72,3 @@ TEST(execve, ziposELF) {
   notpossible;
   EXITS(42);
 }
-
-TEST(execve, ziposAPE) {
-  if (!IsLinux()) {
-    EXPECT_EQ(-1, execve("/zip/life-nomod.com", (char *const[]){0},
-                         (char *const[]){0}));
-    return;
-  }
-  SPAWN(fork);
-  execve("/zip/life-nomod.com", (char *const[]){0}, (char *const[]){0});
-  notpossible;
-  EXITS(42);
-}

--- a/test/libc/calls/execve_test.c
+++ b/test/libc/calls/execve_test.c
@@ -72,3 +72,15 @@ TEST(execve, ziposELF) {
   notpossible;
   EXITS(42);
 }
+
+TEST(execve, ziposAPE) {
+  if (!IsLinux()) {
+    EXPECT_EQ(-1, execve("/zip/life-nomod.com", (char *const[]){0},
+                         (char *const[]){0}));
+    return;
+  }
+  SPAWN(fork);
+  execve("/zip/life-nomod.com", (char *const[]){0}, (char *const[]){0});
+  notpossible;
+  EXITS(42);
+}

--- a/test/libc/calls/fexecve_test.c
+++ b/test/libc/calls/fexecve_test.c
@@ -107,4 +107,16 @@ TEST(fexecve, zipos) {
   if (fd == -1 && errno == ENOSYS) _Exit(42);
   fexecve(fd, (char *const[]){0}, (char *const[]){0});
   EXITS(42);
+  close(fd);
+}
+
+TEST(fexecve, ziposAPE) {
+  if (!IsLinux() && !IsFreebsd()) return;
+  int fd = open("/zip/life-nomod.com", O_RDONLY);
+  SPAWN(fork);
+  ASSERT_NE(-1, fd);
+  if (fd == -1 && errno == ENOSYS) _Exit(42);
+  fexecve(fd, (char *const[]){0}, (char *const[]){0});
+  EXITS(42);
+  close(fd);
 }

--- a/test/libc/calls/fexecve_test.c
+++ b/test/libc/calls/fexecve_test.c
@@ -100,6 +100,17 @@ TEST(fexecve, APE) {
   EXITS(42);
 }
 
+TEST(fexecve, APE_cloexec) {
+  if (!IsLinux() && !IsFreebsd()) return;
+  testlib_extract("/zip/life-nomod.com", "life-nomod.com", 0555);
+  SPAWN(fork);
+  int fd = open("life-nomod.com", O_RDONLY | O_CLOEXEC);
+  ASSERT_NE(-1, fd);
+  if (fd == -1 && errno == ENOSYS) _Exit(42);
+  fexecve(fd, (char *const[]){0}, (char *const[]){0});
+  EXITS(42);
+}
+
 TEST(fexecve, zipos) {
   if (!IsLinux() && !IsFreebsd()) return;
   int fd = open("/zip/life.elf", O_RDONLY);

--- a/test/libc/calls/fexecve_test.c
+++ b/test/libc/calls/fexecve_test.c
@@ -101,7 +101,7 @@ TEST(fexecve, APE) {
 }
 
 TEST(fexecve, zipos) {
-  if (!IsLinux()) return;
+  if (!IsLinux() && !IsFreebsd()) return;
   int fd = open("/zip/life.elf", O_RDONLY);
   SPAWN(vfork);
   if (fd == -1 && errno == ENOSYS) _Exit(42);

--- a/test/libc/calls/fexecve_test.c
+++ b/test/libc/calls/fexecve_test.c
@@ -27,6 +27,8 @@
 #include "libc/testlib/testlib.h"
 // clang-format off
 
+STATIC_YOINK("zip_uri_support");
+
 int fds[2];
 char buf[8];
 char testlib_enable_tmp_setup_teardown;
@@ -93,6 +95,15 @@ TEST(fexecve, APE) {
   SPAWN(fork);
   int fd = open("life-nomod.com", O_RDONLY);
   ASSERT_NE(-1, fd);
+  if (fd == -1 && errno == ENOSYS) _Exit(42);
+  fexecve(fd, (char *const[]){0}, (char *const[]){0});
+  EXITS(42);
+}
+
+TEST(fexecve, zipos) {
+  if (!IsLinux()) return;
+  int fd = open("/zip/life.elf", O_RDONLY);
+  SPAWN(vfork);
   if (fd == -1 && errno == ENOSYS) _Exit(42);
   fexecve(fd, (char *const[]){0}, (char *const[]){0});
   EXITS(42);

--- a/test/libc/calls/fexecve_test.c
+++ b/test/libc/calls/fexecve_test.c
@@ -103,7 +103,7 @@ TEST(fexecve, APE) {
 TEST(fexecve, zipos) {
   if (!IsLinux() && !IsFreebsd()) return;
   int fd = open("/zip/life.elf", O_RDONLY);
-  SPAWN(vfork);
+  SPAWN(fork);
   if (fd == -1 && errno == ENOSYS) _Exit(42);
   fexecve(fd, (char *const[]){0}, (char *const[]){0});
   EXITS(42);

--- a/test/libc/calls/test.mk
+++ b/test/libc/calls/test.mk
@@ -92,6 +92,7 @@ o/$(MODE)/test/libc/calls/fexecve_test.com.dbg:				\
 		$(TEST_LIBC_CALLS_DEPS)					\
 		o/$(MODE)/test/libc/calls/fexecve_test.o		\
 		o/$(MODE)/test/libc/calls/calls.pkg			\
+		o/$(MODE)/test/libc/mem/prog/life.elf.zip.o			\
 		o/$(MODE)/tool/build/echo.zip.o				\
 		o/$(MODE)/test/libc/calls/life-nomod.com.zip.o		\
 		$(LIBC_TESTMAIN)					\

--- a/test/libc/calls/test.mk
+++ b/test/libc/calls/test.mk
@@ -92,7 +92,7 @@ o/$(MODE)/test/libc/calls/fexecve_test.com.dbg:				\
 		$(TEST_LIBC_CALLS_DEPS)					\
 		o/$(MODE)/test/libc/calls/fexecve_test.o		\
 		o/$(MODE)/test/libc/calls/calls.pkg			\
-		o/$(MODE)/test/libc/mem/prog/life.elf.zip.o			\
+		o/$(MODE)/test/libc/mem/prog/life.elf.zip.o		\
 		o/$(MODE)/tool/build/echo.zip.o				\
 		o/$(MODE)/test/libc/calls/life-nomod.com.zip.o		\
 		$(LIBC_TESTMAIN)					\


### PR DESCRIPTION
Maps zipos to a real file descriptor for `fexecve`. You can now run ELF binaries embedded in `/zip`.

Supports Linux via `memfd_create`. FreeBSD via `shm_open(SHM_ANON` (available since FreeBSD 8.0), not tested.   (all `fexecve` platforms) 

Adding support for more sysv systems to the mapping function `__zipos_to_fd` is possible via various `shm_`. 