### PR TITLE
clang-format: merge include blocks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,6 +8,7 @@ AlwaysBreakBeforeMultilineStrings: false
 AllowShortFunctionsOnASingleLine: false
 KeepEmptyLinesAtTheStartOfBlocks: true
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
+IncludeBlocks: Merge
 ---
 Language: Cpp
 AllowShortFunctionsOnASingleLine: false


### PR DESCRIPTION
When running clang-format on files: `clang-format -i -style=file test/libc/fmt/fmt_test.c` or when the file type is known to `clang-format`,  `IncludeBlocks: Regroup` was applied causing headers to be split up into blocks. This frustrating behavior was disabled by setting it to  `IncludeBlocks: Merge`.


https://clang.llvm.org/docs/ClangFormatStyleOptions.html#includeblocks 