### PR TITLE
Close Lua state before exiting redbean worker to allow GC to collect

### DIFF
--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -6556,6 +6556,7 @@ static int ExitWorker(void) {
       monitorth = 0;
     }
   }
+  LuaDestroy();
   _Exit(0);
 }
 


### PR DESCRIPTION
@jart, this is a small patch to destroy the Lua state and allow Lua GC handlers to be called before workers exit. The only other way to get close to this is to call `os.exit(true, true)` from `OnWorkerStop`, but obviously it's not ideal, as it exits the process a bit too early not allowing redbean to finish its work.