### PR TITLE
Change `TZDEFRULES` and `TZDEFRULESTRING` to `"GMT"`.

### DIFF
--- a/libc/time/localtime.c
+++ b/libc/time/localtime.c
@@ -110,11 +110,10 @@ static const char	gmt[] = "GMT";
 /*
 ** The DST rules to use if TZ has no rules and we can't load TZDEFRULES.
 ** Default to US rules as of 2017-05-07.
-** POSIX does not specify the default DST rules;
-** for historical reasons, US rules are a common default.
+** Default to GMT rules as of 2023-07-25.
 */
 #ifndef TZDEFRULESTRING
-#define TZDEFRULESTRING ",M3.2.0,M11.1.0"
+#define TZDEFRULESTRING "GMT0"
 #endif
 
 struct ttinfo {				/* time type information */

--- a/libc/time/tzfile.internal.h
+++ b/libc/time/tzfile.internal.h
@@ -29,7 +29,7 @@
 #endif /* !defined TZDEFAULT */
 
 #ifndef TZDEFRULES
-#define TZDEFRULES	"New_York"
+#define TZDEFRULES	"GMT"
 #endif /* !defined TZDEFRULES */
 
 


### PR DESCRIPTION
This is a companion to changing the default `TZ` value from `"GST"` to `"GMT"`. The rationale is the same: it’s a less surprising "not defined" default.

For the curious, details follow.

===

`TZDEFRULES` is defined [here](https://github.com/jart/cosmopolitan/blob/6843150e0c6322f50cda0ce59cca0b2e7397a3a7/libc/time/tzfile.internal.h#L32) and only used [here](https://github.com/jart/cosmopolitan/blob/e0c2b91b3ec6f88d060d6059210a993a0ef46b08/libc/time/localtime.c#L1135), by `localtime_tzparse()`.

In the original IANA code, the value of `TZDEFRULES` is `"posixrules"`. `"posixrules"` was a POSIX fallback mechanism that tried to derive rules for one timezone from another. Foolish mortals! It was declared obsolete in the 2019b IANA release. (For more info about what it tried to do, see [`man 5 tzfile`](https://www.man7.org/linux/man-pages/man5/tzfile.5.html).)

If `TZDEFRULES` were set to `NULL`, `localtime_tzparse()` would fall back to `TZDEFAULT`, because of this:

https://github.com/jart/cosmopolitan/blob/e0c2b91b3ec6f88d060d6059210a993a0ef46b08/libc/time/localtime.c#L382-L383

A recent pull request set `TZDEFAULT` to `"GMT"`, so in a sense setting `TZDEFRULES` to `NULL` is another option. Setting it directly to `"GMT"`, though, does a better job of making the intent obvious: if you can't find any rules, don't apply any rules.

`TZDEFULESTRING` is defined [here](https://github.com/jart/cosmopolitan/blob/e0c2b91b3ec6f88d060d6059210a993a0ef46b08/libc/time/localtime.c#L122) and only used [here](https://github.com/jart/cosmopolitan/blob/e0c2b91b3ec6f88d060d6059210a993a0ef46b08/libc/time/localtime.c#L1165C11-L1165C11), also in `localtime_tzparse()`.

The value I've used, `"GMT0"`, is the same value `gmtload()` passes to `localtime_tzparse()`:

https://github.com/jart/cosmopolitan/blob/e0c2b91b3ec6f88d060d6059210a993a0ef46b08/libc/time/localtime.c#L1372-L1376

The format of the string is defined in Section 8.3 of the POSIX standard, available [here](https://pubs.opengroup.org/onlinepubs/9699919799/).

I'm not sure I really wanted to know this much about how this stuff works. (How much *do* I really know…?) I'm not sure you really wanted to know this much about how this stuff works either. But here we are.

P.S. All of this is, in some sense, pointless; even `redbean-2.2.com` falls back to `"GMT"` if a timezone isn't found:

```sh
TZ="xxx" ./redbean-2.2.com -i -e "print(unix.localtime(unix.clock_gettime()))"
2023	7	26	17	32	38	0	3	206	0	GMT
```

This change really only affects deeper, darker corners of the code. "You're in a maze of twisty little passages…"