### PR TITLE
Redbean: Support for unshare() mount() prctl() in Lua 

### DIFF
--- a/third_party/lua/lunix.c
+++ b/third_party/lua/lunix.c
@@ -82,6 +82,7 @@
 #include "libc/sysv/consts/limits.h"
 #include "libc/sysv/consts/log.h"
 #include "libc/sysv/consts/map.h"
+#include "libc/sysv/consts/mount.h"
 #include "libc/sysv/consts/msg.h"
 #include "libc/sysv/consts/nr.h"
 #include "libc/sysv/consts/o.h"
@@ -3605,6 +3606,52 @@ int LuaUnix(lua_State *L) {
   LuaSetIntField(L, "PLEDGE_PENALTY_KILL_PROCESS", PLEDGE_PENALTY_KILL_PROCESS);
   LuaSetIntField(L, "PLEDGE_PENALTY_RETURN_EPERM", PLEDGE_PENALTY_RETURN_EPERM);
   LuaSetIntField(L, "PLEDGE_STDERR_LOGGING", PLEDGE_STDERR_LOGGING);
+
+  // mount() / unmount() options
+  LuaSetIntField(L, "MS_RDONLY", MS_RDONLY);
+  LuaSetIntField(L, "MNT_RDONLY", MNT_RDONLY);
+  LuaSetIntField(L, "MS_NOSUID", MS_NOSUID);
+  LuaSetIntField(L, "MNT_NOSUID", MNT_NOSUID);
+  LuaSetIntField(L, "MS_NODEV", MS_NODEV);
+  LuaSetIntField(L, "MNT_NODEV", MNT_NODEV);
+  LuaSetIntField(L, "MS_NOEXEC", MS_NOEXEC);
+  LuaSetIntField(L, "MNT_NOEXEC", MNT_NOEXEC);
+  LuaSetIntField(L, "MS_SYNCHRONOUS", MS_SYNCHRONOUS);
+  LuaSetIntField(L, "MNT_SYNCHRONOUS", MNT_SYNCHRONOUS);
+  LuaSetIntField(L, "MS_REMOUNT", MS_REMOUNT);
+  LuaSetIntField(L, "MNT_UPDATE", MNT_UPDATE);
+  LuaSetIntField(L, "MS_MANDLOCK", MS_MANDLOCK);
+  LuaSetIntField(L, "MS_DIRSYNC", MS_DIRSYNC);
+  LuaSetIntField(L, "MS_NOATIME", MS_NOATIME);
+  LuaSetIntField(L, "MNT_NOATIME", MNT_NOATIME);
+  LuaSetIntField(L, "MS_NODIRATIME", MS_NODIRATIME);
+  LuaSetIntField(L, "MS_BIND", MS_BIND);
+  LuaSetIntField(L, "MS_MOVE", MS_MOVE);
+  LuaSetIntField(L, "MS_REC", MS_REC);
+  LuaSetIntField(L, "MS_SILENT", MS_SILENT);
+  LuaSetIntField(L, "MS_POSIXACL", MS_POSIXACL);
+  LuaSetIntField(L, "MS_UNBINDABLE", MS_UNBINDABLE);
+  LuaSetIntField(L, "MS_PRIVATE", MS_PRIVATE);
+  LuaSetIntField(L, "MS_SLAVE", MS_SLAVE);
+  LuaSetIntField(L, "MS_SHARED", MS_SHARED);
+  LuaSetIntField(L, "MS_RELATIME", MS_RELATIME);
+  LuaSetIntField(L, "MNT_RELATIME", MNT_RELATIME);
+  LuaSetIntField(L, "MS_KERNMOUNT", MS_KERNMOUNT);
+  LuaSetIntField(L, "MS_I_VERSION", MS_I_VERSION);
+  LuaSetIntField(L, "MS_STRICTATIME", MS_STRICTATIME);
+  LuaSetIntField(L, "MNT_STRICTATIME", MNT_STRICTATIME);
+  LuaSetIntField(L, "MS_LAZYTIME", MS_LAZYTIME);
+  LuaSetIntField(L, "MS_ACTIVE", MS_ACTIVE);
+  LuaSetIntField(L, "MS_NOUSER", MS_NOUSER);
+  LuaSetIntField(L, "MS_RMT_MASK", MS_RMT_MASK);
+  LuaSetIntField(L, "MS_MGC_VAL", MS_MGC_VAL);
+  LuaSetIntField(L, "MS_MGC_MSK", MS_MGC_MSK);
+  LuaSetIntField(L, "MNT_ASYNC", MNT_ASYNC);
+  LuaSetIntField(L, "MNT_RELOAD", MNT_RELOAD);
+  LuaSetIntField(L, "MNT_SUIDDIR", MNT_SUIDDIR);
+  LuaSetIntField(L, "MNT_NOCLUSTERR", MNT_NOCLUSTERR);
+  LuaSetIntField(L, "MNT_NOCLUSTERW", MNT_NOCLUSTERW);
+  LuaSetIntField(L, "MNT_SNAPSHOT", MNT_SNAPSHOT);
 
   // prctl() options
   LuaSetIntField(L, "PR_GET_SECCOMP", PR_GET_SECCOMP);

--- a/third_party/lua/lunix.c
+++ b/third_party/lua/lunix.c
@@ -22,6 +22,7 @@
 #include "libc/calls/cp.internal.h"
 #include "libc/calls/ioctl.h"
 #include "libc/calls/makedev.h"
+#include "libc/calls/mount.h"
 #include "libc/calls/pledge.h"
 #include "libc/calls/struct/bpf.h"
 #include "libc/calls/struct/dirent.h"
@@ -3196,6 +3197,28 @@ static int LuaUnixFdopendir(lua_State *L) {
   }
 }
 
+
+// unix.mount(source:str, target:str, filesystemtype: str[, mountflags: int[, data: str]])
+//     ├─→ true
+//     ├─→ nil, unix.Errno
+static int LuaUnixMount(lua_State *L) {
+  int olderr = errno;
+  return SysretBool(
+	L, "mount", olderr,
+	mount(luaL_checkstring(L, 1), luaL_checkstring(L, 2), luaL_checkstring(L, 3),
+	      luaL_optinteger(L, 4, 0), luaL_optstring(L, 5, NULL)));
+}
+
+// unix.umount(target: str[, flags: int)
+//     ├─→ true
+//     ├─→ nil, unix.Errorno
+static int LuaUnixUnmount(lua_State *L) {
+  int olderr = errno;
+  return SysretBool(
+	L, "unmount", olderr,
+	unmount(luaL_checkstring(L, 1), luaL_optinteger(L, 2, 0)));
+}
+
 static const luaL_Reg kLuaUnixDirMeth[] = {
     {"close", LuaUnixDirClose},    //
     {"read", LuaUnixDirRead},      //
@@ -3288,6 +3311,7 @@ static const luaL_Reg kLuaUnix[] = {
     {"mapshared", LuaUnixMapshared},      // mmap(MAP_SHARED) w/ mutex+atomics
     {"minor", LuaUnixMinor},              // extract device info
     {"mkdir", LuaUnixMkdir},              // make directory
+    {"mount", LuaUnixMount},		  // mount filesystem
     {"nanosleep", LuaUnixNanosleep},      // sleep w/ nano precision
     {"open", LuaUnixOpen},                // open file fd at lowest slot
     {"opendir", LuaUnixOpendir},          // read directory entry list
@@ -3337,6 +3361,7 @@ static const luaL_Reg kLuaUnix[] = {
     {"truncate", LuaUnixTruncate},        // shrink or extend file medium
     {"umask", LuaUnixUmask},              // set default file mask
     {"unlink", LuaUnixUnlink},            // remove file
+    {"unmount", LuaUnixUnmount},	  // unmount filesystem
     {"unveil", LuaUnixUnveil},            // filesystem sandboxing
     {"utimensat", LuaUnixUtimensat},      // change access/modified time
     {"wait", LuaUnixWait},                // wait for child to change status


### PR DESCRIPTION
These changes should extend Redbean's Lua's functionality to add additional unix syscalls per requested here #794.

I wasn't able to find any direct support for the ``unshare`` syscall in the Cosmopolitan C lib, so for now I am opening this pull request as incomplete without support for it. 
Few notes I have to leave for the maintainers:
* I made sure to add fields for the unix module for *all* flags and options for these syscalls, something that I perceived as something that pollutes the ``unix`` module so please let me know if there's any other way to implement it.
* Where can I add these syscalls to the documentation? And is there any need to add tests for them?
* I apologize in advance for any mistake whether it be a grave error or a styling mistake, this is my first PR for this project (and one the first for an open source project 💖)