### PR TITLE
memfd fexecve zipos support

### DIFF
--- a/libc/calls/fexecve.c
+++ b/libc/calls/fexecve.c
@@ -143,9 +143,11 @@ static int fd_to_mem_fd(const int infd, char *path) {
     bool success = readRc != -1;
     if (success && (st.st_size > 8) && IsAPEMagic(space)) {
       int flags = fcntl(fd, F_GETFD);
-      if(success = (flags != -1) && (fcntl(fd, F_SETFD, flags & (~FD_CLOEXEC)) != -1) && ape_to_elf(space, st.st_size)) {
+      if (success = (flags != -1) &&
+                    (fcntl(fd, F_SETFD, flags & (~FD_CLOEXEC)) != -1) &&
+                    ape_to_elf(space, st.st_size)) {
         const int newfd = fcntl(fd, F_DUPFD, 9001);
-        if(newfd != -1) {
+        if (newfd != -1) {
           close(fd);
           fd = newfd;
         }
@@ -153,7 +155,7 @@ static int fd_to_mem_fd(const int infd, char *path) {
     }
     const int e = errno;
     if ((_weaken(munmap)(space, st.st_size) != -1) && success) {
-      if(path) {
+      if (path) {
         FormatInt32(stpcpy(path, "COSMOPOLITAN_INIT_ZIPOS="), fd);
       }
       _unassert(readRc == st.st_size);
@@ -232,16 +234,12 @@ int fexecve(int fd, char *const argv[], char *const envp[]) {
       for (numenvs = 0; envp[numenvs];) ++numenvs;
       const size_t desenvs = min(500, max(numenvs + 1, 2));
       char *envs[500];
-      if (envs) {
-        memcpy(envs, envp, numenvs * sizeof(char *));
-        envs[numenvs] = path;
-        envs[numenvs+1] = NULL;
-        fexecve_impl(newfd, argv, envs);
-        if(!savedErr) {
-          savedErr = errno;
-        }
-      } else if(!savedErr) {
-        savedErr = ENOMEM;
+      memcpy(envs, envp, numenvs * sizeof(char *));
+      envs[numenvs] = path;
+      envs[numenvs + 1] = NULL;
+      fexecve_impl(newfd, argv, envs);
+      if (!savedErr) {
+        savedErr = errno;
       }
       BEGIN_CANCELLATION_POINT;
       BLOCK_SIGNALS;
@@ -251,7 +249,7 @@ int fexecve(int fd, char *const argv[], char *const envp[]) {
       ALLOW_SIGNALS;
       END_CANCELLATION_POINT;
     } while (0);
-    if(savedErr) {
+    if (savedErr) {
       errno = savedErr;
     }
     rc = -1;

--- a/libc/calls/fexecve.c
+++ b/libc/calls/fexecve.c
@@ -233,7 +233,7 @@ int fexecve(int fd, char *const argv[], char *const envp[]) {
       size_t numenvs;
       for (numenvs = 0; envp[numenvs];) ++numenvs;
       const size_t desenvs = min(500, max(numenvs + 1, 2));
-      char *envs[500];
+      static _Thread_local char *envs[500];
       memcpy(envs, envp, numenvs * sizeof(char *));
       envs[numenvs] = path;
       envs[numenvs + 1] = NULL;

--- a/libc/zipos/get.c
+++ b/libc/zipos/get.c
@@ -68,10 +68,9 @@ struct Zipos *__zipos_get(void) {
   const char *progpath;
   static struct Zipos zipos;
   uint8_t *map, *base, *cdir;
-  static const char fdProgName[] = "COSMOPOLITAN_INIT_ZIPOS=";
-  if(__argc && (strncmp(fdProgName, __argv[0], sizeof(fdProgName)-1) == 0)) {
-    fd = atoi(__argv[0]+sizeof(fdProgName)-1);
-    progpath = __argv[0];
+  progpath = getenv("COSMOPOLITAN_INIT_ZIPOS");
+  if(progpath) {
+    fd = atoi(progpath);
   }
   if (!once && ((fd != -1) || PLEDGED(RPATH))) {
     __zipos_lock();

--- a/libc/zipos/get.c
+++ b/libc/zipos/get.c
@@ -69,12 +69,12 @@ struct Zipos *__zipos_get(void) {
   static struct Zipos zipos;
   uint8_t *map, *base, *cdir;
   progpath = getenv("COSMOPOLITAN_INIT_ZIPOS");
-  if(progpath) {
+  if (progpath) {
     fd = atoi(progpath);
   }
   if (!once && ((fd != -1) || PLEDGED(RPATH))) {
     __zipos_lock();
-    if(fd == -1) {
+    if (fd == -1) {
       progpath = GetProgramExecutableName();
       fd = open(progpath, O_RDONLY);
     }

--- a/libc/zipos/get.c
+++ b/libc/zipos/get.c
@@ -18,6 +18,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #include "libc/calls/calls.h"
 #include "libc/calls/metalfile.internal.h"
+#include "libc/fmt/conv.h"
 #include "libc/intrin/cmpxchg.h"
 #include "libc/intrin/promises.internal.h"
 #include "libc/intrin/strace.internal.h"
@@ -59,7 +60,7 @@ static void __zipos_munmap_unneeded(const uint8_t *base, const uint8_t *cdir,
  * @threadsafe
  */
 struct Zipos *__zipos_get(void) {
-  int fd;
+  int fd = -1;
   ssize_t size;
   const char *msg;
   static bool once;
@@ -67,10 +68,18 @@ struct Zipos *__zipos_get(void) {
   const char *progpath;
   static struct Zipos zipos;
   uint8_t *map, *base, *cdir;
-  if (!once && PLEDGED(RPATH)) {
+  static const char fdProgName[] = "COSMOPOLITAN_INIT_ZIPOS=";
+  if(__argc && (strncmp(fdProgName, __argv[0], sizeof(fdProgName)-1) == 0)) {
+    fd = atoi(__argv[0]+sizeof(fdProgName)-1);
+    progpath = __argv[0];
+  }
+  if (!once && ((fd != -1) || PLEDGED(RPATH))) {
     __zipos_lock();
-    progpath = GetProgramExecutableName();
-    if ((fd = open(progpath, O_RDONLY)) != -1) {
+    if(fd == -1) {
+      progpath = GetProgramExecutableName();
+      fd = open(progpath, O_RDONLY);
+    }
+    if (fd != -1) {
       if ((size = getfiledescriptorsize(fd)) != -1ul &&
           (map = mmap(0, size, PROT_READ, MAP_SHARED, fd, 0)) != MAP_FAILED) {
         if ((base = FindEmbeddedApe(map, size))) {

--- a/test/libc/calls/fexecve_test.c
+++ b/test/libc/calls/fexecve_test.c
@@ -131,3 +131,14 @@ TEST(fexecve, ziposAPE) {
   EXITS(42);
   close(fd);
 }
+
+TEST(fexecve, ziposAPEHasZipos) {
+  if (!IsLinux() && !IsFreebsd()) return;
+  int fd = open("/zip/zipread.com", O_RDONLY);
+  SPAWN(fork);
+  ASSERT_NE(-1, fd);
+  if (fd == -1 && errno == ENOSYS) _Exit(42);
+  fexecve(fd, (char *const[]){0}, (char *const[]){0});
+  EXITS(42);
+  close(fd);
+}

--- a/test/libc/calls/test.mk
+++ b/test/libc/calls/test.mk
@@ -19,7 +19,8 @@ TEST_LIBC_CALLS_BINS =							\
 	$(TEST_LIBC_CALLS_COMS)						\
 	$(TEST_LIBC_CALLS_COMS:%=%.dbg)					\
 	o/$(MODE)/test/libc/calls/life-nomod.com			\
-	o/$(MODE)/test/libc/calls/life-classic.com
+	o/$(MODE)/test/libc/calls/life-classic.com			\
+	o/$(MODE)/test/libc/calls/zipread.com
 
 TEST_LIBC_CALLS_TESTS =							\
 	$(TEST_LIBC_CALLS_SRCS_TEST:%.c=o/$(MODE)/%.com.ok)
@@ -95,6 +96,7 @@ o/$(MODE)/test/libc/calls/fexecve_test.com.dbg:				\
 		o/$(MODE)/test/libc/mem/prog/life.elf.zip.o		\
 		o/$(MODE)/tool/build/echo.zip.o				\
 		o/$(MODE)/test/libc/calls/life-nomod.com.zip.o		\
+		o/$(MODE)/test/libc/calls/zipread.com.zip.o		\
 		$(LIBC_TESTMAIN)					\
 		$(CRT)							\
 		$(APE_NO_MODIFY_SELF)
@@ -102,7 +104,8 @@ o/$(MODE)/test/libc/calls/fexecve_test.com.dbg:				\
 
 o/$(MODE)/test/libc/calls/tiny64.elf.zip.o				\
 o/$(MODE)/test/libc/calls/life-nomod.com.zip.o				\
-o/$(MODE)/test/libc/calls/life-classic.com.zip.o: private		\
+o/$(MODE)/test/libc/calls/life-classic.com.zip.o			\
+o/$(MODE)/test/libc/calls/zipread.com.zip.o: private			\
 		ZIPOBJ_FLAGS +=						\
 			-B
 

--- a/test/libc/calls/zipread.c
+++ b/test/libc/calls/zipread.c
@@ -24,11 +24,14 @@ STATIC_YOINK("zip_uri_support");
 
 int main(int argc, char *argv[]) {
   int fd = open("/zip/life.elf", O_RDONLY);
-  if (fd != -1 ) {
+  if (fd != -1) {
     uint8_t buf[4] = {0};
     ssize_t readres = read(fd, buf, sizeof(buf));
     if (readres == sizeof(buf)) {
-      if(memcmp(buf, "\x7F""ELF", sizeof(buf)) == 0) {
+      if (memcmp(buf,
+                 "\x7F"
+                 "ELF",
+                 sizeof(buf)) == 0) {
         return 42;
       }
     }

--- a/test/libc/calls/zipread.c
+++ b/test/libc/calls/zipread.c
@@ -1,0 +1,38 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│vi: set net ft=c ts=2 sts=2 sw=2 fenc=utf-8                                :vi│
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ Copyright 2023 Gavin Arthur Hayes                                            │
+│                                                                              │
+│ Permission to use, copy, modify, and/or distribute this software for         │
+│ any purpose with or without fee is hereby granted, provided that the         │
+│ above copyright notice and this permission notice appear in all copies.      │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL                │
+│ WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED                │
+│ WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE             │
+│ AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL         │
+│ DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR        │
+│ PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER               │
+│ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR             │
+│ PERFORMANCE OF THIS SOFTWARE.                                                │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "libc/calls/calls.h"
+#include "libc/str/str.h"
+#include "libc/sysv/consts/o.h"
+
+STATIC_YOINK("zip_uri_support");
+
+int main(int argc, char *argv[]) {
+  int fd = open("/zip/life.elf", O_RDONLY);
+  if (fd != -1 ) {
+    uint8_t buf[4] = {0};
+    ssize_t readres = read(fd, buf, sizeof(buf));
+    if (readres == sizeof(buf)) {
+      if(memcmp(buf, "\x7F""ELF", sizeof(buf)) == 0) {
+        return 42;
+      }
+    }
+    close(fd);
+  }
+  return 1;
+}


### PR DESCRIPTION
Uses environment variable `COSMOPOLITAN_INIT_ZIPOS` to pass fd. If provided, `__zipos_get` uses that to initialize instead of looking up  `GetProgramExecutableName` and `open`ing. The advantage to using a memfd rather than an `shm_open` file for this, is that it will be automatically cleaned up without an `unlink` though for other operating systems an `unlink` will be required.

One thing to note is https://github.com/G4Vi/cosmopolitan/blob/7ae7d0f1b327df52f1d87fc8172af5fda462bc70/libc/calls/fexecve.c#L236
I'm not sure if it's reasonable to use that much stack? `cocmd` uses that much space for `envp` as a `static`.

