### PR TITLE
Fix session changeset procesing (reverting some of 0d748ad5 changes)

### DIFF
--- a/tool/net/lsqlite3.c
+++ b/tool/net/lsqlite3.c
@@ -2312,7 +2312,7 @@ static int db_concat_changeset(lua_State *L) {
     int rc = sqlite3changegroup_new(&pGrp);
     for (int i = 1; rc == SQLITE_OK && i <= n; i++) {
         lua_rawgeti(L, 2, i);
-        cset = gc(strdup(lua_tostring(L, -1)));
+        cset = (void *)lua_tostring(L, -1);
         nset = lua_rawlen(L, -1);
         rc = sqlite3changegroup_add(pGrp, nset, cset);
         lua_pop(L, 1);  // pop the string
@@ -2328,7 +2328,7 @@ static int db_concat_changeset(lua_State *L) {
 
 static int db_apply_changeset(lua_State *L) {
     sdb *db = lsqlite_checkdb(L, 1);
-    char *cset = gc(strdup(luaL_checkstring(L, 2)));
+    void *cset = (void *)luaL_checkstring(L, 2);
     int nset = lua_rawlen(L, 2);
     int top = lua_gettop(L);
     int rc;


### PR DESCRIPTION
This removes strdup from Lua SQLite wrapper, as it's applied to binary changeset strings, thus cutting them short (because of strlen). It also doesn't need strdup in that context, as lua strings should be anchored as long as their values are in the stack (and in this case they should be until the function completes).