### PR TITLE
ape: Fix uname -m redirection

### DIFF
--- a/ape/ape.S
+++ b/ape/ape.S
@@ -592,7 +592,7 @@ ape_disk:
 
 #ifdef APE_IS_SHELL_SCRIPT
 apesh:	.ascii	"\n@\n#'\"\n"			// sixth edition shebang
-	.ascii	"m=\"$(/bin/uname -m >/dev/null)\" || "
+	.ascii	"m=\"$(/bin/uname -m 2>/dev/null)\" || "
 	.ascii	"m=\"$(/usr/bin/uname -m)\"\n"
 
 	.ascii	"if [ \"$m\" = x86_64 ] || [ \"$m\" = amd64 ]; then\n"


### PR DESCRIPTION
This was leading to errors like

    .../tool/build/fixupobj.com: this ape binary lacks  support
