### PR TITLE
Fix rgbtoxterm tool to output the proper colors

### DIFF
--- a/tool/viz/rgbtoxterm.c
+++ b/tool/viz/rgbtoxterm.c
@@ -107,7 +107,7 @@ void processarg(const char *arg) {
     return;
   }
   fprintf(fout_, "%s[%s%d;5;%hhum%s", rawmode_ ? "\e" : "\\e",
-          emphasis_ ? "1;" : "", background_ ? 48 : 38, rgb2tty(r, g, b),
+          emphasis_ ? "1;" : "", background_ ? 48 : 38, rgb2tty(r, g, b).xt,
           &"\n"[rawmode_]);
 }
 


### PR DESCRIPTION
I apologize for how random and minor this change is, but I was idly prodding through the executables from `make all` and noticed this tool wasn't working correctly. I'm guessing `rgb2tty` returned a byte in the past, but it presently returns a struct, so this printf has been pulling the value of the red channel instead of the xterm color code.