### PR TITLE
Fix underflow in GetZipCdir / fix posix_spawn_test.c

### DIFF
--- a/libc/str/getzipcdir.c
+++ b/libc/str/getzipcdir.c
@@ -55,11 +55,12 @@ void *GetZipCdir(const uint8_t *p, size_t n) {
         continue;
       }
     }
-    while (magic = READ32LE(p + i),
-           magic != kZipCdir64LocatorMagic && magic != kZipCdirHdrMagic &&
-           i + 0x10000 + 0x1000 >= n) --i;
-    if (magic == kZipCdir64LocatorMagic &&
-        i + kZipCdir64LocatorSize <= n &&
+    while (magic = READ32LE(p + i), magic != kZipCdir64LocatorMagic &&
+                                        magic != kZipCdirHdrMagic &&
+                                        i + 0x10000 + 0x1000 >= n && i > 0) {
+      --i;
+    }
+    if (magic == kZipCdir64LocatorMagic && i + kZipCdir64LocatorSize <= n &&
         IsZipCdir64(p, n, ZIP_LOCATE64_OFFSET(p + i))) {
       return p + ZIP_LOCATE64_OFFSET(p + i);
     } else if (magic == kZipCdirHdrMagic && IsZipCdir32(p, n, i)) {
@@ -73,6 +74,6 @@ void *GetZipCdir(const uint8_t *p, size_t n) {
       } while (j-- && i - j < 128);
       return p + i;
     }
-  } while (i-- + 0x10000 + 0x1000 >= n);
+  } while (i > 0 && i-- + 0x10000 + 0x1000 >= n);
   return 0;
 }

--- a/test/libc/stdio/posix_spawn_test.c
+++ b/test/libc/stdio/posix_spawn_test.c
@@ -51,7 +51,7 @@ __attribute__((__constructor__)) static void init(void) {
 TEST(posix_spawn, test) {
   int rc, ws, pid;
   char *prog = GetProgramExecutableName();
-  char *args[] = {program_invocation_name, NULL};
+  char *args[] = {prog, NULL};
   char *envs[] = {"THE_DOGE=42", NULL};
   EXPECT_EQ(0, posix_spawn(&pid, prog, NULL, NULL, args, envs));
   EXPECT_NE(-1, waitpid(pid, &ws, 0));


### PR DESCRIPTION
- Fix underflow in `GetZipCdir` when not found on small files, caused `SIGSEGV` (Fixes #754).
- posix_spawn_test.c: fix zipos not working when binfmt_misc APE is not setup. Previously `argv[0]` was set to `program_invocation_name` often causing `GetProgramExecutableName` being unable to find it (due to the current dir being changed) and deciding on `/usr/bin/ape`.

Edit: Decided to hold on changing the Actions script, some additional issues need to be investigated first.