### PR TITLE
Revert apeinstall.sh binfmt flags

### DIFF
--- a/ape/apeinstall.sh
+++ b/ape/apeinstall.sh
@@ -137,20 +137,13 @@ if [ x"$(uname -s)" = xLinux ]; then
     echo done >&2
   fi
 
-  uname_r="$(uname -r)"
-  if printf '%s\n%s\n' 5.12 "$uname_r" | sort -CV; then
-    FLAGS=FP
-  else
-    FLAGS=F
-  fi
-
   echo >&2
   echo registering APE with binfmt_misc >&2
   echo you may need to edit configs to persist across reboot >&2
-  echo '$SUDO sh -c "echo '"'"':APE:M::MZqFpD::/usr/bin/ape:'"$FLAGS'"' >/proc/sys/fs/binfmt_misc/register"' >&2
-  $SUDO sh -c "echo ':APE:M::MZqFpD::/usr/bin/ape:$FLAGS' >/proc/sys/fs/binfmt_misc/register" || exit
-  echo '$SUDO sh -c "echo '"'"':APE-jart:M::jartsr::/usr/bin/ape:'"$FLAGS'"' >/proc/sys/fs/binfmt_misc/register"' >&2
-  $SUDO sh -c "echo ':APE-jart:M::jartsr::/usr/bin/ape:$FLAGS' >/proc/sys/fs/binfmt_misc/register" || exit
+  echo '$SUDO sh -c "echo '"'"':APE:M::MZqFpD::/usr/bin/ape:'"'"' >/proc/sys/fs/binfmt_misc/register"' >&2
+  $SUDO sh -c "echo ':APE:M::MZqFpD::/usr/bin/ape:' >/proc/sys/fs/binfmt_misc/register" || exit
+  echo '$SUDO sh -c "echo '"'"':APE-jart:M::jartsr::/usr/bin/ape:'"'"' >/proc/sys/fs/binfmt_misc/register"' >&2
+  $SUDO sh -c "echo ':APE-jart:M::jartsr::/usr/bin/ape:' >/proc/sys/fs/binfmt_misc/register" || exit
   echo done >&2
 
   if [ x"$(cat /proc/sys/fs/binfmt_misc/status)" = xdisabled ]; then


### PR DESCRIPTION
The P flag breaks backwards compatibility with older binaries. The idea is to revert this commit after that break has been resolved.