### PR TITLE
Fix `import asyncio`

### DIFF
--- a/third_party/python/Lib/asyncio/__init__.py
+++ b/third_party/python/Lib/asyncio/__init__.py
@@ -5,17 +5,8 @@ import sys
 # The selectors module is in the stdlib in Python 3.4 but not in 3.3.
 # Do this first, so the other submodules can use "from . import selectors".
 # Prefer asyncio/selectors.py over the stdlib one, as ours may be newer.
-try:
-    from . import selectors
-except ImportError:
-    import selectors  # Will also be exported.
+import selectors  # Will also be exported.
 
-if sys.platform == 'win32':
-    # Similar thing for _overlapped.
-    try:
-        from . import _overlapped
-    except ImportError:
-        import _overlapped  # Will also be exported.
 
 # This relies on each of the submodules having an __all__ variable.
 from .base_events import *
@@ -42,9 +33,5 @@ __all__ = (base_events.__all__ +
            tasks.__all__ +
            transports.__all__)
 
-if sys.platform == 'win32':  # pragma: no cover
-    from .windows_events import *
-    __all__ += windows_events.__all__
-else:
-    from .unix_events import *  # pragma: no cover
-    __all__ += unix_events.__all__
+from .unix_events import *  # pragma: no cover
+__all__ += unix_events.__all__

--- a/third_party/python/Lib/asyncio/events.py
+++ b/third_party/python/Lib/asyncio/events.py
@@ -659,7 +659,7 @@ def _init_event_loop_policy():
     global _event_loop_policy
     with _lock:
         if _event_loop_policy is None:  # pragma: no branch
-            from . import DefaultEventLoopPolicy
+            from .unix_events import DefaultEventLoopPolicy
             _event_loop_policy = DefaultEventLoopPolicy()
 
 

--- a/third_party/python/Lib/asyncio/selector_events.py
+++ b/third_party/python/Lib/asyncio/selector_events.py
@@ -22,7 +22,7 @@ from . import compat
 from . import constants
 from . import events
 from . import futures
-from . import selectors
+import selectors
 from . import transports
 from . import sslproto
 from .coroutines import coroutine

--- a/third_party/python/Lib/asyncio/unix_events.py
+++ b/third_party/python/Lib/asyncio/unix_events.py
@@ -19,7 +19,7 @@ from . import coroutines
 from . import events
 from . import futures
 from . import selector_events
-from . import selectors
+import selectors
 from . import transports
 from .coroutines import coroutine
 from .log import logger

--- a/third_party/python/python.c
+++ b/third_party/python/python.c
@@ -495,7 +495,7 @@ PYTHON_YOINK("smtplib");
 PYTHON_YOINK("nntplib");
 
 PYTHON_YOINK("asdl");
-#ifdef WITH_THREAD
+
 PYTHON_YOINK("_thread");
 PYTHON_YOINK("_thread.LockType");
 PYTHON_YOINK("_thread.RLock");
@@ -513,6 +513,11 @@ PYTHON_YOINK("_thread.interrupt_main");
 PYTHON_YOINK("_thread.stack_size");
 PYTHON_YOINK("_thread.start_new");
 PYTHON_YOINK("_thread.start_new_thread");
+PYTHON_YOINK("concurrent");
+PYTHON_YOINK("concurrent.futures");
+PYTHON_YOINK("concurrent.futures._base");
+PYTHON_YOINK("concurrent.futures.process");
+PYTHON_YOINK("concurrent.futures.thread");
 PYTHON_YOINK("asynchat");
 PYTHON_YOINK("asyncore");
 PYTHON_YOINK("asyncio");
@@ -535,12 +540,8 @@ PYTHON_YOINK("asyncio.sslproto");
 PYTHON_YOINK("asyncio.streams");
 PYTHON_YOINK("asyncio.subprocess");
 PYTHON_YOINK("asyncio.tasks");
-PYTHON_YOINK("asyncio.test_utils");
 PYTHON_YOINK("asyncio.transports");
 PYTHON_YOINK("asyncio.unix_events");
-PYTHON_YOINK("asyncio.windows_events");
-PYTHON_YOINK("asyncio.windows_utils");
-#endif
 
 int
 main(int argc, char **argv)

--- a/third_party/python/python.mk
+++ b/third_party/python/python.mk
@@ -724,6 +724,28 @@ THIRD_PARTY_PYTHON_STAGE2_A_PYS =						\
 	third_party/python/Lib/_sysconfigdata_m_cosmo_x86_64_cosmo.py		\
 	third_party/python/Lib/_threading_local.py				\
 	third_party/python/Lib/_weakrefset.py					\
+	third_party/python/Lib/asyncio/base_events.py	\
+	third_party/python/Lib/asyncio/base_futures.py	\
+	third_party/python/Lib/asyncio/base_subprocess.py	\
+	third_party/python/Lib/asyncio/base_tasks.py	\
+	third_party/python/Lib/asyncio/compat.py	\
+	third_party/python/Lib/asyncio/constants.py	\
+	third_party/python/Lib/asyncio/coroutines.py	\
+	third_party/python/Lib/asyncio/events.py	\
+	third_party/python/Lib/asyncio/futures.py	\
+	third_party/python/Lib/asyncio/__init__.py	\
+	third_party/python/Lib/asyncio/locks.py	\
+	third_party/python/Lib/asyncio/log.py	\
+	third_party/python/Lib/asyncio/proactor_events.py	\
+	third_party/python/Lib/asyncio/protocols.py	\
+	third_party/python/Lib/asyncio/queues.py	\
+	third_party/python/Lib/asyncio/selector_events.py	\
+	third_party/python/Lib/asyncio/sslproto.py	\
+	third_party/python/Lib/asyncio/streams.py	\
+	third_party/python/Lib/asyncio/subprocess.py	\
+	third_party/python/Lib/asyncio/tasks.py	\
+	third_party/python/Lib/asyncio/transports.py	\
+	third_party/python/Lib/asyncio/unix_events.py	\
 	third_party/python/Lib/abc.py						\
 	third_party/python/Lib/aifc.py						\
 	third_party/python/Lib/antigravity.py					\
@@ -759,6 +781,11 @@ THIRD_PARTY_PYTHON_STAGE2_A_PYS =						\
 	third_party/python/Lib/difflib.py					\
 	third_party/python/Lib/dis.py						\
 	third_party/python/Lib/dummy_threading.py				\
+	third_party/python/Lib/concurrent/__init__.py			\
+	third_party/python/Lib/concurrent/futures/__init__.py			\
+	third_party/python/Lib/concurrent/futures/process.py			\
+	third_party/python/Lib/concurrent/futures/thread.py			\
+	third_party/python/Lib/concurrent/futures/_base.py			\
 	third_party/python/Lib/email/__init__.py				\
 	third_party/python/Lib/email/_encoded_words.py				\
 	third_party/python/Lib/email/_header_value_parser.py			\


### PR DESCRIPTION
`asyncio` and `concurrent` were not building correctly due to their reliance on lazy imports for windows/unix code.

They were not giving errors because by default they are under a `#ifdef WITH_THREAD` block.

I removed the conditional on this PR but can change it to something more sensible if need be. Here are the places where it seems to be enabled by default:

```
third_party/python/Lib/_sysconfigdata_m_cosmo_x86_64_cosmo.py
800: 'WITH_THREAD': 1,
```
and
```
third_party/python/pyconfig.h
497:#ifndef WITH_THREAD
498:#define WITH_THREAD 1
```