### PR TITLE
ignore trailing slash when sorting zipos entries

### DIFF
--- a/libc/runtime/zipos-get.c
+++ b/libc/runtime/zipos-get.c
@@ -77,10 +77,13 @@ static int __zipos_compare_names(const void *a, const void *b, void *c) {
   struct Zipos *z = (struct Zipos *)c;
   int xn = ZIP_CFILE_NAMESIZE(z->map + *x);
   int yn = ZIP_CFILE_NAMESIZE(z->map + *y);
+  const char *xp = ZIP_CFILE_NAME(z->map + *x);
+  const char *yp = ZIP_CFILE_NAME(z->map + *y);
+  if (xn && xp[xn-1] == '/') --xn;
+  if (yn && yp[yn-1] == '/') --yn;
   int n = MIN(xn, yn);
   if (n) {
-    int res =
-        memcmp(ZIP_CFILE_NAME(z->map + *x), ZIP_CFILE_NAME(z->map + *y), n);
+    int res = memcmp(xp, yp, n);
     if (res) return res;
   }
   return xn - yn;  // xn and yn are 16-bit


### PR DESCRIPTION
before running the binary search in zipos-find.c, the query string is checked for a trailing slash, which if found is ignored during the memcmp as part of the search.

however, '/' (ASCII 47) is after '-' (ASCII 45),  so the sorted array could contain entries like "/zip/x-" followed by "/zip/x/". Now, if the query string is "/zip/x/", the trailing slash will be removed, but then "/zip/x-" will be incorrectly matched, leading to an error.

this change adds a similar check to ignore the trailing slash during the construction of the sorted array to ensure "/zip/x-" occurs after "/zip/x/", and avoid such errors.