### PR TITLE
More reliable $prog.ape

### DIFF
--- a/ape/ape-m1.c
+++ b/ape/ape-m1.c
@@ -997,7 +997,7 @@ int main(int argc, char **argv, char **envp) {
        but it will if you say:
            ln -sf /usr/local/bin/ape /opt/cosmos/bin/bash.ape
        and then use #!/opt/cosmos/bin/bash.ape instead. */
-    M->ps.literally = 0;
+    M->ps.literally = 1;
     argc = sp[0];
     argv = (char **)(sp + 1);
   } else if ((M->ps.literally = argc >= 3 && !StrCmp(argv[1], "-"))) {

--- a/ape/ape-m1.c
+++ b/ape/ape-m1.c
@@ -768,7 +768,7 @@ __attribute__((__noreturn__)) static void Spawn(const char *exe, int fd,
 
 static const char *TryElf(struct ApeLoader *M, union ElfEhdrBuf *ebuf,
                           const char *exe, int fd, long *sp, long *auxv,
-                          char *execfn, char literally) {
+                          char *execfn) {
   long i, rc;
   unsigned size;
   struct ElfEhdr *e;
@@ -865,7 +865,7 @@ static const char *TryElf(struct ApeLoader *M, union ElfEhdrBuf *ebuf,
   auxv[8] = AT_PAGESZ;
   auxv[9] = pagesz;
   auxv[10] = AT_FLAGS;
-  auxv[11] = literally ? AT_FLAGS_PRESERVE_ARGV0 : 0;
+  auxv[11] = M->ps.literally ? AT_FLAGS_PRESERVE_ARGV0 : 0;
   auxv[12] = AT_UID;
   auxv[13] = getuid();
   auxv[14] = AT_EUID;
@@ -1081,9 +1081,9 @@ int main(int argc, char **argv, char **envp) {
         }
       }
       if (i >= sizeof(ebuf->ehdr)) {
-        TryElf(M, ebuf, exe, fd, sp, auxv, execfn, M->ps.literally);
+        TryElf(M, ebuf, exe, fd, sp, auxv, execfn);
       }
     }
   }
-  Pexit(exe, 0, TryElf(M, ebuf, exe, fd, sp, auxv, execfn, M->ps.literally));
+  Pexit(exe, 0, TryElf(M, ebuf, exe, fd, sp, auxv, execfn));
 }

--- a/ape/ape-m1.c
+++ b/ape/ape-m1.c
@@ -325,17 +325,7 @@ static char AccessCommand(struct PathSearcher *ps, unsigned long pathlen) {
   if (pathlen && ps->path[pathlen - 1] != '/') ps->path[pathlen++] = '/';
   memmove(ps->path + pathlen, ps->name, ps->namelen);
   ps->path[pathlen + ps->namelen] = 0;
-  if (!access(ps->path, X_OK)) {
-    if (ps->indirect) {
-      ps->namelen -= 4;
-      ps->path[pathlen + ps->namelen] = 0;
-      if (access(ps->path, X_OK) < 0) {
-        Pexit(ps->path, -errno, "access(X_OK)");
-      }
-    }
-    return 1;
-  }
-  return 0;
+  return !access(ps->path, X_OK);
 }
 
 static char SearchPath(struct PathSearcher *ps) {
@@ -382,6 +372,7 @@ static char *Commandv(struct PathSearcher *ps, const char *name,
                       const char *syspath) {
   ps->syspath = syspath ? syspath : "/bin:/usr/local/bin:/usr/bin";
   if (!(ps->namelen = StrLen((ps->name = name)))) return 0;
+  if (ps->indirect) ps->namelen -= 4;
   if (ps->namelen + 1 > sizeof(ps->path)) return 0;
   if (FindCommand(ps)) {
     return ps->path;

--- a/ape/ape-m1.c
+++ b/ape/ape-m1.c
@@ -361,12 +361,8 @@ static char FindCommand(struct PathSearcher *ps) {
   ps->path[0] = 0;
 
   /* paths are always 100% taken literally when a slash exists
-       $ ape foo/bar.com arg1 arg2 */
-  if (memchr(ps->name, '/', ps->namelen)) {
-    return AccessCommand(ps, 0);
-  }
-
-  /* we don't run files in the current directory
+       $ ape foo/bar.com arg1 arg2
+     we don't run files in the current directory
        $ ape foo.com arg1 arg2
      unless $PATH has an empty string entry, e.g.
        $ expert PATH=":/bin"
@@ -374,8 +370,8 @@ static char FindCommand(struct PathSearcher *ps) {
      however we will execute this
        $ ape - foo.com foo.com arg1 arg2
      because cosmo's execve needs it */
-  if (ps->literally && AccessCommand(ps, 0)) {
-    return 1;
+  if (ps->literally || memchr(ps->name, '/', ps->namelen)) {
+    return AccessCommand(ps, 0);
   }
 
   /* otherwise search for name on $PATH */

--- a/ape/ape-m1.c
+++ b/ape/ape-m1.c
@@ -371,8 +371,8 @@ static char FindCommand(struct PathSearcher *ps) {
 static char *Commandv(struct PathSearcher *ps, const char *name,
                       const char *syspath) {
   ps->syspath = syspath ? syspath : "/bin:/usr/local/bin:/usr/bin";
-  if (!(ps->namelen = StrLen((ps->name = name)))) return 0;
-  if (ps->indirect) ps->namelen -= 4;
+  ps->name = name;
+  if (!(ps->namelen = ps->indirect ? ps->indirect : StrLen(ps->name))) return 0;
   if (ps->namelen + 1 > sizeof(ps->path)) return 0;
   if (FindCommand(ps)) {
     return ps->path;

--- a/ape/ape-m1.c
+++ b/ape/ape-m1.c
@@ -966,6 +966,9 @@ int main(int argc, char **argv, char **envp) {
     }
   }
   prog = GetEnv(envp + i + 1, "executable_path");
+  if (!execfn) {
+    execfn = prog;
+  }
 
   /* sneak the system five abi back out of args */
   sp = (long *)(argv - 1);
@@ -1020,9 +1023,6 @@ int main(int argc, char **argv, char **envp) {
     prog = (char *)sp[2];
     argc = sp[1] = sp[0] - 1;
     argv = (char **)((sp += 1) + 1);
-  }
-  if (!execfn) {
-    execfn = prog;
   }
 
   /* allocate ephemeral memory for reading file */

--- a/ape/ape-m1.c
+++ b/ape/ape-m1.c
@@ -891,7 +891,7 @@ int main(int argc, char **argv, char **envp) {
   struct ApeLoader *M;
   long *sp, *sp2, *auxv;
   union ElfEhdrBuf *ebuf;
-  char *p, *pe, *exe, *prog, *execfn, *shell;
+  char *p, *pe, *exe, *prog, *execfn;
 
   /* allocate loader memory in program's arg block */
   n = sizeof(struct ApeLoader);

--- a/ape/ape-m1.c
+++ b/ape/ape-m1.c
@@ -960,6 +960,7 @@ int main(int argc, char **argv, char **envp) {
       execfn = envp[i] + 2;
     }
   }
+  prog = GetEnv(envp + i + 1, "executable_path");
 
   /* sneak the system five abi back out of args */
   sp = (long *)(argv - 1);
@@ -981,8 +982,8 @@ int main(int argc, char **argv, char **envp) {
   sp = sp2;
 
   /* interpret command line arguments */
-  if ((M->ps.indirect = argc > 0 ? GetIndirectOffset(argv[0]) : 0)) {
-    /* if argv[0] is $prog.ape, then we strip off the .ape and run
+  if ((M->ps.indirect = GetIndirectOffset(prog))) {
+    /* if called as $prog.ape, then strip off the .ape and run the
        $prog. This allows you to use symlinks to trick the OS when
        a native executable is required. For example, let's say you
        want to use the APE binary /opt/cosmos/bin/bash as a system
@@ -992,11 +993,8 @@ int main(int argc, char **argv, char **envp) {
            ln -sf /usr/local/bin/ape /opt/cosmos/bin/bash.ape
        and then use #!/opt/cosmos/bin/bash.ape instead. */
     M->ps.literally = 0;
-    if (*argv[0] == '-' && (shell = GetEnv(envp, "SHELL")) &&
-        !StrCmp(argv[0] + 1, BaseName(shell))) {
-      execfn = prog = shell;
-    } else {
-      prog = (char *)sp[1];
+    if (!execfn) {
+      execfn = prog;
     }
     argc = sp[0];
     argv = (char **)(sp + 1);

--- a/ape/ape-m1.c
+++ b/ape/ape-m1.c
@@ -954,7 +954,7 @@ int main(int argc, char **argv, char **envp) {
   M->lib.dlerror = dlerror;
 
   /* getenv("_") is close enough to at_execfn */
-  execfn = argc > 0 ? argv[0] : 0;
+  execfn = 0;
   for (i = 0; envp[i]; ++i) {
     if (envp[i][0] == '_' && envp[i][1] == '=') {
       execfn = envp[i] + 2;
@@ -993,9 +993,6 @@ int main(int argc, char **argv, char **envp) {
            ln -sf /usr/local/bin/ape /opt/cosmos/bin/bash.ape
        and then use #!/opt/cosmos/bin/bash.ape instead. */
     M->ps.literally = 0;
-    if (!execfn) {
-      execfn = prog;
-    }
     argc = sp[0];
     argv = (char **)(sp + 1);
   } else if ((M->ps.literally = argc >= 3 && !StrCmp(argv[1], "-"))) {
@@ -1018,6 +1015,9 @@ int main(int argc, char **argv, char **envp) {
     prog = (char *)sp[2];
     argc = sp[1] = sp[0] - 1;
     argv = (char **)((sp += 1) + 1);
+  }
+  if (!execfn) {
+    execfn = prog;
   }
 
   /* allocate ephemeral memory for reading file */

--- a/test/libc/calls/getprogramexecutablename_test.c
+++ b/test/libc/calls/getprogramexecutablename_test.c
@@ -58,8 +58,7 @@ void SetUpOnce(void) {
       skiptests = IsOpenbsd() || (IsXnu() && !IsXnuSilicon());
     }
   } else {
-    skiparg0 =
-        !(IsXnuSilicon() || (getauxval(AT_FLAGS) & AT_FLAGS_PRESERVE_ARGV0));
+    skiparg0 = !(getauxval(AT_FLAGS) & AT_FLAGS_PRESERVE_ARGV0);
   }
   fprintf(stderr, loaded ? "loaded\n" : "not loaded\n");
   if (skiptests) {


### PR DESCRIPTION
Now it doesn't matter what argv `$prog.ape` is invoked with. We just get our executable path the apple way.

https://github.com/opensource-apple/dyld/blob/master/src/dyld.cpp#L4789

PR also includes passing `AT_FLAGS` from the M1 loader, which lets the `GetProgramExecutableName` tests always detect whether `argv[0]` should be tested from `auxv`.

Also changes `literally` to match `loader.c` in behavior.