### PR TITLE
Bugfix: ape --help should exit 0

### DIFF
--- a/ape/loader.c
+++ b/ape/loader.c
@@ -876,7 +876,7 @@ __attribute__((__noreturn__)) static void ShowUsage(int os, int fd, int rc) {
         "NAME\n"
         "\n"
         "  actually portable executable loader version " APE_VERSION_STR "\n"
-        "  copyright 2023 justine alexandra roberts tunney\n"
+        "  copyrights 2024 justine alexandra roberts tunney\n"
         "  https://justine.lol/ape.html\n"
         "\n"
         "USAGE\n"

--- a/ape/loader.c
+++ b/ape/loader.c
@@ -978,7 +978,8 @@ EXTERN_C __attribute__((__noreturn__)) void ApeLoader(long di, long *sp,
     ShowUsage(os, 2, 1);
   } else {
     if (argv[1][0] == '-') {
-      rc = !(argv[1][1] == 'h' && !argv[1][2]) || !StrCmp(argv[1] + 1, "-help");
+      rc = !((argv[1][1] == 'h' && !argv[1][2]) ||
+             !StrCmp(argv[1] + 1, "-help"));
       ShowUsage(os, 1 + rc, rc);
     }
     prog = (char *)sp[2];


### PR DESCRIPTION
Just missing a set of parens.