### PR TITLE
Update Windows IP_MULTICAST constants to use Ws2tcpip.h values (#839)

### DIFF
--- a/libc/sysv/consts.sh
+++ b/libc/sysv/consts.sh
@@ -833,8 +833,8 @@ syscon	scm	SCM_TIMESTAMPNS				35			35			0			0			0			0			0			0
 syscon	scm	SCM_WIFI_STATUS				41			41			0			0			0			0			0			0
 
 #	group	name					GNU/Systemd		GNU/Systemd (Aarch64)	XNU's Not UNIX!		MacOS (Arm64)		FreeBSD			OpenBSD			NetBSD			The New Technology	Commentary
-syscon	ip	IP_TOS					1			1			3			3			3			3			3			8			# bsd consensus
-syscon	ip	IP_TTL					2			2			4			4			4			4			4			7			# bsd consensus
+syscon	ip	IP_TOS					1			1			3			3			3			3			3			3			# bsd consensus
+syscon	ip	IP_TTL					2			2			4			4			4			4			4			4			# bsd consensus
 syscon	ip	IP_HDRINCL				3			3			2			2			2			2			2			2			# bsd consensus
 syscon	ip	IP_DEFAULT_MULTICAST_LOOP		1			1			1			1			1			1			1			1			# consensus
 syscon	ip	IP_DEFAULT_MULTICAST_TTL		1			1			1			1			1			1			1			1			# consensus
@@ -842,18 +842,18 @@ syscon	ip	IP_PMTUDISC_DONT			0			0			0			0			0			0			0			0			# consensus
 syscon	ip	IP_MAX_MEMBERSHIPS			20			20			0x0fff			0x0fff			0x0fff			0x0fff			0x0fff			20			# bsd consensus
 syscon	ip	IP_OPTIONS				4			4			1			1			1			1			1			1			# bsd consensus
 syscon	ip	IP_RECVTTL				12			12			24			24			65			31			23			21
-syscon	ip	IP_ADD_MEMBERSHIP			35			35			12			12			12			12			12			5			# bsd consensus
-syscon	ip	IP_DROP_MEMBERSHIP			36			36			13			13			13			13			13			6			# bsd consensus
-syscon	ip	IP_MULTICAST_IF				0x20			0x20			9			9			9			9			9			2			# bsd consensus
-syscon	ip	IP_MULTICAST_LOOP			34			34			11			11			11			11			11			4			# bsd consensus
-syscon	ip	IP_MULTICAST_TTL			33			33			10			10			10			10			10			3			# bsd consensus
+syscon	ip	IP_ADD_MEMBERSHIP			35			35			12			12			12			12			12			12			# bsd consensus
+syscon	ip	IP_DROP_MEMBERSHIP			36			36			13			13			13			13			13			13			# bsd consensus
+syscon	ip	IP_MULTICAST_IF				0x20			0x20			9			9			9			9			9			9			# bsd consensus
+syscon	ip	IP_MULTICAST_LOOP			34			34			11			11			11			11			11			11			# bsd consensus
+syscon	ip	IP_MULTICAST_TTL			33			33			10			10			10			10			10			10			# bsd consensus
 syscon	ip	IP_RECVOPTS				6			6			5			5			5			5			5			0			# bsd consensus
 syscon	ip	IP_RECVRETOPTS				7			7			6			6			6			6			6			0			# bsd consensus
 syscon	ip	IP_RECVDSTADDR				0			0			7			7			7			7			7			0			# bsd consensus
 syscon	ip	IP_RETOPTS				7			7			8			8			8			8			8			0			# bsd consensus
 syscon	ip	IP_ADD_SOURCE_MEMBERSHIP		39			39			70			70			70			0			0			15
 syscon	ip	IP_BLOCK_SOURCE				38			38			72			72			72			0			0			17
-syscon	ip	IP_DROP_SOURCE_MEMBERSHIP		40			40			71			71			71			0			0			0x10
+syscon	ip	IP_DROP_SOURCE_MEMBERSHIP		40			40			71			71			71			0			0			16
 syscon	ip	IP_UNBLOCK_SOURCE			37			37			73			73			73			0			0			18
 syscon	ip	IP_IPSEC_POLICY				0x10			0x10			21			21			21			0			0			0
 syscon	ip	IP_MINTTL				21			21			0			0			66			32			24			0			# minimum ttl for packet or drop

--- a/libc/sysv/consts/IP_ADD_MEMBERSHIP.S
+++ b/libc/sysv/consts/IP_ADD_MEMBERSHIP.S
@@ -1,2 +1,2 @@
 #include "libc/sysv/consts/syscon.internal.h"
-.syscon ip,IP_ADD_MEMBERSHIP,35,35,12,12,12,12,12,5
+.syscon ip,IP_ADD_MEMBERSHIP,35,35,12,12,12,12,12,12

--- a/libc/sysv/consts/IP_DROP_MEMBERSHIP.S
+++ b/libc/sysv/consts/IP_DROP_MEMBERSHIP.S
@@ -1,2 +1,2 @@
 #include "libc/sysv/consts/syscon.internal.h"
-.syscon ip,IP_DROP_MEMBERSHIP,36,36,13,13,13,13,13,6
+.syscon ip,IP_DROP_MEMBERSHIP,36,36,13,13,13,13,13,13

--- a/libc/sysv/consts/IP_DROP_SOURCE_MEMBERSHIP.S
+++ b/libc/sysv/consts/IP_DROP_SOURCE_MEMBERSHIP.S
@@ -1,2 +1,2 @@
 #include "libc/sysv/consts/syscon.internal.h"
-.syscon ip,IP_DROP_SOURCE_MEMBERSHIP,40,40,71,71,71,0,0,0x10
+.syscon ip,IP_DROP_SOURCE_MEMBERSHIP,40,40,71,71,71,0,0,16

--- a/libc/sysv/consts/IP_MULTICAST_IF.S
+++ b/libc/sysv/consts/IP_MULTICAST_IF.S
@@ -1,2 +1,2 @@
 #include "libc/sysv/consts/syscon.internal.h"
-.syscon ip,IP_MULTICAST_IF,0x20,0x20,9,9,9,9,9,2
+.syscon ip,IP_MULTICAST_IF,0x20,0x20,9,9,9,9,9,9

--- a/libc/sysv/consts/IP_MULTICAST_LOOP.S
+++ b/libc/sysv/consts/IP_MULTICAST_LOOP.S
@@ -1,2 +1,2 @@
 #include "libc/sysv/consts/syscon.internal.h"
-.syscon ip,IP_MULTICAST_LOOP,34,34,11,11,11,11,11,4
+.syscon ip,IP_MULTICAST_LOOP,34,34,11,11,11,11,11,11

--- a/libc/sysv/consts/IP_MULTICAST_TTL.S
+++ b/libc/sysv/consts/IP_MULTICAST_TTL.S
@@ -1,2 +1,2 @@
 #include "libc/sysv/consts/syscon.internal.h"
-.syscon ip,IP_MULTICAST_TTL,33,33,10,10,10,10,10,3
+.syscon ip,IP_MULTICAST_TTL,33,33,10,10,10,10,10,10

--- a/libc/sysv/consts/IP_TOS.S
+++ b/libc/sysv/consts/IP_TOS.S
@@ -1,2 +1,2 @@
 #include "libc/sysv/consts/syscon.internal.h"
-.syscon ip,IP_TOS,1,1,3,3,3,3,3,8
+.syscon ip,IP_TOS,1,1,3,3,3,3,3,3

--- a/libc/sysv/consts/IP_TTL.S
+++ b/libc/sysv/consts/IP_TTL.S
@@ -1,2 +1,2 @@
 #include "libc/sysv/consts/syscon.internal.h"
-.syscon ip,IP_TTL,2,2,4,4,4,4,4,7
+.syscon ip,IP_TTL,2,2,4,4,4,4,4,4


### PR DESCRIPTION
@jart, this fixes the Windows IP_MULTICAST* constants to use Ws2tcpip.h values, as described by Microsoft in https://learn.microsoft.com/en-US/troubleshoot/windows/win32/header-library-requirement-socket-ipproto-ip. I also changed one 0x10 to 16 for consistency.