### PR TITLE
add * and ? operators to cocmd via musl glob

### DIFF
--- a/tool/build/cocmd.c
+++ b/tool/build/cocmd.c
@@ -18,6 +18,8 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #include "libc/runtime/runtime.h"
 
+STATIC_YOINK("glob");
+
 int main(int argc, char **argv, char **envp) {
   return _cocmd(argc, argv, envp);
 }


### PR DESCRIPTION
Tilda not added as the musl glob does not support `GLOB_TILDA`.

`globfree` is never called as all cocmd paths end in `execve` or `exit`.