### PR TITLE
Fix regression when building deathstar.com for aarch64

### DIFF
--- a/tool/viz/deathstar.c
+++ b/tool/viz/deathstar.c
@@ -15,8 +15,10 @@
 #define FRAMERATE 23.976
 #define WRITE(s)  write(1, s, strlen(s))
 
+#ifdef __x86_64__
 __static_yoink("vga_console");
 __static_yoink("EfiMain");
+#endif
 
 struct Sphere {
   double cx, cy, cz, r;


### PR DESCRIPTION
It turns out my earlier commit ddc08dc974 caused a build with `MODE=aarch64` to fail.  The commit changed `deathstar.c` to link in code to support a VGA console, but this is not implemented yet for AArch64.  Thanks to @ahgamut for spotting this issue.