### PR TITLE
Update ProgramDirectory to prepend Lua path instead of appending (#862).

### DIFF
--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -4584,6 +4584,12 @@ static int LuaProgramBrand(lua_State *L) {
 }
 
 static int LuaProgramDirectory(lua_State *L) {
+  struct stat st;
+  char *path = luaL_checkstring(L, 1);
+  // check to raise a Lua error, to allow it to be handled
+  if (stat(path, &st) == -1 || !S_ISDIR(st.st_mode)) {
+    return luaL_argerror(L, 1, "not a directory");
+  }
   return LuaProgramString(L, ProgramDirectory);
 }
 

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -5355,22 +5355,11 @@ static void LuaSetConstant(lua_State *L, const char *s, long x) {
   lua_setglobal(L, s);
 }
 
-static char *GetDefaultLuaPath(void) {
-  char *s;
-  size_t i;
-  for (s = 0, i = 0; i < stagedirs.n; ++i) {
-    appendf(&s, "%s/.lua/?.lua;%s/.lua/?/init.lua;", stagedirs.p[i].s,
-            stagedirs.p[i].s);
-  }
-  appends(&s, DEFAULTLUAPATH);
-  return s;
-}
-
 static void LuaStart(void) {
 #ifndef STATIC
   size_t i;
   lua_State *L = GL = luaL_newstate();
-  g_lua_path_default = GetDefaultLuaPath();
+  g_lua_path_default = DEFAULTLUAPATH;
   luaL_openlibs(L);
   for (i = 0; i < ARRAYLEN(kLuaLibs); ++i) {
     luaL_requiref(L, kLuaLibs[i].name, kLuaLibs[i].func, 1);
@@ -5520,7 +5509,6 @@ static void LuaDestroy(void) {
 #ifndef STATIC
   lua_State *L = GL;
   lua_close(L);
-  free(g_lua_path_default);
 #endif
 }
 


### PR DESCRIPTION
This update checks the default path in the current path and prepends the added path in front of it. If the path is not found, then it's appended at the end (as the current implementation does). In either case it preserves the order of the additions, but allows to prepend, thus making `require` to check in added paths first, before checking the internal archive.