### PR TITLE
Invoke cocmd.com as a shell script when necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,15 @@
 #
 #   build/config.mk
 
+# Some versions of make can't invoke the bundled
+# cocmd.com directly. If we can invoke it, use it
+# directly as the shell. Otherwise, invoke it as a
+# shell script to work around this.
+ifeq ($((build/bootstrap/cocmd.com)),build/bootstrap/cocmd.com: error: wrong number of args)
 SHELL      = build/bootstrap/cocmd.com
+else
+.SHELLFLAGS = build/bootstrap/cocmd.com -c
+endif
 MAKEFLAGS += --no-builtin-rules
 
 .SUFFIXES:


### PR DESCRIPTION
When I tried installing cosmopolitan following the getting started directions in the README, I got the following error:

```
cosmo ) cosmocc --update
building cosmo host toolchain...
make: build/bootstrap/cocmd.com: No such file or directory
make: build/bootstrap/cocmd.com: No such file or directory
Makefile:88: *** you need to download https://justine.lol/cosmocc-0.0.16.zip and unzip it inside the cosmo directory.  Stop.
```

Upon further investigation, this turned out to be because my version of make (4.4.1 on NixOS) couldn't correctly invoke build/bootstrap/cocmd.com, even though my shell could with no issue.

I tried a few different remedies, but the one which seemed least disruptive was to improve the Makefile so that it invokes cocmd.com as a shell script instead of a binary when invoking it as a binary does not work.