### PR TITLE
unveil: Added truncate support on Linux 6.2+

### DIFF
--- a/libc/calls/landlock.h
+++ b/libc/calls/landlock.h
@@ -26,6 +26,15 @@
  */
 #define LANDLOCK_ACCESS_FS_REFER 0x2000ul
 
+/**
+ * Control file truncation.
+ *
+ * @see https://lore.kernel.org/all/20221018182216.301684-1-gnoack3000@gmail.com/
+ * @see https://docs.kernel.org/userspace-api/landlock.html
+ * @note ABI 3+
+ */
+#define LANDLOCK_ACCESS_FS_TRUNCATE 0x4000ul
+
 #if !(__ASSEMBLER__ + __LINKER__ + 0)
 COSMOPOLITAN_C_START_
 


### PR DESCRIPTION
(see also commit message for more details).

Note that I have only been able to test this on a kernel with Landlock ABI version 3 support - my testing of kernels without it has been limited to manually modifying `landlock_create_ruleset`'s return statement to `return (flags == LANDLOCK_CREATE_RULESET_VERSION) && rc > 2 ? 2 : rc;` to test that the backup codepaths for the old ABI work properly, but this doesn't ensure that they also work on old kernels.