### PR TITLE
Rename __zipos_free -> __zipos_drop

### DIFF
--- a/libc/runtime/zipos-close.c
+++ b/libc/runtime/zipos-close.c
@@ -39,7 +39,7 @@ int __zipos_close(int fd) {
   if (!__vforked) {
     struct ZiposHandle *h;
     h = (struct ZiposHandle *)(intptr_t)g_fds.p[fd].handle;
-    __zipos_free(h);
+    __zipos_drop(h);
   }
   return rc;
 }

--- a/libc/runtime/zipos.S
+++ b/libc/runtime/zipos.S
@@ -35,7 +35,7 @@
 	.yoink	__zipos_mmap
 	.yoink  __zipos_postdup
 	.yoink  __zipos_keep
-	.yoink  __zipos_free
+	.yoink  __zipos_drop
 
 //	TODO(jart): why does corruption happen when zip has no assets?
 	.yoink	.cosmo

--- a/libc/runtime/zipos.internal.h
+++ b/libc/runtime/zipos.internal.h
@@ -38,7 +38,7 @@ struct Zipos {
 };
 
 int __zipos_close(int);
-void __zipos_free(struct ZiposHandle *);
+void __zipos_drop(struct ZiposHandle *);
 struct ZiposHandle *__zipos_keep(struct ZiposHandle *);
 struct Zipos *__zipos_get(void) pureconst;
 size_t __zipos_normpath(char *, const char *, size_t);


### PR DESCRIPTION
Removes the separate decref function, uses keep/drop in the internal API.