### PR TITLE
Fix indentation, make llvm happy

### DIFF
--- a/libc/calls/getprogramexecutablename.greg.c
+++ b/libc/calls/getprogramexecutablename.greg.c
@@ -58,8 +58,8 @@ static inline int AllNumDot(const char *s) {
       case 0:   return 1;
       case '0': case '1': case '2': case '3': case '4':
       case '5': case '6': case '7': case '8': case '9': case '.':
-        /* continue */
-      }
+        ; /* continue */
+    }
   }
 }
 


### PR DESCRIPTION
clang says "label at end of switch statement is a C2x extension."