### PR TITLE
Fix readme info about installing cosmo and ape at Ubuntu 23.04 64bit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ It's recommended that Cosmopolitan be installed to `/opt/cosmo` and
 contains your non-monorepo artifacts.
 
 ```
+sudo rm /opt/cosmo/o/depend # If ape exist and is broken, this makes possible to reinstall ape
+ape/apeinstall.sh
 sudo mkdir -p /opt
 sudo chmod 1777 /opt
 git clone https://github.com/jart/cosmopolitan /opt/cosmo
 cd /opt/cosmo
 make -j8 toolchain
-ape/apeinstall.sh  # optional
 mkdir -p /opt/cosmos/bin
 export PATH="/opt/cosmos/bin:$PATH"
 echo 'PATH="/opt/cosmos/bin:$PATH"' >>~/.profile


### PR DESCRIPTION
Fix readme info about installing cosmo and ape at Ubuntu 23.04 64bit.

Added improvements mentioned at previous PR at
https://github.com/jart/cosmopolitan/pull/846