### PR TITLE
fix x-axis blurring in nesemu1 tty conversion

### DIFF
--- a/examples/nesemu1.cc
+++ b/examples/nesemu1.cc
@@ -294,7 +294,7 @@ void GetTermSize(void) {
   tyn_ = wsize_.ws_row * 2;
   txn_ = wsize_.ws_col * 2;
   ssy_ = ComputeSamplingSolution(tyn_, ChopAxis(tyn_, DYN), 0, 0, 2);
-  ssx_ = ComputeSamplingSolution(txn_, ChopAxis(txn_, DXN), 0, 0, 0);
+  ssx_ = ComputeSamplingSolution(txn_, ChopAxis(txn_, DXN), 0, 0, 2);
   R = (unsigned char*)realloc(R, tyn_ * txn_);
   G = (unsigned char*)realloc(G, tyn_ * txn_);
   B = (unsigned char*)realloc(B, tyn_ * txn_);


### PR DESCRIPTION
before this change:
![before](https://github.com/jart/cosmopolitan/assets/41098605/6c9b9e61-be27-4715-a992-8ba37f2270fa)


after this change:
![after](https://github.com/jart/cosmopolitan/assets/41098605/ecf7e500-9630-4c6b-9bb9-bf5494f84f3f)


Screenshots taken while rendering on `kitty` terminal, with the lowest allowed font size.
Aspect ratio is off because I am on fullscreen, here's a square-shaped screenshot after applying this change:

![after2](https://github.com/jart/cosmopolitan/assets/41098605/fcf77403-ecc7-4a58-9f4c-de4614fe4e97)


I am not sure if `2` is the correct value, but it is definitely better than zero, because the value ends up being used in a division.