### PR TITLE
Fix buffer overflow in TryPath

### DIFF
--- a/libc/calls/getprogramexecutablename.greg.c
+++ b/libc/calls/getprogramexecutablename.greg.c
@@ -98,6 +98,7 @@ static int TryPath(const char *q, int com) {
   }
   *p = 0;
   if (!sys_faccessat(AT_FDCWD, g_prog.u.buf, F_OK, 0)) return 1;
+  if (!com) return 0;
   p = WRITE32LE(p, READ32LE(".com"));
   *p = 0;
   if (!sys_faccessat(AT_FDCWD, g_prog.u.buf, F_OK, 0)) return 1;


### PR DESCRIPTION
Missed this when changing the code back to be like the old version. com is now a parameter.

The only plausible way to trigger this would be to pass a loader pathname close to MAX_PATH characters long, and then remove that path prior to the first sys_faccessat.