### PR TITLE
tool/cosmocc: Allow exceptions and rtti

### DIFF
--- a/tool/cosmocc/bin/cosmocc
+++ b/tool/cosmocc/bin/cosmocc
@@ -151,11 +151,9 @@ for x; do
   elif [ x"$x" = x"-r" ] ||
        [ x"$x" = x"-S" ] ||
        [ x"$x" = x"-pie" ] ||
-       [ x"$x" = x"-frtti" ] ||
        [ x"$x" = x"-shared" ] ||
        [ x"$x" = x"-nostdlib" ] ||
        [ x"$x" = x"-mred-zone" ] ||
-       [ x"$x" = x"-fexceptions" ] ||
        [ x"$x" = x"-fsanitize=thread" ]; then
     fatal_error "$x flag not supported"
   elif [ x"$x" = x"-mno-red-zone" ]; then

--- a/tool/cosmocc/bin/cosmocross
+++ b/tool/cosmocc/bin/cosmocross
@@ -142,11 +142,9 @@ for x; do
     continue
   elif [ x"$x" = x"-r" ] ||
        [ x"$x" = x"-pie" ] ||
-       [ x"$x" = x"-frtti" ] ||
        [ x"$x" = x"-shared" ] ||
        [ x"$x" = x"-nostdlib" ] ||
        [ x"$x" = x"-mred-zone" ] ||
-       [ x"$x" = x"-fexceptions" ] ||
        [ x"$x" = x"-fsanitize=thread" ]; then
     echo "$PROG: $x not supported" >&2
     exit 1


### PR DESCRIPTION
With `libunwind` and `libcxxabi` included in `libcosmo`, we can now allow users to build C++ applications with exceptions and RTTI enabled.

The default is still disabling these two to avoid bloating the binary.

Closes #1065.

**DO NOT MERGE**. This PR has no meaning until #1069 and #1063 are applied.
