### PR TITLE
Add EncodeBase32() to Redbean

### DIFF
--- a/net/http/base32.c
+++ b/net/http/base32.c
@@ -1,0 +1,79 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│vi: set net ft=c ts=2 sts=2 sw=2 fenc=utf-8                                :vi│
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ Copyright 2021 Justine Alexandra Roberts Tunney                              │
+│                                                                              │
+│ Permission to use, copy, modify, and/or distribute this software for         │
+│ any purpose with or without fee is hereby granted, provided that the         │
+│ above copyright notice and this permission notice appear in all copies.      │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL                │
+│ WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED                │
+│ WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE             │
+│ AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL         │
+│ DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR        │
+│ PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER               │
+│ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR             │
+│ PERFORMANCE OF THIS SOFTWARE.                                                │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "libc/assert.h"
+#include "libc/macros.internal.h"
+#include "libc/mem/mem.h"
+#include "libc/str/str.h"
+
+asm(".ident\t\"\\n\\n\
+Apache License, Version 2.0\\n\
+Copyright 2010 Google Inc.\"");
+asm(".include \"libc/disclaimer.inc\"");
+
+const char base32def[] = "0123456789abcdefghjkmnpqrstvwxyz";
+
+int tobits(int b) {
+  int bits = 0; while (b && (b >>= 1)) bits++;
+  return bits;
+}
+
+// the next function is based on
+// https://github.com/google/google-authenticator-libpam/blob/master/src/base32.c
+// Copyright 2010 Google Inc.; Author: Markus Gutschke
+// licensed under Apache License, Version 2.0
+char* EncodeBase32(const char *s, size_t sl,
+                   const char *a, size_t al,
+                   size_t *ol) {
+  size_t count = 0;
+  char *r;
+  if (al == 0) {
+    a = base32def;
+    al = sizeof(base32def)/sizeof(a[0]);
+  }
+  unassert(2 <= al && al <= 128);
+  int bl = tobits(al);
+  int mask = (1 << bl) - 1;
+  *ol = (sl * 8 + bl - 1) / bl; // calculate exact output length
+  if (!(r = malloc(*ol + 1))) {
+    *ol = 0;
+    return r;
+  }
+  if (sl > 0) {
+    int buffer = s[0];
+    size_t next = 1;
+    int bitsLeft = 8;
+    while (count < *ol && (bitsLeft > 0 || next < sl)) {
+      if (bitsLeft < bl) {
+        if (next < sl) {
+          buffer <<= 8;
+          buffer |= s[next++] & 0xFF;
+          bitsLeft += 8;
+        } else {
+          int pad = bl - bitsLeft;
+          buffer <<= pad;
+          bitsLeft += pad;
+        }
+      }
+      bitsLeft -= bl;
+      r[count++] = a[mask & (buffer >> bitsLeft)];
+    }
+  }
+  if (count < *ol) r[count] = '\000';
+  return r;
+}

--- a/net/http/escape.h
+++ b/net/http/escape.h
@@ -35,6 +35,7 @@ char *EncodeHttpHeaderValue(const char *, size_t, size_t *);
 char *VisualizeControlCodes(const char *, size_t, size_t *);
 char *IndentLines(const char *, size_t, size_t *, size_t);
 char *EncodeBase32(const char *, size_t, const char *, size_t, size_t *);
+char *DecodeBase32(const char *, size_t, const char *, size_t, size_t *);
 char *EncodeBase64(const char *, size_t, size_t *);
 char *DecodeBase64(const char *, size_t, size_t *);
 

--- a/net/http/escape.h
+++ b/net/http/escape.h
@@ -34,6 +34,7 @@ char *EncodeLatin1(const char *, size_t, size_t *, int);
 char *EncodeHttpHeaderValue(const char *, size_t, size_t *);
 char *VisualizeControlCodes(const char *, size_t, size_t *);
 char *IndentLines(const char *, size_t, size_t *, size_t);
+char *EncodeBase32(const char *, size_t, const char *, size_t, size_t *);
 char *EncodeBase64(const char *, size_t, size_t *);
 char *DecodeBase64(const char *, size_t, size_t *);
 

--- a/test/tool/net/lfuncs_test.lua
+++ b/test/tool/net/lfuncs_test.lua
@@ -55,6 +55,14 @@ assert(EncodeBase32("12") == "64s0")
 assert(EncodeBase32("\33", "01") == "00100001")
 assert(EncodeBase32("\33", "0123456789abcdef") == "21")
 
+assert(DecodeBase32("64s36d1n6r") == "123456")
+assert(DecodeBase32("64s0") == "12")
+assert(DecodeBase32("64 \t\r\ns0") == "12")
+assert(DecodeBase32("64s0!64s0") == "12")
+
+assert(EncodeBase32("\1\2\3\4\255", "0123456789abcdef") == "01020304ff")
+assert(DecodeBase32("01020304ff", "0123456789abcdef") == "\1\2\3\4\255")
+
 assert(EscapeHtml(nil) == nil)
 assert(EscapeHtml("?hello&there<>") == "?hello&amp;there&lt;&gt;")
 

--- a/test/tool/net/lfuncs_test.lua
+++ b/test/tool/net/lfuncs_test.lua
@@ -50,6 +50,11 @@ assert(bin(0x1940efe9d47ae889) == "0b0001100101000000111011111110100111010100011
 assert(EncodeHex("\1\2\3\4\255") == "01020304ff")
 assert(DecodeHex("01020304ff") == "\1\2\3\4\255")
 
+assert(EncodeBase32("123456") == "64s36d1n6r")
+assert(EncodeBase32("12") == "64s0")
+assert(EncodeBase32("\33", "01") == "00100001")
+assert(EncodeBase32("\33", "0123456789abcdef") == "21")
+
 assert(EscapeHtml(nil) == nil)
 assert(EscapeHtml("?hello&there<>") == "?hello&amp;there&lt;&gt;")
 

--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -737,6 +737,10 @@ FUNCTIONS
           Turns ASCII base-16 hexadecimal byte string into binary string,
           case-insensitively. Non-hex characters may not appear in string.
 
+  EncodeBase32(binary:str[, alphabet:str]) → ascii:str
+          Turns binary into ASCII using provided alphabet (using Crockford's
+          base32 encoding by default).
+
   DecodeBase64(ascii:str) → binary:str
           Turns ASCII into binary, in a permissive way that ignores
           characters outside the base64 alphabet, such as whitespace. See

--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -737,12 +737,20 @@ FUNCTIONS
           Turns ASCII base-16 hexadecimal byte string into binary string,
           case-insensitively. Non-hex characters may not appear in string.
 
+  DecodeBase32(ascii:str[, alphabet:str]) → binary:str
+          Turns ASCII into binary using provided alphabet. The default
+          decoding uses Crockford's base32 alphabet in a permissive way
+          that ignores whitespaces and dash ('-') and stops at the first
+          character outside of the alphabet.
+
   EncodeBase32(binary:str[, alphabet:str]) → ascii:str
           Turns binary into ASCII using provided alphabet (using Crockford's
-          base32 encoding by default).
+          base32 encoding by default). Any alphabet that has a power of 2
+          length (up to 128) may be supplied for encoding and decoding,
+          which allows to provide alternative base32 encodings.
 
   DecodeBase64(ascii:str) → binary:str
-          Turns ASCII into binary, in a permissive way that ignores
+          Turns ASCII into binary in a permissive way that ignores
           characters outside the base64 alphabet, such as whitespace. See
           decodebase64.c.
 

--- a/tool/net/lfuncs.c
+++ b/tool/net/lfuncs.c
@@ -605,19 +605,28 @@ int LuaEncodeLatin1(lua_State *L) {
   }
 }
 
-int LuaEncodeBase32(lua_State *L) {
+dontinline int LuaBase32Impl(lua_State *L,
+    char *B32(const char *, size_t, const char *, size_t, size_t *)) {
   char *p;
   size_t sl, al; // source/output and alphabet lengths
   const char *s = luaL_checklstring(L, 1, &sl);
   // use an empty string, as EncodeBase32 provides a default value
   const char *a = luaL_optlstring(L, 2, "", &al);
-  if (al & (al - 1) || al > 128 || al == 1)
+  if (!IS2POW(al) || al > 128 || al == 1)
     return luaL_error(L, "alphabet length is not a power of 2 in range 2..128");
-  if (!(p = EncodeBase32(s, sl, a, al, &sl)))
+  if (!(p = B32(s, sl, a, al, &sl)))
     return luaL_error(L, "out of memory");
   lua_pushlstring(L, p, sl);
   free(p);
   return 1;
+}
+
+int LuaEncodeBase32(lua_State *L) {
+  return LuaBase32Impl(L, EncodeBase32);
+}
+
+int LuaDecodeBase32(lua_State *L) {
+  return LuaBase32Impl(L, DecodeBase32);
 }
 
 int LuaEncodeHex(lua_State *L) {

--- a/tool/net/lfuncs.c
+++ b/tool/net/lfuncs.c
@@ -605,6 +605,21 @@ int LuaEncodeLatin1(lua_State *L) {
   }
 }
 
+int LuaEncodeBase32(lua_State *L) {
+  char *p;
+  size_t sl, al; // source/output and alphabet lengths
+  const char *s = luaL_checklstring(L, 1, &sl);
+  // use an empty string, as EncodeBase32 provides a default value
+  const char *a = luaL_optlstring(L, 2, "", &al);
+  if (al & (al - 1) || al > 128 || al == 1)
+    return luaL_error(L, "alphabet length is not a power of 2 in range 2..128");
+  if (!(p = EncodeBase32(s, sl, a, al, &sl)))
+    return luaL_error(L, "out of memory");
+  lua_pushlstring(L, p, sl);
+  free(p);
+  return 1;
+}
+
 int LuaEncodeHex(lua_State *L) {
   char *p;
   size_t n;

--- a/tool/net/lfuncs.h
+++ b/tool/net/lfuncs.h
@@ -24,6 +24,7 @@ int LuaDecodeBase64(lua_State *);
 int LuaDecodeHex(lua_State *);
 int LuaDecodeLatin1(lua_State *);
 int LuaDeflate(lua_State *);
+int LuaEncodeBase32(lua_State *);
 int LuaEncodeBase64(lua_State *);
 int LuaEncodeHex(lua_State *);
 int LuaEncodeLatin1(lua_State *);

--- a/tool/net/lfuncs.h
+++ b/tool/net/lfuncs.h
@@ -20,6 +20,7 @@ int LuaCompress(lua_State *);
 int LuaCrc32(lua_State *);
 int LuaCrc32c(lua_State *);
 int LuaDecimate(lua_State *);
+int LuaDecodeBase32(lua_State *);
 int LuaDecodeBase64(lua_State *);
 int LuaDecodeHex(lua_State *);
 int LuaDecodeLatin1(lua_State *);

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -5127,6 +5127,7 @@ static const luaL_Reg kLuaFuncs[] = {
     {"Crc32", LuaCrc32},                                        //
     {"Crc32c", LuaCrc32c},                                      //
     {"Decimate", LuaDecimate},                                  //
+    {"DecodeBase32", LuaDecodeBase32},                          //
     {"DecodeBase64", LuaDecodeBase64},                          //
     {"DecodeHex", LuaDecodeHex},                                //
     {"DecodeJson", LuaDecodeJson},                              //

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -5132,6 +5132,7 @@ static const luaL_Reg kLuaFuncs[] = {
     {"DecodeJson", LuaDecodeJson},                              //
     {"DecodeLatin1", LuaDecodeLatin1},                          //
     {"Deflate", LuaDeflate},                                    //
+    {"EncodeBase32", LuaEncodeBase32},                          //
     {"EncodeBase64", LuaEncodeBase64},                          //
     {"EncodeHex", LuaEncodeHex},                                //
     {"EncodeJson", LuaEncodeJson},                              //


### PR DESCRIPTION
@jart, this implements EncodeBase32, but I tweaked the function from google-authenticator-libpam to (1) allow the alphabet to be configurable and (2) work with any power of 2. I added a couple of tests, so it seems to do what's needed. I don't need DecodeBase32, so it's not included, but let me know if you think it's worth adding for consistency.