### PR TITLE
zipos mmap - run entirely under __mmi_lock, hide implementation strace

### DIFF
--- a/libc/runtime/internal.h
+++ b/libc/runtime/internal.h
@@ -44,6 +44,9 @@ int GetDosEnviron(const char16_t *, char *, size_t, char **, size_t);
 bool __intercept_flag(int *, char *[], const char *);
 int sys_mprotect_nt(void *, size_t, int) _Hide;
 int __inflate(void *, size_t, const void *, size_t);
+noasan void *Mmap(void *addr, size_t size, int prot, int flags, int fd,
+                  int64_t off) _Hide;
+noasan int Munmap(char *, size_t) _Hide;
 
 COSMOPOLITAN_C_END_
 #endif /* !(__ASSEMBLER__ + __LINKER__ + 0) */

--- a/libc/runtime/munmap.c
+++ b/libc/runtime/munmap.c
@@ -40,8 +40,6 @@
 #define ADDR(x)    ((int64_t)((uint64_t)(x) << 32) >> 16)
 #define FRAME(x)   ((int)((intptr_t)(x) >> 16))
 
-static noasan int Munmap(char *, size_t);
-
 static noasan void MunmapShadow(char *p, size_t n) {
   intptr_t a, b, x, y;
   KERNTRACE("MunmapShadow(%p, %'zu)", p, n);
@@ -115,7 +113,7 @@ static noasan void MunmapImpl(char *p, size_t n) {
   }
 }
 
-static noasan int Munmap(char *p, size_t n) {
+noasan int Munmap(char *p, size_t n) {
   unsigned i;
   char poison;
   intptr_t a, b, x, y;

--- a/libc/zipos/zipos.S
+++ b/libc/zipos/zipos.S
@@ -34,7 +34,7 @@
 	.yoink	__zipos_read
 	.yoink	__zipos_stat
 	.yoink	__zipos_notat
-	.yoink	__zipos_mmap
+	.yoink	__zipos_Mmap
 
 //	TODO(jart): why does corruption happen when zip has no assets?
 	.yoink	.cosmo

--- a/libc/zipos/zipos.internal.h
+++ b/libc/zipos/zipos.internal.h
@@ -48,8 +48,8 @@ ssize_t __zipos_write(struct ZiposHandle *, const struct iovec *, size_t,
 int64_t __zipos_lseek(struct ZiposHandle *, int64_t, unsigned) _Hide;
 int __zipos_fcntl(int, int, uintptr_t) _Hide;
 int __zipos_notat(int, const char *) _Hide;
-void *__zipos_mmap(void *, uint64_t, int32_t, int32_t, struct ZiposHandle *,
-                   int64_t) _Hide;
+noasan void *__zipos_Mmap(void *, uint64_t, int32_t, int32_t,
+                          struct ZiposHandle *, int64_t) _Hide;
 
 #ifdef _NOPL0
 #define __zipos_lock()   _NOPL0("__threadcalls", __zipos_lock)


### PR DESCRIPTION
Makes the zipos mmap safer occurring entirely under the `__mmi_lock` just like `Mmap` and `Munmap` normally runs under.

Fixes zipos mmap showing implementation STRACEs, it now appears like normal mmap.