### PR TITLE
Fix stack alignment and auxv for APE loader on macOS

### DIFF
--- a/ape/loader.c
+++ b/ape/loader.c
@@ -947,6 +947,11 @@ EXTERN_C __attribute__((__noreturn__)) void ApeLoader(long di, long *sp,
     os = OPENBSD;
   }
 
+  /* xnu passes auxv as an array of strings */
+  if (os == XNU) {
+    *auxv = 0;
+  }
+
   /* detect netbsd and find end of words */
   pagesz = 0;
   for (ap = auxv; ap[0]; ap += 2) {

--- a/ape/start.S
+++ b/ape/start.S
@@ -23,6 +23,7 @@
 #ifdef __aarch64__
 
 _start:	mov	x1,sp
+	and     sp,x1,#-16
 	mov	x29,0
 	bl	ApeLoader
 	.endfn	_start,globl
@@ -33,6 +34,7 @@ XnuEntrypoint:
 	mov	$_HOSTXNU,%dl			// xnu's not unix!
 ElfEntrypoint:
 	mov	%rsp,%rsi			// save real stack
+	andq    $-16,%rsp                       // force SSE alignment
 	call	ApeLoader
 	.endfn	ElfEntrypoint,globl
 	.endfn	XnuEntrypoint,globl


### PR DESCRIPTION
Hi @jart,

Through extensive testing on another project, I have found that the Cosmopolitan APE loader sometimes crashes with SIGSEGV on x86_64 macOS for two reasons: 1) the startup stack pointer isn't automatically aligned by the kernel (it varies based on passed argv/envp strings), and 2) the macOS auxv vector isn't ELF compatible; they're passed as a pointer array similar to `char **environ`, rather than an ELF-compatible twin-pointer array. Depending on the arguments passed to the loader, the stack misalignment can cause a crash very early in startup.S when calling the loader entry point `ApeLoader`, or later, when the aux vector is assumed to be ELF-compatible.

These fixes (with the exception of the ARM64 startup) have been tested on macOS Mojave and Catalina using the loader in another project. I am unable to test on the latest Cosmopolitan tree, as `build/bootstrap/make.com` immediately segfaults, the reason for which is almost assuredly this same problem. After this fix is incorporated and make.com updated, I will test the Cosmopolitan build and report further.

Thank you!

