### PR TITLE
Extend Pledge with anet (same as inet, but with no connect)

### DIFF
--- a/libc/calls/pledge-linux.c
+++ b/libc/calls/pledge-linux.c
@@ -811,6 +811,22 @@ static const uint16_t kPledgeInet[] = {
     __NR_linux_getsockname,            //
 };
 
+// anet is similar to init, but without connect;
+// this allows to accept, but not initiate socket connections
+static const uint16_t kPledgeAnet[] = {
+    __NR_linux_socket | INET,          //
+    __NR_linux_listen,                 //
+    __NR_linux_bind,                   //
+    __NR_linux_sendto,                 //
+    __NR_linux_accept,                 //
+    __NR_linux_accept4,                //
+    __NR_linux_ioctl | INET,           //
+    __NR_linux_getsockopt | RESTRICT,  //
+    __NR_linux_setsockopt | RESTRICT,  //
+    __NR_linux_getpeername,            //
+    __NR_linux_getsockname,            //
+};
+
 static const uint16_t kPledgeUnix[] = {
     __NR_linux_socket | UNIX,          //
     __NR_linux_listen,                 //
@@ -955,6 +971,7 @@ const struct Pledges kPledge[PROMISE_LEN_] = {
     [PROMISE_FLOCK] = {"flock", PLEDGE(kPledgeFlock)},             //
     [PROMISE_FATTR] = {"fattr", PLEDGE(kPledgeFattr)},             //
     [PROMISE_INET] = {"inet", PLEDGE(kPledgeInet)},                //
+    [PROMISE_ANET] = {"anet", PLEDGE(kPledgeAnet)},                //
     [PROMISE_UNIX] = {"unix", PLEDGE(kPledgeUnix)},                //
     [PROMISE_DNS] = {"dns", PLEDGE(kPledgeDns)},                   //
     [PROMISE_TTY] = {"tty", PLEDGE(kPledgeTty)},                   //

--- a/libc/calls/pledge-linux.c
+++ b/libc/calls/pledge-linux.c
@@ -1279,14 +1279,15 @@ static privileged void OnSigSys(int sig, siginfo_t *si, void *vctx) {
   FixCpy(ord, si->si_syscall, 12);
   for (found = i = 0; i < ARRAYLEN(kPledge); ++i) {
     if (HasSyscall(kPledge + i, si->si_syscall)) {
-      Log("error: pledge ", kPledge[i].name, " for ",
-          GetSyscallName(si->si_syscall), " (ord=", ord, ")\n", NULL);
+      Log("error: protected syscall ", GetSyscallName(si->si_syscall),
+          " (ord=", ord, "); pledge promise '", kPledge[i].name, "' to allow\n",
+          NULL);
       found = true;
     }
   }
   if (!found) {
-    Log("error: bad syscall (", GetSyscallName(si->si_syscall), " ord=", ord,
-        ")\n", NULL);
+    Log("error: bad syscall ", GetSyscallName(si->si_syscall),
+        " (ord=", ord, ")\n", NULL);
   }
   switch (mode & PLEDGE_PENALTY_MASK) {
     case PLEDGE_PENALTY_KILL_PROCESS:

--- a/libc/calls/pledge.c
+++ b/libc/calls/pledge.c
@@ -143,6 +143,9 @@
  * - "inet" allows socket(AF_INET), listen, bind, connect, accept,
  *   accept4, getpeername, getsockname, setsockopt, getsockopt, sendto.
  *
+ * - "anet" allows socket(AF_INET), listen, bind, accept,
+ *   accept4, getpeername, getsockname, setsockopt, getsockopt, sendto.
+ *
  * - "unix" allows socket(AF_UNIX), listen, bind, connect, accept,
  *   accept4, getpeername, getsockname, setsockopt, getsockopt.
  *

--- a/libc/intrin/promises.internal.h
+++ b/libc/intrin/promises.internal.h
@@ -23,7 +23,8 @@
 #define PROMISE_VMINFO    19
 #define PROMISE_TMPPATH   20
 #define PROMISE_CHOWN     21
-#define PROMISE_LEN_      22
+#define PROMISE_ANET      22
+#define PROMISE_LEN_      23
 
 #define PLEDGED(x) ((~__promises >> PROMISE_##x) & 1)
 

--- a/test/libc/calls/pledge2_test.c
+++ b/test/libc/calls/pledge2_test.c
@@ -79,7 +79,7 @@ TEST(pledge, testLogMessage_inSoftyMode) {
   read(fds[0], msg, sizeof(msg));
   close(fds[0]);
   if (IsLinux()) {
-    ASSERT_STARTSWITH("error: pledge inet for socket", msg);
+    ASSERT_STARTSWITH("error: protected syscall socket", msg);
   }
 }
 
@@ -97,7 +97,7 @@ TEST(pledge, testLogMessage_onKillProcess) {
   read(fds[0], msg, sizeof(msg));
   close(fds[0]);
   if (IsLinux()) {
-    ASSERT_STARTSWITH("error: pledge inet for socket", msg);
+    ASSERT_STARTSWITH("error: protected syscall socket", msg);
   }
 }
 

--- a/test/libc/calls/pledge_test.c
+++ b/test/libc/calls/pledge_test.c
@@ -615,7 +615,7 @@ TEST(pledge, everything) {
     // contains 591 bpf instructions [2022-07-24]
     ASSERT_SYS(0, 0,
                pledge("stdio rpath wpath cpath dpath "
-                      "flock fattr inet unix dns tty "
+                      "flock fattr inet anet unix dns tty "
                       "recvfd sendfd proc exec id "
                       "unveil settime prot_exec "
                       "vminfo tmppath",

--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -4347,6 +4347,11 @@ UNIX MODULE
       Allows socket (AF_INET), listen, bind, connect, accept,
       getpeername, getsockname, setsockopt, getsockopt.
 
+    anet
+
+      Allows socket (AF_INET), listen, bind, accept,
+      getpeername, getsockname, setsockopt, getsockopt.
+
     unix
 
       Allows socket (AF_UNIX), listen, bind, connect, accept,

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -7401,12 +7401,12 @@ void RedBean(int argc, char *argv[]) {
   CHECK_NE(-1, fstat(zfd, &zst));
   OpenZip(true);
   SetDefaults();
-  LuaStart();
-  GetOpts(argc, argv);
   // this can fail with EPERM if we're running under pledge()
   if (!interpretermode && !(interfaces = GetHostIps())) {
     WARNF("(srvr) failed to query system network interface addresses: %m");
   }
+  LuaStart();
+  GetOpts(argc, argv);
 #ifndef STATIC
   if (selfmodifiable) {
     MakeExecutableModifiable();

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -7182,7 +7182,8 @@ static int WindowsReplThread(void *arg, int tid) {
 
 static void InstallSignalHandler(int sig, void *handler) {
   struct sigaction sa = {.sa_sigaction = handler};
-  CHECK_NE(-1, sigaction(sig, &sa, 0));
+  if (sigaction(sig, &sa, 0) == -1)
+    WARNF("(srvr) failed to set signal handler #%d: %m", sig);
 }
 
 static void SigInit(void) {


### PR DESCRIPTION
This is useful for configurations where it's desirable to start redbean (or another socket listening application), but not to allow `connect` socket calls.

I moved `GetHostIps` in redbean before `GetOpts`, as this allows to pass `unix.pledge` as a command line option that may disable `connect` and still run `GetHostIps`, as it requires `connect`. It may still fail under external `pledge`, but that's by design.

I also slightly tweaked the message shown to make it a bit more clear on what may need to be done:

```
error: protected syscall connect (ord=02a); pledge promise 'inet' to allow
```

There is also similar "unix" promise that also includes connect, but I'm not sure if it also needs a corresponding promise to be added without connect for consistency. Maybe we can add one when there is a read use case for it...