### PR TITLE
Change the default `TZ` value from `GST` to `GMT` #861

### DIFF
--- a/libc/time/tzfile.internal.h
+++ b/libc/time/tzfile.internal.h
@@ -25,7 +25,7 @@
 #endif /* !defined TZDIR */
 
 #ifndef TZDEFAULT
-#define TZDEFAULT	"GST"
+#define TZDEFAULT	"GMT"
 #endif /* !defined TZDEFAULT */
 
 #ifndef TZDEFRULES


### PR DESCRIPTION
With this change, `unix.localtime()` will match `unix.gmtime()` unless `TZ` has been (successfully) defined.

First, that seems like a less surprising "not defined" default; see #861.

Second, it matches `localtime()`'s current behaviour when `TZ` has been defined but can't be found.

If that doesn't fly, it might at least be worth documenting the fact that the default is `GST`.***

There are two related changes that might also make sense: 

* Change [`TZDEFULES`](https://github.com/jart/cosmopolitan/blob/e0c2b91b3ec6f88d060d6059210a993a0ef46b08/libc/time/tzfile.internal.h#L32) to `GMT`
* Change [`TZDEFRULESTRING`](https://github.com/jart/cosmopolitan/blob/e0c2b91b3ec6f88d060d6059210a993a0ef46b08/libc/time/localtime.c#L122) to, effectively, `GMT` (i.e., no DST)

The thinking is the same: that seems like a less surprising "not defined" default.

If you're good with that I could add those changes to this pull request?

===

***I saw a comment somewhere saying that "GST" is "Google Standard Time." But it looks like there's a different (and official) "GST" timezone: [Gulf Standard Time](https://www.timeanddate.com/time/zones/gst). When I google for "google standard time gst", "Gulf Standard Time" is the only thing that shows up.