### PR TITLE
fix path handling in bind/connect

### DIFF
--- a/libc/calls/mkntpath.c
+++ b/libc/calls/mkntpath.c
@@ -94,6 +94,7 @@ textwindows int __mkntsunpath(
     p[1] = ':';
     p[2] = '\\';
     p += 3;
+    q += 3;
     n = 3;
   } else if (IsSlash(q[0]) && q[1] == 't' && q[2] == 'm' && q[3] == 'p' &&
              (IsSlash(q[4]) || !q[4])) {

--- a/libc/calls/mkntpath.c
+++ b/libc/calls/mkntpath.c
@@ -78,7 +78,7 @@ textwindows size_t __normntpath(char16_t *p, size_t n) {
  * @return short count excluding NUL on success, or -1 w/ errno
  * @error ENAMETOOLONG
  */
-textwindows int __mkwin32_sun_path(
+textwindows int __mkntsunpath(
     const char *path, char sun_path[hasatleast kNtUnixSocketNameMax]) {
   // 1. Need +1 for NUL-terminator
   if (!path || (IsAsan() && !__asan_is_valid_str(path))) {

--- a/libc/calls/mkntpath.c
+++ b/libc/calls/mkntpath.c
@@ -79,12 +79,12 @@ textwindows size_t __normntpath(char16_t *p, size_t n) {
  * @error ENAMETOOLONG
  */
 textwindows int __mkwin32_sun_path(
-    const char *path, char sun_path[hasatleast UNIX_SOCKET_NAME_MAX]) {
+    const char *path, char sun_path[hasatleast kNtUnixSocketNameMax]) {
   // 1. Need +1 for NUL-terminator
   if (!path || (IsAsan() && !__asan_is_valid_str(path))) {
     return efault();
   }
-  char16_t tmp_path[UNIX_SOCKET_NAME_MAX];
+  char16_t tmp_path[kNtUnixSocketNameMax];
   char *p = sun_path;
   const char *q = path;
   size_t n = 0;
@@ -98,15 +98,15 @@ textwindows int __mkwin32_sun_path(
   } else if (IsSlash(q[0]) && q[1] == 't' && q[2] == 'm' && q[3] == 'p' &&
              (IsSlash(q[4]) || !q[4])) {
     if (!q[4] || !q[5]) return efault();
-    GetTempPath(UNIX_SOCKET_NAME_MAX, tmp_path);
-    n = tprecode16to8(p, UNIX_SOCKET_NAME_MAX, tmp_path).ax;
+    GetTempPath(kNtUnixSocketNameMax, tmp_path);
+    n = tprecode16to8(p, kNtUnixSocketNameMax, tmp_path).ax;
     p += n;
     q += 5;
   }
-  for (; n < UNIX_SOCKET_NAME_MAX; n++) {
+  for (; n < kNtUnixSocketNameMax; n++) {
     if (!(*p++ = *q++)) break;
   }
-  if (n == UNIX_SOCKET_NAME_MAX) {
+  if (n == kNtUnixSocketNameMax) {
     return efault();
   }
   return n;

--- a/libc/calls/syscall_support-nt.internal.h
+++ b/libc/calls/syscall_support-nt.internal.h
@@ -4,12 +4,15 @@
 #include "libc/nt/struct/overlapped.h"
 COSMOPOLITAN_C_START_
 
+#define UNIX_SOCKET_NAME_MAX 108
+
 bool isdirectory_nt(const char *);
 bool isregularfile_nt(const char *);
 bool issymlink_nt(const char *);
 bool32 ntsetprivilege(int64_t, const char16_t *, uint32_t);
 char16_t *__create_pipe_name(char16_t *);
 size_t __normntpath(char16_t *, size_t);
+int __mkwin32_sun_path(const char *, char[hasatleast UNIX_SOCKET_NAME_MAX]);
 int __mkntpath(const char *, char16_t[hasatleast PATH_MAX]);
 int __mkntpath2(const char *, char16_t[hasatleast PATH_MAX], int);
 int __mkntpathath(int64_t, const char *, int, char16_t[hasatleast PATH_MAX]);

--- a/libc/calls/syscall_support-nt.internal.h
+++ b/libc/calls/syscall_support-nt.internal.h
@@ -4,7 +4,7 @@
 #include "libc/nt/struct/overlapped.h"
 COSMOPOLITAN_C_START_
 
-#define UNIX_SOCKET_NAME_MAX 108
+#define kNtUnixSocketNameMax 108
 
 bool isdirectory_nt(const char *);
 bool isregularfile_nt(const char *);
@@ -12,7 +12,7 @@ bool issymlink_nt(const char *);
 bool32 ntsetprivilege(int64_t, const char16_t *, uint32_t);
 char16_t *__create_pipe_name(char16_t *);
 size_t __normntpath(char16_t *, size_t);
-int __mkwin32_sun_path(const char *, char[hasatleast UNIX_SOCKET_NAME_MAX]);
+int __mkwin32_sun_path(const char *, char[hasatleast kNtUnixSocketNameMax]);
 int __mkntpath(const char *, char16_t[hasatleast PATH_MAX]);
 int __mkntpath2(const char *, char16_t[hasatleast PATH_MAX], int);
 int __mkntpathath(int64_t, const char *, int, char16_t[hasatleast PATH_MAX]);

--- a/libc/calls/syscall_support-nt.internal.h
+++ b/libc/calls/syscall_support-nt.internal.h
@@ -12,7 +12,7 @@ bool issymlink_nt(const char *);
 bool32 ntsetprivilege(int64_t, const char16_t *, uint32_t);
 char16_t *__create_pipe_name(char16_t *);
 size_t __normntpath(char16_t *, size_t);
-int __mkwin32_sun_path(const char *, char[hasatleast kNtUnixSocketNameMax]);
+int __mkntsunpath(const char *, char[hasatleast kNtUnixSocketNameMax]);
 int __mkntpath(const char *, char16_t[hasatleast PATH_MAX]);
 int __mkntpath2(const char *, char16_t[hasatleast PATH_MAX], int);
 int __mkntpathath(int64_t, const char *, int, char16_t[hasatleast PATH_MAX]);

--- a/libc/sock/bind-nt.c
+++ b/libc/sock/bind-nt.c
@@ -27,12 +27,9 @@
 __msabi extern typeof(__sys_bind_nt) *const __imp_bind;
 
 textwindows int sys_bind_nt(struct Fd *f, const void *addr, uint32_t addrsize) {
-  struct sockaddr_un *sun, nt_sun;
-  if (f->family == AF_UNIX && ((struct sockaddr *)addr)->sa_family == AF_UNIX &&
-      addrsize >= sizeof(struct sockaddr_un)) {
-    sun = (struct sockaddr_un *)addr;
-    nt_sun.sun_family = AF_UNIX;
-    if (__mkntsunpath(sun->sun_path, nt_sun.sun_path) == -1) return -1;
+  struct sockaddr_un nt_sun;
+  if (f->family == AF_UNIX) {
+    if (__convert_sockaddr_un_to_nt(&nt_sun, addr, addrsize) == -1) return -1;
     addr = &nt_sun;
   }
   if (__imp_bind(f->handle, addr, addrsize) != -1) {

--- a/libc/sock/bind-nt.c
+++ b/libc/sock/bind-nt.c
@@ -32,7 +32,7 @@ textwindows int sys_bind_nt(struct Fd *f, const void *addr, uint32_t addrsize) {
       addrsize >= sizeof(struct sockaddr_un)) {
     sun = (struct sockaddr_un *)addr;
     nt_sun.sun_family = AF_UNIX;
-    if (__mkwin32_sun_path(sun->sun_path, nt_sun.sun_path) == -1) return -1;
+    if (__mkntsunpath(sun->sun_path, nt_sun.sun_path) == -1) return -1;
     addr = &nt_sun;
   }
   if (__imp_bind(f->handle, addr, addrsize) != -1) {

--- a/libc/sock/connect-nt.c
+++ b/libc/sock/connect-nt.c
@@ -147,7 +147,7 @@ textwindows int sys_connect_nt(struct Fd *f, const void *addr,
       addrsize >= sizeof(struct sockaddr_un)) {
     sun = (struct sockaddr_un *)addr;
     nt_sun.sun_family = AF_UNIX;
-    if (__mkwin32_sun_path(sun->sun_path, nt_sun.sun_path) == -1) return -1;
+    if (__mkntsunpath(sun->sun_path, nt_sun.sun_path) == -1) return -1;
     addr = &nt_sun;
   }
   sigset_t mask = __sig_block();

--- a/libc/sock/connect-nt.c
+++ b/libc/sock/connect-nt.c
@@ -142,12 +142,9 @@ static textwindows int sys_connect_nt_impl(struct Fd *f, const void *addr,
 
 textwindows int sys_connect_nt(struct Fd *f, const void *addr,
                                uint32_t addrsize) {
-  struct sockaddr_un *sun, nt_sun;
-  if (f->family == AF_UNIX && ((struct sockaddr *)addr)->sa_family == AF_UNIX &&
-      addrsize >= sizeof(struct sockaddr_un)) {
-    sun = (struct sockaddr_un *)addr;
-    nt_sun.sun_family = AF_UNIX;
-    if (__mkntsunpath(sun->sun_path, nt_sun.sun_path) == -1) return -1;
+  struct sockaddr_un nt_sun;
+  if (f->family == AF_UNIX) {
+    if (__convert_sockaddr_un_to_nt(&nt_sun, addr, addrsize) == -1) return -1;
     addr = &nt_sun;
   }
   sigset_t mask = __sig_block();

--- a/libc/sock/struct/sockaddr.internal.h
+++ b/libc/sock/struct/sockaddr.internal.h
@@ -45,6 +45,7 @@ const char *DescribeSockaddr(char[128], const struct sockaddr *, size_t);
 
 void __convert_bsd_to_sockaddr(struct sockaddr_storage *);
 void __convert_sockaddr_to_bsd(struct sockaddr_storage *);
+int __convert_sockaddr_un_to_nt(struct sockaddr_un *, const void *, uint32_t);
 uint8_t __get_sockaddr_len(const struct sockaddr_storage *);
 void __write_sockaddr(const struct sockaddr_storage *, void *, uint32_t *);
 

--- a/test/libc/sock/unix_test.c
+++ b/test/libc/sock/unix_test.c
@@ -123,7 +123,6 @@ TEST(unix, stream_absolute) {
   int ws;
   if (IsWindows() && !IsAtLeastWindows10()) return;
   atomic_bool *ready = _mapshared(1);
-  // TODO(jart): move this line down when kFdProcess is gone
   ASSERT_SYS(0, 3, socket(AF_UNIX, SOCK_STREAM, 0));
   if (!fork()) {
     close(3);


### PR DESCRIPTION
fix #1000
I didn't patch the getsockname for unix socket, so it would be win32 path instead of unix path, I don't think anyone really cares about the sockname of a unix socket...