### PR TITLE
Make test/libc/calls/pledge_test.c work with "nonstandard" umask

### DIFF
--- a/test/libc/calls/pledge_test.c
+++ b/test/libc/calls/pledge_test.c
@@ -493,10 +493,12 @@ TEST(pledge, open_cpath) {
   ASSERT_SYS(0, 0, touch("foo", 0644));
   ASSERT_NE(-1, (pid = fork()));
   if (!pid) {
+    unsigned omask = umask(022);
     ASSERT_SYS(0, 0, pledge("stdio cpath", 0));
     ASSERT_SYS(0, 3, open("foo", O_WRONLY | O_TRUNC | O_CREAT, 0644));
     ASSERT_SYS(0, 0, fstat(3, &st));
     ASSERT_EQ(0100644, st.st_mode);
+    umask(omask);
     // make sure open() can't apply the setuid bit
     ASSERT_SYS(EPERM, -1, open("bar", O_WRONLY | O_TRUNC | O_CREAT, 04644));
     _Exit(0);


### PR DESCRIPTION
The test was failing if the process's umask happened to be `0077`, for example.  The file `foo` was then created with a file mode of `0100600`, rather than the expected `0100644`.