### PR TITLE
README: note version zsh and fish were patched to support ape

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ You now have a portable program.
 
 ```sh
 ./hello.com
-bash -c './hello.com'  # zsh/fish workaround (we patched them in 2021)
+bash -c './hello.com'  # older zsh/fish workaround (patched in zsh 5.9 and fish 3.3.0)
 ```
 
 If `./hello.com` executed on Linux throws an error about not finding an


### PR DESCRIPTION
Noting the exact versions should reduce some confusion about why APE doesn't work with the user's shell. I had a coworker trying to run an APE with zsh 5.8.1 and I wasn't sure why it wasn't working as it was released after 2021.

I just sent the CLA for contributions done under by employer Dylibso.