### PR TITLE
Re-sync to Lua 5.4.3.

### DIFF
--- a/third_party/lua/lapi.c
+++ b/third_party/lua/lapi.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define lapi_c
 #define LUA_CORE
+
 #include "third_party/lua/lapi.h"
 #include "third_party/lua/ldebug.h"
 #include "third_party/lua/ldo.h"
@@ -42,6 +43,7 @@
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lundump.h"
 #include "third_party/lua/lvm.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\
@@ -1524,7 +1526,7 @@ LUA_API int lua_error (lua_State *L) {
   else
     luaG_errormsg(L);  /* raise a regular error */
   /* code unreachable; will unlock when control actually leaves the kernel */
-  __builtin_unreachable();
+  __builtin_unreachable();  // [jart]
 }
 
 

--- a/third_party/lua/lapi.h
+++ b/third_party/lua/lapi.h
@@ -4,7 +4,7 @@
 #include "third_party/lua/llimits.h"
 #include "third_party/lua/lstate.h"
 
-/* clang-format off */
+// clang-format off
 
 /* Increments 'L->top', checking for stack overflows */
 #define api_incr_top(L)   {L->top++; api_check(L, L->top <= L->ci->top, \

--- a/third_party/lua/lauxlib.c
+++ b/third_party/lua/lauxlib.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define lauxlib_c
 #define LUA_LIB
+
 #include "libc/calls/calls.h"
 #include "libc/errno.h"
 #include "libc/mem/mem.h"
@@ -34,6 +35,7 @@
 #include "third_party/lua/lauxlib.h"
 #include "third_party/lua/lprefix.h"
 #include "third_party/lua/lua.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/lauxlib.h
+++ b/third_party/lua/lauxlib.h
@@ -1,10 +1,12 @@
 #ifndef lauxlib_h
 #define lauxlib_h
+
 #include "libc/assert.h"
 #include "libc/stdio/stdio.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/luaconf.h"
-/* clang-format off */
+
+// clang-format off
 
 /* global table */
 #define LUA_GNAME	"_G"

--- a/third_party/lua/lbaselib.c
+++ b/third_party/lua/lbaselib.c
@@ -27,12 +27,14 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define lbaselib_c
 #define LUA_LIB
+
 #include "libc/str/str.h"
 #include "third_party/lua/lauxlib.h"
 #include "third_party/lua/lprefix.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lualib.h"
-/* clang-format off */
+
+// clang-format off
 
 asm(".ident\t\"\\n\\n\
 Lua 5.4.3 (MIT License)\\n\

--- a/third_party/lua/lcode.c
+++ b/third_party/lua/lcode.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define lcode_c
 #define LUA_CORE
+
 #include "libc/fmt/conv.h"
 #include "third_party/lua/lcode.h"
 #include "third_party/lua/ldebug.h"
@@ -42,6 +43,7 @@
 #include "third_party/lua/ltable.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lvm.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/lcode.h
+++ b/third_party/lua/lcode.h
@@ -6,7 +6,7 @@
 #include "third_party/lua/lopcodes.h"
 #include "third_party/lua/lparser.h"
 
-/* clang-format off */
+// clang-format off
 
 /*
 ** Marks the end of a patch list. It is an invalid value both as an absolute

--- a/third_party/lua/lcorolib.c
+++ b/third_party/lua/lcorolib.c
@@ -27,10 +27,12 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define lcorolib_c
 #define LUA_LIB
+
 #include "third_party/lua/lauxlib.h"
 #include "third_party/lua/lprefix.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lualib.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/lctype.h
+++ b/third_party/lua/lctype.h
@@ -1,6 +1,9 @@
 #ifndef lctype_h
 #define lctype_h
+
 #include "third_party/lua/lua.h"
+
+// clang-format off
 
 /*
 ** In ASCII, this 'ltolower' is correct for alphabetic characters and

--- a/third_party/lua/ldblib.c
+++ b/third_party/lua/ldblib.c
@@ -27,11 +27,13 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define ldblib_c
 #define LUA_LIB
+
 #include "libc/str/str.h"
 #include "third_party/lua/lauxlib.h"
 #include "third_party/lua/lprefix.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lualib.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/ldebug.c
+++ b/third_party/lua/ldebug.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define ldebug_c
 #define LUA_CORE
+
 #include "libc/str/str.h"
 #include "third_party/lua/lapi.h"
 #include "third_party/lua/lcode.h"
@@ -42,6 +43,7 @@
 #include "third_party/lua/ltm.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lvm.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/ldebug.h
+++ b/third_party/lua/ldebug.h
@@ -3,8 +3,7 @@
 
 #include "third_party/lua/lstate.h"
 
-/* clang-format off */
-
+// clang-format off
 
 #define pcRel(pc, p)	(cast_int((pc) - (p)->code) - 1)
 

--- a/third_party/lua/ldo.c
+++ b/third_party/lua/ldo.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define ldo_c
 #define LUA_CORE
+
 #include "libc/intrin/weaken.h"
 #include "libc/log/log.h"
 #include "libc/mem/gc.h"
@@ -51,6 +52,7 @@
 #include "third_party/lua/lundump.h"
 #include "third_party/lua/lvm.h"
 #include "third_party/lua/lzio.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\
@@ -87,14 +89,14 @@ asm(".include \"libc/disclaimer.inc\"");
 #elif defined(LUA_USE_POSIX)				/* }{ */
 
 /* in POSIX, try _longjmp/_setjmp (more efficient) */
-#define LUAI_THROW(L,c)		_gclongjmp((c)->b, 1)
+#define LUAI_THROW(L,c)		_gclongjmp((c)->b, 1)  // [jart]
 #define LUAI_TRY(L,c,a)		if (_setjmp((c)->b) == 0) { a }
 #define luai_jmpbuf		jmp_buf
 
 #else							/* }{ */
 
 /* ISO C handling with long jumps */
-#define LUAI_THROW(L,c)		_gclongjmp((c)->b, 1)
+#define LUAI_THROW(L,c)		_gclongjmp((c)->b, 1)  // [jart]
 #define LUAI_TRY(L,c,a)		if (setjmp((c)->b) == 0) { a }
 #define luai_jmpbuf		jmp_buf
 
@@ -153,7 +155,7 @@ l_noret luaD_throw (lua_State *L, int errcode) {
         lua_unlock(L);
         g->panic(L);  /* call panic function (last chance to jump out) */
       }
-      if (_weaken(__die)) _weaken(__die)();
+      if (_weaken(__die)) _weaken(__die)();  // [jart]
       _Exitr(41);
     }
   }

--- a/third_party/lua/ldo.h
+++ b/third_party/lua/ldo.h
@@ -5,7 +5,7 @@
 #include "third_party/lua/lstate.h"
 #include "third_party/lua/lzio.h"
 
-/* clang-format off */
+// clang-format off
 
 /*
 ** Macro to check stack size and grow stack if needed.  Parameters

--- a/third_party/lua/ldump.c
+++ b/third_party/lua/ldump.c
@@ -27,11 +27,13 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define ldump_c
 #define LUA_CORE
+
 #include "third_party/lua/lobject.h"
 #include "third_party/lua/lprefix.h"
 #include "third_party/lua/lstate.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lundump.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/lfunc.c
+++ b/third_party/lua/lfunc.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define lfunc_c
 #define LUA_CORE
+
 #include "third_party/lua/ldebug.h"
 #include "third_party/lua/ldo.h"
 #include "third_party/lua/lfunc.h"
@@ -37,6 +38,7 @@
 #include "third_party/lua/lstate.h"
 #include "third_party/lua/ltm.h"
 #include "third_party/lua/lua.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/lfunc.h
+++ b/third_party/lua/lfunc.h
@@ -3,7 +3,7 @@
 
 #include "third_party/lua/lobject.h"
 
-/* clang-format off */
+// clang-format off
 
 #define sizeCclosure(n)	(cast_int(offsetof(CClosure, upvalue)) + \
                          cast_int(sizeof(TValue)) * (n))

--- a/third_party/lua/lgc.c
+++ b/third_party/lua/lgc.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define lgc_c
 #define LUA_CORE
+
 #include "libc/str/str.h"
 #include "third_party/lua/ldebug.h"
 #include "third_party/lua/ldo.h"
@@ -40,6 +41,7 @@
 #include "third_party/lua/ltable.h"
 #include "third_party/lua/ltm.h"
 #include "third_party/lua/lua.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/lgc.h
+++ b/third_party/lua/lgc.h
@@ -4,7 +4,7 @@
 #include "third_party/lua/lobject.h"
 #include "third_party/lua/lstate.h"
 
-/* clang-format off */
+// clang-format off
 
 /*
 ** Collectable objects may have one of three colors: white, which means

--- a/third_party/lua/linit.c
+++ b/third_party/lua/linit.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define linit_c
 #define LUA_LIB
+
 /*
 ** If you embed Lua in your program and need to open the standard
 ** libraries, call luaL_openlibs in your program. If you need a
@@ -42,10 +43,12 @@
 **  lua_setfield(L, -2, modname);
 **  lua_pop(L, 1);  // remove PRELOAD table
 */
+
 #include "third_party/lua/lauxlib.h"
 #include "third_party/lua/lprefix.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lualib.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/liolib.c
+++ b/third_party/lua/liolib.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define liolib_c
 #define LUA_LIB
+
 #include "libc/calls/calls.h"
 #include "libc/calls/weirdtypes.h"
 #include "libc/errno.h"
@@ -38,6 +39,7 @@
 #include "third_party/lua/lprefix.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lualib.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/ljumptab.inc
+++ b/third_party/lua/ljumptab.inc
@@ -1,9 +1,3 @@
-/*
-** $Id: ljumptab.h $
-** Jump Table for the Lua interpreter
-** See Copyright Notice in lua.h
-*/
-
 #undef vmdispatch
 #undef vmcase
 #undef vmbreak

--- a/third_party/lua/llex.c
+++ b/third_party/lua/llex.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define llex_c
 #define LUA_CORE
+
 #include "third_party/lua/llex.h"
 #include "third_party/lua/lctype.h"
 #include "third_party/lua/ldebug.h"
@@ -40,6 +41,7 @@
 #include "third_party/lua/ltable.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lzio.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\
@@ -413,9 +415,9 @@ static void read_string (LexState *ls, int del, SemInfo *seminfo) {
         int c;  /* final character to be saved */
         save_and_next(ls);  /* keep '\\' for error messages */
         switch (ls->current) {
-          case 'e': c = '\e'; goto read_save;
           case 'a': c = '\a'; goto read_save;
           case 'b': c = '\b'; goto read_save;
+          case 'e': c = '\e'; goto read_save;  // [jart]
           case 'f': c = '\f'; goto read_save;
           case 'n': c = '\n'; goto read_save;
           case 'r': c = '\r'; goto read_save;

--- a/third_party/lua/llex.h
+++ b/third_party/lua/llex.h
@@ -1,16 +1,10 @@
-/*
-** $Id: llex.h $
-** Lexical Analyzer
-** See Copyright Notice in lua.h
-*/
-
 #ifndef llex_h
 #define llex_h
 
 #include "third_party/lua/lobject.h"
 #include "third_party/lua/lzio.h"
 
-/* clang-format off */
+// clang-format off
 
 /*
 ** Single-char tokens (terminal symbols) are represented by their own

--- a/third_party/lua/llimits.h
+++ b/third_party/lua/llimits.h
@@ -5,7 +5,7 @@
 #include "libc/math.h"
 #include "third_party/lua/lua.h"
 
-/* clang-format off */
+// clang-format off
 
 /*
 ** 'lu_mem' and 'l_mem' are unsigned/signed integers big enough to count

--- a/third_party/lua/lmathlib.c
+++ b/third_party/lua/lmathlib.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define lmathlib_c
 #define LUA_LIB
+
 #include "libc/calls/calls.h"
 #include "libc/math.h"
 #include "libc/nt/struct/msg.h"
@@ -34,6 +35,7 @@
 #include "third_party/lua/lprefix.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lualib.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/lmem.c
+++ b/third_party/lua/lmem.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define lmem_c
 #define LUA_CORE
+
 #include "libc/log/log.h"
 #include "third_party/lua/ldebug.h"
 #include "third_party/lua/ldo.h"
@@ -36,6 +37,7 @@
 #include "third_party/lua/lprefix.h"
 #include "third_party/lua/lstate.h"
 #include "third_party/lua/lua.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\
@@ -171,7 +173,7 @@ static void *tryagain (lua_State *L, void *block,
                        size_t osize, size_t nsize) {
   global_State *g = G(L);
   if (completestate(g) && !g->gcstopem) {
-    WARNF("reacting to malloc() failure by running lua garbage collector...");
+    WARNF("reacting to malloc() failure by running lua garbage collector...");  // [jart]
     luaC_fullgc(L, 1);  /* try to free some memory... */
     return (*g->frealloc)(g->ud, block, osize, nsize);  /* try again */
   }

--- a/third_party/lua/lmem.h
+++ b/third_party/lua/lmem.h
@@ -4,7 +4,7 @@
 #include "third_party/lua/llimits.h"
 #include "third_party/lua/lua.h"
 
-/* clang-format off */
+// clang-format off
 
 #define luaM_error(L)	luaD_throw(L, LUA_ERRMEM)
 

--- a/third_party/lua/loadlib.c
+++ b/third_party/lua/loadlib.c
@@ -27,12 +27,14 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define loadlib_c
 #define LUA_LIB
+
 #include "libc/runtime/runtime.h"
 #include "libc/str/str.h"
 #include "third_party/lua/lauxlib.h"
 #include "third_party/lua/lprefix.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lualib.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\
@@ -40,14 +42,16 @@ Lua 5.4.3 (MIT License)\\n\
 Copyright 1994–2021 Lua.org, PUC-Rio.\"");
 asm(".include \"libc/disclaimer.inc\"");
 
+
 /*
-** This module contains an implementation of loadlib for Unix systems
+**
+** [jart] This module contains an implementation of loadlib for Unix systems
 ** that have dlfcn, an implementation for Windows, and a stub for other
 ** systems.
 */
 
 
-const char *g_lua_path_default = LUA_PATH_DEFAULT;
+const char *g_lua_path_default = LUA_PATH_DEFAULT;  // [jart]
 
 
 /*
@@ -761,7 +765,7 @@ static void createclibstable (lua_State *L) {
 
 
 static const char *GetLuaPathDefault(void) {
-  return g_lua_path_default;
+  return g_lua_path_default;  // [jart]
 }
 
 

--- a/third_party/lua/lobject.c
+++ b/third_party/lua/lobject.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define lobject_c
 #define LUA_CORE
+
 #include "libc/str/str.h"
 #include "third_party/lua/lctype.h"
 #include "third_party/lua/ldebug.h"
@@ -38,12 +39,19 @@
 #include "third_party/lua/lstring.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lvm.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\
 Lua 5.4.3 (MIT License)\\n\
 Copyright 1994–2021 Lua.org, PUC-Rio.\"");
 asm(".include \"libc/disclaimer.inc\"");
+
+
+/*
+** Computes ceil(log2(x))
+*/
+// [jart] moved to lobject.h
 
 
 static lua_Integer intarith (lua_State *L, int op, lua_Integer v1,
@@ -267,9 +275,9 @@ static const char *l_str2d (const char *s, lua_Number *result) {
 
 
 #define MAXBY10		cast(lua_Unsigned, LUA_MAXINTEGER / 10)
-#define MAXBY8		cast(lua_Unsigned, LUA_MAXINTEGER / 8)
+#define MAXBY8		cast(lua_Unsigned, LUA_MAXINTEGER / 8)  // [jart]
 #define MAXLASTD	cast_int(LUA_MAXINTEGER % 10)
-#define MAXLASTD8	cast_int(LUA_MAXINTEGER % 8)
+#define MAXLASTD8	cast_int(LUA_MAXINTEGER % 8)  // [jart]
 
 static const char *l_str2int (const char *s, lua_Integer *result) {
   lua_Unsigned a = 0;

--- a/third_party/lua/lobject.h
+++ b/third_party/lua/lobject.h
@@ -5,7 +5,7 @@
 #include "third_party/lua/llimits.h"
 #include "third_party/lua/lua.h"
 
-/* clang-format off */
+// clang-format off
 
 /*
 ** Extra types for collectable non-values
@@ -786,7 +786,7 @@ LUAI_FUNC void luaO_chunkid (char *out, const char *source, size_t srclen);
 ** Computes ceil(log2(x))
 */
 static inline int luaO_ceillog2 (unsigned int x) {
-  return --x ? _bsr(x) + 1 : 0;
+  return --x ? _bsr(x) + 1 : 0;  // [jart]
 }
 
 #endif

--- a/third_party/lua/lopcodes.c
+++ b/third_party/lua/lopcodes.c
@@ -27,8 +27,10 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define lopcodes_c
 #define LUA_CORE
+
 #include "third_party/lua/lopcodes.h"
 #include "third_party/lua/lprefix.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/lopcodes.h
+++ b/third_party/lua/lopcodes.h
@@ -3,7 +3,7 @@
 
 #include "third_party/lua/llimits.h"
 
-/* clang-format off */
+// clang-format off
 
 /*===========================================================================
   We assume that instructions are unsigned 32-bit integers.

--- a/third_party/lua/lopnames.h
+++ b/third_party/lua/lopnames.h
@@ -1,13 +1,7 @@
-/*
-** $Id: lopnames.h $
-** Opcode names
-** See Copyright Notice in lua.h
-*/
-
-#if !defined(lopnames_h)
+#ifndef lopnames_h
 #define lopnames_h
 
-
+// clang-format off
 
 /* ORDER OP */
 

--- a/third_party/lua/loslib.c
+++ b/third_party/lua/loslib.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define loslib_c
 #define LUA_LIB
+
 #include "libc/calls/calls.h"
 #include "libc/calls/weirdtypes.h"
 #include "libc/errno.h"
@@ -41,6 +42,7 @@
 #include "third_party/lua/lprefix.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lualib.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\
@@ -142,7 +144,7 @@ asm(".include \"libc/disclaimer.inc\"");
 #define LUA_TMPNAMBUFSIZE	32
 
 #define lua_tmpnam(b,e) { \
-        strcpy(b, kTmpPath); \
+        strcpy(b, kTmpPath); \  // [jart]
         strcat(b, "lua_XXXXXX"); \
         e = mkstemp(b); \
         if (e != -1) close(e); \

--- a/third_party/lua/loslib.c
+++ b/third_party/lua/loslib.c
@@ -143,8 +143,9 @@ asm(".include \"libc/disclaimer.inc\"");
 
 #define LUA_TMPNAMBUFSIZE	32
 
+// [jart]
 #define lua_tmpnam(b,e) { \
-        strcpy(b, kTmpPath); \  // [jart]
+        strcpy(b, kTmpPath); \
         strcat(b, "lua_XXXXXX"); \
         e = mkstemp(b); \
         if (e != -1) close(e); \

--- a/third_party/lua/lparser.c
+++ b/third_party/lua/lparser.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define lparser_c
 #define LUA_CORE
+
 #include "libc/str/str.h"
 #include "third_party/lua/lcode.h"
 #include "third_party/lua/ldebug.h"
@@ -42,6 +43,7 @@
 #include "third_party/lua/lstring.h"
 #include "third_party/lua/ltable.h"
 #include "third_party/lua/lua.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/lparser.h
+++ b/third_party/lua/lparser.h
@@ -5,7 +5,7 @@
 #include "third_party/lua/lobject.h"
 #include "third_party/lua/lzio.h"
 
-/* clang-format off */
+// clang-format off
 
 /*
 ** Expression and variable descriptor.

--- a/third_party/lua/lprefix.h
+++ b/third_party/lua/lprefix.h
@@ -1,6 +1,8 @@
 #ifndef lprefix_h
 #define lprefix_h
 
+// clang-format off
+
 /*
 ** Allows POSIX/XSI stuff
 */

--- a/third_party/lua/lstate.c
+++ b/third_party/lua/lstate.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define lstate_c
 #define LUA_CORE
+
 #include "libc/str/str.h"
 #include "libc/time/time.h"
 #include "third_party/lua/lapi.h"
@@ -42,6 +43,7 @@
 #include "third_party/lua/ltable.h"
 #include "third_party/lua/ltm.h"
 #include "third_party/lua/lua.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/lstate.h
+++ b/third_party/lua/lstate.h
@@ -7,7 +7,7 @@
 #include "third_party/lua/lzio.h"
 #include "third_party/lua/tms.h"
 
-/* clang-format off */
+// clang-format off
 
 /*
 ** Some notes about garbage-collected objects: All objects in Lua must

--- a/third_party/lua/lstring.c
+++ b/third_party/lua/lstring.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define lstring_c
 #define LUA_CORE
+
 #include "libc/str/str.h"
 #include "third_party/lua/ldebug.h"
 #include "third_party/lua/ldo.h"
@@ -36,6 +37,7 @@
 #include "third_party/lua/lstate.h"
 #include "third_party/lua/lstring.h"
 #include "third_party/lua/lua.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/lstring.h
+++ b/third_party/lua/lstring.h
@@ -5,7 +5,7 @@
 #include "third_party/lua/lobject.h"
 #include "third_party/lua/lstate.h"
 
-/* clang-format off */
+// clang-format off
 
 /*
 ** Memory-allocation error message must be preallocated (it cannot

--- a/third_party/lua/lstrlib.c
+++ b/third_party/lua/lstrlib.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define lstrlib_c
 #define LUA_LIB
+
 #include "libc/math.h"
 #include "libc/str/str.h"
 #include "third_party/lua/cosmo.h"
@@ -34,6 +35,7 @@
 #include "third_party/lua/lprefix.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lualib.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\
@@ -67,7 +69,7 @@ asm(".include \"libc/disclaimer.inc\"");
 
 
 
-static int str_format(lua_State *);
+static int str_format(lua_State *);  // [jart]
 
 
 static int str_len (lua_State *L) {

--- a/third_party/lua/ltable.c
+++ b/third_party/lua/ltable.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define ltable_c
 #define LUA_CORE
+
 #include "third_party/lua/ldebug.h"
 #include "third_party/lua/ldo.h"
 #include "third_party/lua/lgc.h"
@@ -38,6 +39,7 @@
 #include "third_party/lua/ltable.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lvm.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/ltable.h
+++ b/third_party/lua/ltable.h
@@ -3,7 +3,7 @@
 
 #include "third_party/lua/lobject.h"
 
-/* clang-format off */
+// clang-format off
 
 #define gnode(t,i)	(&(t)->node[i])
 #define gval(n)		(&(n)->i_val)

--- a/third_party/lua/ltablib.c
+++ b/third_party/lua/ltablib.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define ltablib_c
 #define LUA_LIB
+
 #include "libc/calls/calls.h"
 #include "libc/calls/weirdtypes.h"
 #include "libc/str/str.h"
@@ -34,6 +35,7 @@
 #include "third_party/lua/lprefix.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lualib.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/ltests.c
+++ b/third_party/lua/ltests.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define ltests_c
 #define LUA_CORE
+
 #include "third_party/lua/lapi.h"
 #include "third_party/lua/lauxlib.h"
 #include "third_party/lua/lcode.h"
@@ -36,13 +37,14 @@
 #include "third_party/lua/lfunc.h"
 #include "third_party/lua/lmem.h"
 #include "third_party/lua/lopcodes.h"
-#include "third_party/lua/lopnames.inc"
+#include "third_party/lua/lopnames.h"
 #include "third_party/lua/lprefix.h"
 #include "third_party/lua/lstate.h"
 #include "third_party/lua/lstring.h"
 #include "third_party/lua/ltable.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lualib.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\
@@ -1263,7 +1265,7 @@ static int panicback (lua_State *L) {
   b = (struct Aux *)lua_touserdata(L, -1);
   lua_pop(L, 1);  /* remove 'Aux' struct */
   runC(b->L, L, b->paniccode);  /* run optional panic code */
-  _gclongjmp(b->jb, 1);
+  _gclongjmp(b->jb, 1);  // [jart]
   return 1;  /* to avoid warnings */
 }
 
@@ -1724,7 +1726,7 @@ static int runC (lua_State *L, lua_State *L1, const char *pc) {
       lua_error(L1);
     }
     else if EQ("abort") {
-      __die();
+      __die();  // [jart]
     }
     else if EQ("throw") {
 #if defined(__cplusplus)

--- a/third_party/lua/ltests.h
+++ b/third_party/lua/ltests.h
@@ -1,8 +1,9 @@
 #ifndef ltests_h
 #define ltests_h
+
 #include "third_party/lua/lua.h"
 
-/* clang-format off */
+// clang-format off
 
 /* test Lua with compatibility code */
 #define LUA_COMPAT_MATHLIB

--- a/third_party/lua/ltm.c
+++ b/third_party/lua/ltm.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define ltm_c
 #define LUA_CORE
+
 #include "third_party/lua/ldebug.h"
 #include "third_party/lua/ldo.h"
 #include "third_party/lua/lgc.h"
@@ -38,6 +39,7 @@
 #include "third_party/lua/ltm.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lvm.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/ltm.h
+++ b/third_party/lua/ltm.h
@@ -1,9 +1,17 @@
 #ifndef ltm_h
 #define ltm_h
+
 #include "third_party/lua/lobject.h"
 #include "third_party/lua/luaconf.h"
 #include "third_party/lua/tms.h"
-/* clang-format off */
+
+// clang-format off
+
+/*
+* WARNING: if you change the order of this enumeration,
+* grep "ORDER TM" and "ORDER OP"
+*/
+// [jart] moved to tms.h
 
 /*
 ** Mask with 1 in all fast-access methods. A 1 in any of these bits

--- a/third_party/lua/lua.h
+++ b/third_party/lua/lua.h
@@ -1,9 +1,12 @@
 #ifndef COSMOPOLITAN_THIRD_PARTY_LUA_LUA_H_
 #define COSMOPOLITAN_THIRD_PARTY_LUA_LUA_H_
+
 #include "third_party/lua/luaconf.h"
+
 #if !(__ASSEMBLER__ + __LINKER__ + 0)
 COSMOPOLITAN_C_START_
-/* clang-format off */
+
+// clang-format off
 
 #define LUA_VERSION_MAJOR	"5"
 #define LUA_VERSION_MINOR	"4"
@@ -479,8 +482,9 @@ struct lua_Debug {
 
 /* }====================================================================== */
 
-extern const char *g_lua_path_default;
+extern const char *g_lua_path_default;  // [jart]
 
 COSMOPOLITAN_C_END_
+
 #endif /* !(__ASSEMBLER__ + __LINKER__ + 0) */
 #endif /* COSMOPOLITAN_THIRD_PARTY_LUA_LUA_H_ */

--- a/third_party/lua/lua.main.c
+++ b/third_party/lua/lua.main.c
@@ -26,6 +26,7 @@
 │                                                                              │
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define lua_c
+
 #include "third_party/lua/lua.h"
 #include "libc/calls/calls.h"
 #include "libc/calls/struct/sigaction.h"
@@ -50,12 +51,14 @@
 #include "third_party/lua/lualib.h"
 #include "third_party/lua/lunix.h"
 #include "tool/args/args.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\
 Lua 5.4.3 (MIT License)\\n\
 Copyright 1994–2021 Lua.org, PUC-Rio.\"");
 asm(".include \"libc/disclaimer.inc\"");
+
 
 STATIC_STACK_SIZE(0x80000);
 

--- a/third_party/lua/luac.main.c
+++ b/third_party/lua/luac.main.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define luac_c
 #define LUA_CORE
+
 #include "libc/calls/calls.h"
 #include "libc/calls/struct/sigaction.h"
 #include "libc/errno.h"
@@ -37,12 +38,13 @@
 #include "third_party/lua/ldebug.h"
 #include "third_party/lua/lobject.h"
 #include "third_party/lua/lopcodes.h"
-#include "third_party/lua/lopnames.inc"
+#include "third_party/lua/lopnames.h"
 #include "third_party/lua/lprefix.h"
 #include "third_party/lua/lstate.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lualib.h"
 #include "third_party/lua/lundump.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/luaconf.h
+++ b/third_party/lua/luaconf.h
@@ -1,5 +1,6 @@
 #ifndef luaconf_h
 #define luaconf_h
+
 #include "libc/assert.h"
 #include "libc/dce.h"
 #include "libc/fmt/conv.h"
@@ -7,10 +8,10 @@
 #include "libc/limits.h"
 #include "libc/str/unicode.h"
 
-#define LUA_USE_POSIX
-#define LUA_USE_LINENOISE
+// clang-format off
 
-/* clang-format off */
+#define LUA_USE_LINENOISE
+#define LUA_USE_POSIX
 
 /*
 ** ===================================================================

--- a/third_party/lua/lualib.h
+++ b/third_party/lua/lualib.h
@@ -1,8 +1,9 @@
 #ifndef lualib_h
 #define lualib_h
+
 #include "third_party/lua/lua.h"
 
-/* clang-format off */
+// clang-format off
 
 /* version suffix for environment variable names */
 #define LUA_VERSUFFIX          "_" LUA_VERSION_MAJOR "_" LUA_VERSION_MINOR

--- a/third_party/lua/lundump.c
+++ b/third_party/lua/lundump.c
@@ -1,9 +1,30 @@
-/*
-** $Id: lundump.c $
-** load precompiled Lua chunks
-** See Copyright Notice in lua.h
-*/
-
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│vi: set net ft=c ts=2 sts=2 sw=2 fenc=utf-8                                :vi│
+╚──────────────────────────────────────────────────────────────────────────────╝
+│                                                                              │
+│  Lua                                                                         │
+│  Copyright © 2004-2021 Lua.org, PUC-Rio.                                     │
+│                                                                              │
+│  Permission is hereby granted, free of charge, to any person obtaining       │
+│  a copy of this software and associated documentation files (the             │
+│  "Software"), to deal in the Software without restriction, including         │
+│  without limitation the rights to use, copy, modify, merge, publish,         │
+│  distribute, sublicense, and/or sell copies of the Software, and to          │
+│  permit persons to whom the Software is furnished to do so, subject to       │
+│  the following conditions:                                                   │
+│                                                                              │
+│  The above copyright notice and this permission notice shall be              │
+│  included in all copies or substantial portions of the Software.             │
+│                                                                              │
+│  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,             │
+│  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF          │
+│  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.      │
+│  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY        │
+│  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,        │
+│  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE           │
+│  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                      │
+│                                                                              │
+╚─────────────────────────────────────────────────────────────────────────────*/
 #define lundump_c
 #define LUA_CORE
 
@@ -19,7 +40,13 @@
 #include "third_party/lua/lundump.h"
 #include "third_party/lua/lzio.h"
 
-/* clang-format off */
+// clang-format off
+
+asm(".ident\t\"\\n\\n\
+Lua 5.4.3 (MIT License)\\n\
+Copyright 1994–2021 Lua.org, PUC-Rio.\"");
+asm(".include \"libc/disclaimer.inc\"");
+
 
 #if !defined(luai_verifycode)
 #define luai_verifycode(L,f)  /* empty */

--- a/third_party/lua/lundump.h
+++ b/third_party/lua/lundump.h
@@ -1,10 +1,11 @@
 #ifndef lundump_h
 #define lundump_h
+
 #include "third_party/lua/llimits.h"
 #include "third_party/lua/lobject.h"
 #include "third_party/lua/lzio.h"
 
-/* clang-format off */
+// clang-format off
 
 /* data to catch conversion errors */
 #define LUAC_DATA	"\x19\x93\r\n\x1a\n"

--- a/third_party/lua/lutf8lib.c
+++ b/third_party/lua/lutf8lib.c
@@ -1,9 +1,30 @@
-/*
-** $Id: lutf8lib.c $
-** Standard library for UTF-8 manipulation
-** See Copyright Notice in lua.h
-*/
-
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│vi: set net ft=c ts=2 sts=2 sw=2 fenc=utf-8                                :vi│
+╚──────────────────────────────────────────────────────────────────────────────╝
+│                                                                              │
+│  Lua                                                                         │
+│  Copyright © 2004-2021 Lua.org, PUC-Rio.                                     │
+│                                                                              │
+│  Permission is hereby granted, free of charge, to any person obtaining       │
+│  a copy of this software and associated documentation files (the             │
+│  "Software"), to deal in the Software without restriction, including         │
+│  without limitation the rights to use, copy, modify, merge, publish,         │
+│  distribute, sublicense, and/or sell copies of the Software, and to          │
+│  permit persons to whom the Software is furnished to do so, subject to       │
+│  the following conditions:                                                   │
+│                                                                              │
+│  The above copyright notice and this permission notice shall be              │
+│  included in all copies or substantial portions of the Software.             │
+│                                                                              │
+│  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,             │
+│  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF          │
+│  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.      │
+│  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY        │
+│  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,        │
+│  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE           │
+│  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                      │
+│                                                                              │
+╚─────────────────────────────────────────────────────────────────────────────*/
 #define lutf8lib_c
 #define LUA_LIB
 
@@ -12,7 +33,13 @@
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lualib.h"
 
-/* clang-format off */
+// clang-format off
+
+asm(".ident\t\"\\n\\n\
+Lua 5.4.3 (MIT License)\\n\
+Copyright 1994–2021 Lua.org, PUC-Rio.\"");
+asm(".include \"libc/disclaimer.inc\"");
+
 
 #define MAXUNICODE	0x10FFFFu
 

--- a/third_party/lua/lvm.c
+++ b/third_party/lua/lvm.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define lvm_c
 #define LUA_CORE
+
 #include "libc/str/str.h"
 #include "third_party/lua/ldebug.h"
 #include "third_party/lua/ldo.h"
@@ -41,6 +42,7 @@
 #include "third_party/lua/ltm.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lvm.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/lvm.h
+++ b/third_party/lua/lvm.h
@@ -1,10 +1,11 @@
 #ifndef lvm_h
 #define lvm_h
+
 #include "third_party/lua/ldo.h"
 #include "third_party/lua/lobject.h"
 #include "third_party/lua/ltm.h"
 
-/* clang-format off */
+// clang-format off
 
 #if !defined(LUA_NOCVTN2S)
 #define cvt2str(o)	ttisnumber(o)

--- a/third_party/lua/lzio.c
+++ b/third_party/lua/lzio.c
@@ -27,6 +27,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #define lzio_c
 #define LUA_CORE
+
 #include "libc/str/str.h"
 #include "third_party/lua/llimits.h"
 #include "third_party/lua/lmem.h"
@@ -34,6 +35,7 @@
 #include "third_party/lua/lstate.h"
 #include "third_party/lua/lua.h"
 #include "third_party/lua/lzio.h"
+
 // clang-format off
 
 asm(".ident\t\"\\n\\n\

--- a/third_party/lua/lzio.h
+++ b/third_party/lua/lzio.h
@@ -1,16 +1,10 @@
-/*
-** $Id: lzio.h $
-** Buffered streams
-** See Copyright Notice in lua.h
-*/
-
 #ifndef lzio_h
 #define lzio_h
 
 #include "third_party/lua/lmem.h"
 #include "third_party/lua/lua.h"
 
-/* clang-format off */
+// clang-format off
 
 #define EOZ	(-1)			/* end of stream */
 


### PR DESCRIPTION
This prepares the ground for bringing Lua up to 5.4.6. It adds some missing copyrights, removes some overlooked copyrights, makes vertical whitespace consistent across files and adds `[jart]` comments in various places to make subsequent Lua comparisons easier. Well. Hopefully.

In theory, nothing here is controversial.

If we merge this, the 5.4.4 update will be “all signal, no noise.” But the noise level isn’t all that high, so it probably doesn’t matter all that much.