### PR TITLE
Implement __zipos_dup

### DIFF
--- a/libc/calls/close-nt.c
+++ b/libc/calls/close-nt.c
@@ -24,6 +24,7 @@
 #include "libc/nt/enum/filetype.h"
 #include "libc/nt/files.h"
 #include "libc/nt/runtime.h"
+#include "libc/runtime/zipos.internal.h"
 #include "libc/sock/syscall_fd.internal.h"
 #include "libc/sysv/consts/o.h"
 #include "libc/sysv/errfuns.h"
@@ -32,6 +33,8 @@ textwindows int sys_close_nt(int fd, int fildes) {
   if (fd + 0u >= g_fds.n) return ebadf();
   struct Fd *f = g_fds.p + fd;
   switch (f->kind) {
+    case kFdZip:
+      return _weaken(__zipos_close)(fd);
     case kFdEmpty:
       return ebadf();
     case kFdFile:

--- a/libc/calls/dup-nt.c
+++ b/libc/calls/dup-nt.c
@@ -59,30 +59,34 @@ static textwindows int sys_dup_nt_impl(int oldfd, int newfd, int flags,
       return -1;
     }
     if (g_fds.p[newfd].kind) {
-      if (g_fds.p[newfd].kind == kFdZip) {
-        _weaken(__zipos_close)(newfd);
-      } else {
-        sys_close_nt(newfd, newfd);
-      }
+      sys_close_nt(newfd, newfd);
     }
   }
 
-  if (DuplicateHandle(GetCurrentProcess(), g_fds.p[oldfd].handle,
-                      GetCurrentProcess(), &handle, 0, true,
-                      kNtDuplicateSameAccess)) {
-    g_fds.p[newfd] = g_fds.p[oldfd];
-    g_fds.p[newfd].handle = handle;
-    if (flags & _O_CLOEXEC) {
-      g_fds.p[newfd].flags |= _O_CLOEXEC;
-    } else {
-      g_fds.p[newfd].flags &= ~_O_CLOEXEC;
-    }
+  if (__isfdkind(oldfd, kFdZip)) {
+    handle = (intptr_t)_weaken(__zipos_keep)(
+        (struct ZiposHandle *)(intptr_t)g_fds.p[oldfd].handle);
     rc = newfd;
   } else {
-    __releasefd(newfd);
-    rc = __winerr();
+    if (DuplicateHandle(GetCurrentProcess(), g_fds.p[oldfd].handle,
+                        GetCurrentProcess(), &handle, 0, true,
+                        kNtDuplicateSameAccess)) {
+      rc = newfd;
+    } else {
+      rc = __winerr();
+      __releasefd(newfd);
+      __fds_unlock();
+      return rc;
+    }
   }
 
+  g_fds.p[newfd] = g_fds.p[oldfd];
+  g_fds.p[newfd].handle = handle;
+  if (flags & _O_CLOEXEC) {
+    g_fds.p[newfd].flags |= _O_CLOEXEC;
+  } else {
+    g_fds.p[newfd].flags &= ~_O_CLOEXEC;
+  }
   __fds_unlock();
   return rc;
 }

--- a/libc/calls/fcntl.c
+++ b/libc/calls/fcntl.c
@@ -28,6 +28,7 @@
 #include "libc/intrin/strace.internal.h"
 #include "libc/intrin/weaken.h"
 #include "libc/runtime/zipos.internal.h"
+#include "libc/str/str.h"
 #include "libc/sysv/consts/f.h"
 #include "libc/sysv/errfuns.h"
 
@@ -125,6 +126,10 @@ int fcntl(int fd, int cmd, ...) {
           END_CANCELATION_POINT;
         } else {
           rc = sys_fcntl(fd, cmd, arg, __sys_fcntl);
+          if (rc != -1 && (cmd == F_DUPFD || cmd == F_DUPFD_CLOEXEC) &&
+              __isfdkind(rc, kFdZip)) {
+            _weaken(__zipos_postdup)(fd, rc);
+          }
         }
       } else {
         rc = sys_fcntl_nt(fd, cmd, arg);

--- a/libc/calls/fcntl.c
+++ b/libc/calls/fcntl.c
@@ -28,7 +28,6 @@
 #include "libc/intrin/strace.internal.h"
 #include "libc/intrin/weaken.h"
 #include "libc/runtime/zipos.internal.h"
-#include "libc/str/str.h"
 #include "libc/sysv/consts/f.h"
 #include "libc/sysv/errfuns.h"
 
@@ -126,10 +125,6 @@ int fcntl(int fd, int cmd, ...) {
           END_CANCELATION_POINT;
         } else {
           rc = sys_fcntl(fd, cmd, arg, __sys_fcntl);
-          if (rc != -1 && (cmd == F_DUPFD || cmd == F_DUPFD_CLOEXEC) &&
-              __isfdkind(rc, kFdZip)) {
-            _weaken(__zipos_postdup)(fd, rc);
-          }
         }
       } else {
         rc = sys_fcntl_nt(fd, cmd, arg);

--- a/libc/runtime/zipos.S
+++ b/libc/runtime/zipos.S
@@ -33,6 +33,9 @@
 	.yoink	__zipos_stat
 	.yoink	__zipos_notat
 	.yoink	__zipos_mmap
+	.yoink  __zipos_postdup
+	.yoink  __zipos_keep
+	.yoink  __zipos_free
 
 //	TODO(jart): why does corruption happen when zip has no assets?
 	.yoink	.cosmo

--- a/libc/runtime/zipos.internal.h
+++ b/libc/runtime/zipos.internal.h
@@ -20,8 +20,9 @@ struct ZiposHandle {
   struct Zipos *zipos;
   size_t size;
   size_t mapsize;
-  size_t pos;
   size_t cfile;
+  _Atomic(int) refs;
+  size_t pos;         // TODO atomic
   uint8_t *mem;
   uint8_t data[];
 };
@@ -38,6 +39,7 @@ struct Zipos {
 
 int __zipos_close(int);
 void __zipos_free(struct ZiposHandle *);
+struct ZiposHandle *__zipos_keep(struct ZiposHandle *);
 struct Zipos *__zipos_get(void) pureconst;
 size_t __zipos_normpath(char *, const char *, size_t);
 ssize_t __zipos_find(struct Zipos *, struct ZiposUri *);
@@ -45,6 +47,7 @@ ssize_t __zipos_scan(struct Zipos *, struct ZiposUri *);
 ssize_t __zipos_parseuri(const char *, struct ZiposUri *);
 uint64_t __zipos_inode(struct Zipos *, int64_t, const void *, size_t);
 int __zipos_open(struct ZiposUri *, int);
+void __zipos_postdup(int, int);
 int __zipos_access(struct ZiposUri *, int);
 int __zipos_stat(struct ZiposUri *, struct stat *);
 int __zipos_fstat(struct ZiposHandle *, struct stat *);

--- a/test/libc/calls/dup_test.c
+++ b/test/libc/calls/dup_test.c
@@ -75,13 +75,22 @@ TEST(dup, bigNumber) {
   ASSERT_SYS(0, 0, close(100));
 }
 
-TEST(dup2, zipos) {
+TEST(dup2, ziposdest) {
   ASSERT_SYS(0, 3, creat("real", 0644));
   ASSERT_SYS(0, 4, open("/zip/libc/testlib/hyperion.txt", O_RDONLY));
   ASSERT_SYS(0, 2, write(3, "hi", 2));
   ASSERT_SYS(EBADF, -1, write(4, "hi", 2));
   ASSERT_SYS(0, 4, dup2(3, 4));
   ASSERT_SYS(0, 2, write(4, "hi", 2));
+  ASSERT_SYS(0, 0, close(4));
+  ASSERT_SYS(0, 0, close(3));
+}
+
+TEST(dup2, zipossrc) {
+  char b[8];
+  ASSERT_SYS(0, 3, open("/zip/libc/testlib/hyperion.txt", O_RDONLY));
+  ASSERT_SYS(0, 4, dup2(3, 4));
+  ASSERT_SYS(0, 8, read(4, b, 8));
   ASSERT_SYS(0, 0, close(4));
   ASSERT_SYS(0, 0, close(3));
 }

--- a/test/libc/calls/fcntl_test.c
+++ b/test/libc/calls/fcntl_test.c
@@ -32,6 +32,9 @@
 #include "libc/thread/thread.h"
 #include "libc/x/x.h"
 
+__static_yoink("libc/testlib/hyperion.txt");
+__static_yoink("zipos");
+
 int Lock(int fd, int type, long start, long len) {
   int e;
   struct flock lock = {
@@ -119,6 +122,17 @@ TEST(fcntl, F_DUPFD_CLOEXEC) {
   ASSERT_SYS(0, FD_CLOEXEC, fcntl(5, F_GETFD));
   ASSERT_SYS(0, 0, close(5));
   ASSERT_SYS(0, 0, close(3));
+}
+
+TEST(fcntl, ziposDupFd) {
+  char b[8];
+  ASSERT_SYS(0, 3, open("/zip/libc/testlib/hyperion.txt", O_RDONLY));
+  ASSERT_SYS(0, 4, fcntl(3, F_DUPFD, 4));
+  ASSERT_SYS(0, 8, read(3, b, 8));
+  ASSERT_SYS(0, 0, lseek(4, 0, SEEK_SET));
+  ASSERT_SYS(0, 8, read(4, b, 8));
+  ASSERT_SYS(0, 0, close(3));
+  ASSERT_SYS(0, 0, close(4));
 }
 
 void OnSig(int sig) {


### PR DESCRIPTION
Makes ZiposHandle reference-counted by an `rc` field in a union with its
freelist `next` pointer. The functions `__zipos_free` and `__zipos_keep`
function as incref/decref for it. Adds `__zipos_postdup` to fix metadata
on file descriptors after dup-like operations, and adds zipos support to
`sys_dup_nt` + `sys_close_nt`.