### PR TITLE
changes made for cosmocc builds

### DIFF
--- a/bin/cosmocc
+++ b/bin/cosmocc
@@ -182,7 +182,7 @@ fi
 if [ "$1" = "--update" ]; then
   cd $COSMO || exit
   echo "building cosmo host toolchain..." >&2
-  make --silent -j toolchain MODE= || exit
+  make --silent -j toolchain MODE= ARCH=x86_64 || exit
   echo "building cosmo target (MODE=$MODE) toolchain..." >&2
   make --silent -j toolchain MODE="$MODE" || exit
   echo "setting up your cosmos..." >&2

--- a/libc/integral/c.inc
+++ b/libc/integral/c.inc
@@ -138,9 +138,14 @@ typedef signed __int128 int128_t;
 typedef unsigned __int128 uint128_t;
 #endif
 #endif /* _COSMO_SOURCE */
+
+#ifndef __AXDX_T
+#define __AXDX_T
 typedef struct {
   intptr_t ax, dx;
 } axdx_t;
+#endif
+
 
 #ifndef __chibicc__
 #define va_list            __builtin_va_list

--- a/libc/isystem/sys/socket.h
+++ b/libc/isystem/sys/socket.h
@@ -8,6 +8,7 @@
 #include "libc/sock/struct/sockaddr.h"
 #include "libc/sysv/consts/af.h"
 #include "libc/sysv/consts/limits.h"
+#include "libc/sysv/consts/msg.h"
 #include "libc/sysv/consts/pf.h"
 #include "libc/sysv/consts/scm.h"
 #include "libc/sysv/consts/shut.h"

--- a/libc/isystem/ucontext.h
+++ b/libc/isystem/ucontext.h
@@ -1,0 +1,4 @@
+#ifndef _UCONTEXT_H
+#define _UCONTEXT_H
+#include "libc/calls/ucontext.h"
+#endif

--- a/libc/isystem/unistd.h
+++ b/libc/isystem/unistd.h
@@ -13,4 +13,9 @@
 #include "third_party/getopt/long1.h"
 #include "third_party/musl/crypt.h"
 #include "third_party/musl/lockf.h"
+
+#ifndef _CS_PATH
+#define _CS_PATH 0
+#endif
+
 #endif /* _UNISTD_H */

--- a/libc/thread/semaphore.h
+++ b/libc/thread/semaphore.h
@@ -1,6 +1,7 @@
 #ifndef COSMOPOLITAN_LIBC_CALLS_SEMAPHORE_H_
 #define COSMOPOLITAN_LIBC_CALLS_SEMAPHORE_H_
 #include "libc/calls/struct/timespec.h"
+#include "libc/stdbool.h"
 #if !(__ASSEMBLER__ + __LINKER__ + 0)
 COSMOPOLITAN_C_START_
 


### PR DESCRIPTION
these changes are from attempting builds via

https://github.com/ahgamut/superconfigure

- I had submitted a previous PR where I had removed msg.h from sys/socket.h, turns out OpenSSL needs msg.h in sys/socket.h
- libc/thread/semaphore.h uses booleans, so including stdbool.h
- the ifdef around axdx_t is from the gcc build system including CFLAGS twice (when building with the intermediate xgcc)
- specifying ARCH=x86_64 in cosmocc when building with the host toolchain