### PR TITLE
Reorder Launch arguments, pass aarch64 os

### DIFF
--- a/ape/ape-m1.c
+++ b/ape/ape-m1.c
@@ -726,10 +726,10 @@ __attribute__((__noreturn__)) static void Spawn(const char *exe, int fd,
 
   register long *x0 __asm__("x0") = sp;
   register char *x2 __asm__("x2") = path;
+  register int   x3 __asm__("x3") = 8;  /* _HOSTXNU */
   register struct Syslib *x15 __asm__("x15") = lib;
   register long x16 __asm__("x16") = e->e_entry;
   __asm__ volatile("mov\tx1,#0\n\t"
-                   "mov\tx3,#0\n\t"
                    "mov\tx4,#0\n\t"
                    "mov\tx5,#0\n\t"
                    "mov\tx6,#0\n\t"
@@ -758,7 +758,7 @@ __attribute__((__noreturn__)) static void Spawn(const char *exe, int fd,
                    "mov\tx0,#0\n\t"
                    "br\tx16"
                    : /* no outputs */
-                   : "r"(x0), "r"(x2), "r"(x15), "r"(x16)
+                   : "r"(x0), "r"(x2), "r"(x3), "r"(x15), "r"(x16)
                    : "memory");
   __builtin_unreachable();
 }

--- a/ape/launch.S
+++ b/ape/launch.S
@@ -32,15 +32,15 @@
 //	@param	rdi is passed through as-is
 //	@param	rsi is address of entrypoint (becomes zero)
 //	@param	rdx is passed through as-is
-//	@param	rcx is stack pointer (becomes r8)
+//	@param	rcx is passed through as-is
+//	@param	r8  is stack pointer (becomes zero)
 //	@noreturn
 Launch:
 #ifdef __aarch64__
 
 	mov	x16,x1
-	mov	sp,x3
+	mov	sp,x4
 	mov	x1,0
-	mov	x3,x4
 	mov	x4,0
 	mov	x5,0
 	mov	x6,0
@@ -70,8 +70,7 @@ Launch:
 
 #else
 
-	mov	%rcx,%rsp
-	mov	%r8,%rcx
+	mov	%r8,%rsp
 	xor	%r8d,%r8d
 	xor	%r9d,%r9d
 	xor	%r10d,%r10d

--- a/ape/loader.c
+++ b/ape/loader.c
@@ -225,7 +225,7 @@ struct ApeLoader {
 
 EXTERN_C long SystemCall(long, long, long, long, long, long, long, int);
 EXTERN_C void
-Launch(void *, long, void *, void *, int) __attribute__((__noreturn__));
+Launch(void *, long, void *, int, void *) __attribute__((__noreturn__));
 
 extern char __executable_start[];
 extern char _end[];
@@ -768,7 +768,7 @@ __attribute__((__noreturn__)) static void Spawn(int os, char *exe, int fd,
   Msyscall(dynbase + code, codesize, os);
 
   /* call program entrypoint */
-  Launch(IsFreebsd() ? sp : 0, dynbase + e->e_entry, exe, sp, os);
+  Launch(IsFreebsd() ? sp : 0, dynbase + e->e_entry, exe, os, sp);
 }
 
 static const char *TryElf(struct ApeLoader *M, union ElfEhdrBuf *ebuf,

--- a/libc/crt/crt.S
+++ b/libc/crt/crt.S
@@ -143,6 +143,7 @@ _start:
 	mov	x1,x15
 
 //	third arg (x2) is the program path passed by ape-m1.c
+//	fourth arg (x3) is os
 
 //	switch to c code
 	bl	cosmo


### PR DESCRIPTION
Third and fourth arguments are now identical between cosmo and Launch.
By passing sp as argument 4, we save a bit of register juggling.

Fourth argument (os) is now always passed by the loader on aarch64. It
is not yet processed by cosmo. Pushing this change separately, as the
cosmo side turns out to be somewhat more involved.