### PR TITLE
Allow redbean to accept --assimilate option without complaining

### DIFF
--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -7348,6 +7348,9 @@ static void GetOpts(int argc, char *argv[]) {
 void RedBean(int argc, char *argv[]) {
   char ibuf[21];
   int fd;
+  // don't complain about --assimilate if it's the only parameter,
+  // as it can only get here if it's already native or assimilated
+  if (argc == 2 && strcmp(argv[1], "--assimilate") == 0) return;
   if (IsLinux()) {
     // disable weird linux capabilities
     for (int e = errno, i = 0;; ++i) {


### PR DESCRIPTION
This allows using --assimilate on Windows or already assimilated binary. Ref #356.