### PR TITLE
get rsync to build

### DIFF
--- a/libc/isystem/netinet/in.h
+++ b/libc/isystem/netinet/in.h
@@ -24,4 +24,39 @@
 	 && (((const uint32_t *) (a))[2] == ((const uint32_t *) (b))[2])      \
 	 && (((const uint32_t *) (a))[3] == ((const uint32_t *) (b))[3]))
 
+# define IN6_IS_ADDR_UNSPECIFIED(a) \
+	(((const uint32_t *) (a))[0] == 0				      \
+	 && ((const uint32_t *) (a))[1] == 0				      \
+	 && ((const uint32_t *) (a))[2] == 0				      \
+	 && ((const uint32_t *) (a))[3] == 0)
+
+# define IN6_IS_ADDR_LOOPBACK(a) \
+	(((const uint32_t *) (a))[0] == 0				      \
+	 && ((const uint32_t *) (a))[1] == 0				      \
+	 && ((const uint32_t *) (a))[2] == 0				      \
+	 && ((const uint32_t *) (a))[3] == htonl (1))
+
+# define IN6_IS_ADDR_LINKLOCAL(a) \
+	((((const uint32_t *) (a))[0] & htonl (0xffc00000))		      \
+	 == htonl (0xfe800000))
+
+# define IN6_IS_ADDR_SITELOCAL(a) \
+	((((const uint32_t *) (a))[0] & htonl (0xffc00000))		      \
+	 == htonl (0xfec00000))
+
+# define IN6_IS_ADDR_V4MAPPED(a) \
+	((((const uint32_t *) (a))[0] == 0)				      \
+	 && (((const uint32_t *) (a))[1] == 0)				      \
+	 && (((const uint32_t *) (a))[2] == htonl (0xffff)))
+
+# define IN6_IS_ADDR_V4COMPAT(a) \
+	((((const uint32_t *) (a))[0] == 0)				      \
+	 && (((const uint32_t *) (a))[1] == 0)				      \
+	 && (((const uint32_t *) (a))[2] == 0)				      \
+	 && (ntohl (((const uint32_t *) (a))[3]) > 1))
+
+#define IN6_IS_ADDR_MULTICAST(a) (((const uint8_t *) (a))[0] == 0xff)
+
+
+
 #endif /* COSMOPOLITAN_LIBC_ISYSTEM_NETINET_IN_H_ */

--- a/libc/isystem/sys/socket.h
+++ b/libc/isystem/sys/socket.h
@@ -8,7 +8,6 @@
 #include "libc/sock/struct/sockaddr.h"
 #include "libc/sysv/consts/af.h"
 #include "libc/sysv/consts/limits.h"
-#include "libc/sysv/consts/msg.h"
 #include "libc/sysv/consts/pf.h"
 #include "libc/sysv/consts/scm.h"
 #include "libc/sysv/consts/shut.h"


### PR DESCRIPTION
- added some IPV6 comparison macros
- the `MSG_INFO` in `msg.h` clashes with an enum declaration that `rsync` makes