### PR TITLE
Move `tcgetpgrp` and `tcsetpgrp` decls to `unistd.h` (#996)

### DIFF
--- a/libc/calls/calls.h
+++ b/libc/calls/calls.h
@@ -163,6 +163,8 @@ int sigignore(int);
 int siginterrupt(int, int);
 int symlink(const char *, const char *);
 int symlinkat(const char *, int, const char *);
+int tcgetpgrp(int);
+int tcsetpgrp(int, int);
 int truncate(const char *, int64_t);
 int ttyname_r(int, char *, size_t);
 int unlink(const char *);

--- a/libc/calls/termios.h
+++ b/libc/calls/termios.h
@@ -24,11 +24,9 @@ int posix_openpt(int) __wur;
 
 int tcdrain(int);
 int tcgetsid(int);
-int tcgetpgrp(int);
 int tcflow(int, int);
 int tcflush(int, int);
 int tcsetsid(int, int);
-int tcsetpgrp(int, int);
 int tcsendbreak(int, int);
 void cfmakeraw(struct termios *);
 int cfsetspeed(struct termios *, uint32_t);


### PR DESCRIPTION
Fixes issue #996.