### PR TITLE
Fix redbean SQLite to report results on failure to open db

### DIFF
--- a/tool/net/lsqlite3.c
+++ b/tool/net/lsqlite3.c
@@ -639,7 +639,7 @@ static void closevms(lua_State *L, sdb *db, int temp) {
 static int cleanupdb(lua_State *L, sdb *db) {
     sdb_func *func;
     sdb_func *func_next;
-    int top;
+    int top = lua_gettop(L);
     int result;
 
     if (!db->db) return SQLITE_MISUSE;
@@ -679,6 +679,8 @@ static int cleanupdb(lua_State *L, sdb *db) {
         func = func_next;
     }
     db->func = NULL;
+
+    lua_settop(L, top);
     return result;
 }
 


### PR DESCRIPTION
A small patch to fix the issue with not returning `nil` as the first parameter after a failure to open DB.