### PR TITLE
Don’t lowercase the test filename.

### DIFF
--- a/third_party/python/Lib/test/test_genericpath.py
+++ b/third_party/python/Lib/test/test_genericpath.py
@@ -516,7 +516,7 @@ class CommonTest(GenericTest):
 class PathLikeTests(unittest.TestCase):
 
     def setUp(self):
-        self.file_name = support.TESTFN.lower()
+        self.file_name = support.TESTFN
         self.file_path = FakePath(support.TESTFN)
         self.addCleanup(support.unlink, self.file_name)
         create_file(self.file_name, b"test_genericpath.PathLikeTests")


### PR DESCRIPTION
This test fails if Cosmo builds from a path that contains an uppercase character.

Paths with uppercase characters aren’t so common in server Linux. But they are in *desktop* Linux. Guess how I…?

But I digress.

The real problem is that the path is lowercased on one line, but not the next:

```
        self.file_name = support.TESTFN.lower()
        self.file_path = FakePath(support.TESTFN)
```

Given that no other test in the suite lowercases `support.TESTFN`, I opted to remove it from the first line rather than add it to the second.