### PR TITLE
Fix the build on Apple Silicon

### DIFF
--- a/third_party/bash/builtins_printf.c
+++ b/third_party/bash/builtins_printf.c
@@ -193,6 +193,14 @@ static intmax_t tw;
 static char *conv_buf;
 static size_t conv_bufsize;
 
+#ifdef __aarch64__
+#define _COSMO_SOURCE
+#include "libc/assert.h"
+void __floatditf(int a) {   // XXX TODO FIXME missing symbol not found in source
+  npassert(false);
+}
+#endif /* __arch64__ */
+
 int
 printf_builtin (list)
      WORD_LIST *list;


### PR DESCRIPTION
Build was broken by third_party/bash due to `__floatditf` not being found, even though `rg __floatditf` shows no results other than its definition.

I don't know if __aarch64__ is the right check, but hopefully this commit will be short-lived.