### PR TITLE
tool/cosmocc: Do not run fixupobj for text output

### DIFF
--- a/tool/cosmocc/bin/cosmocc
+++ b/tool/cosmocc/bin/cosmocc
@@ -88,6 +88,7 @@ APELINKFLAGS=
 FLAGS_X86_64=
 FLAGS_AARCH64=
 INPUT_FILE_COUNT=0
+OUTPUT_IS_TEXT=0
 for x; do
   if [ x"$x" != x"${x#* }" ]; then
     fatal_error "arguments containing spaces unsupported: $x"
@@ -204,6 +205,12 @@ for x; do
   elif [ x"$x" = x"--param" ]; then
     NEED_EQUAL=$x
     continue
+  elif [ x"$x" = x"-M" ] ||
+       [ x"$x" = x"-MM" ] ||
+       [ x"$x" = x"-MD" ] ||
+       [ x"$x" = x"-MMD" ] ||
+       [ x"$x" = x"-E" ]; then
+    OUTPUT_IS_TEXT=1
   fi
   FLAGS="$FLAGS $x"
   ARGS="$ARGS $x"
@@ -325,11 +332,15 @@ build_object() {
         $PRECIOUS
     log_command "$@"
     "$@" || exit
-    set -- \
-        "$BIN/fixupobj" \
-        "$OUTPUT_X86_64"
-    log_command "$@"
-    exec "$@"
+    if [ $OUTPUT_IS_TEXT -eq 0 ]; then
+      set -- \
+          "$BIN/fixupobj" \
+          "$OUTPUT_X86_64"
+      log_command "$@"
+      exec "$@"
+    else
+      exit
+    fi
   ) &
   pid1=$!
   (
@@ -345,11 +356,15 @@ build_object() {
         $PRECIOUS
     log_command "$@"
     "$@" || exit
-    set -- \
-        "$BIN/fixupobj" \
-        "$OUTPUT_AARCH64"
-    log_command "$@"
-    exec "$@"
+    if [ $OUTPUT_IS_TEXT -eq 0 ]; then
+      set -- \
+          "$BIN/fixupobj" \
+          "$OUTPUT_AARCH64"
+      log_command "$@"
+      exec "$@"
+    else
+      exit
+    fi
   ) 2>"$out2" &
   pid2=$!
   if ! wait $pid1; then

--- a/tool/cosmocc/bin/cosmocross
+++ b/tool/cosmocc/bin/cosmocross
@@ -100,6 +100,7 @@ INTENT=ld
 GOT_SOME=0
 NEED_OUTPUT=
 RELOCATABLE=0
+OUTPUT_IS_TEXT=0
 for x; do
   if [ $FIRST -eq 1 ]; then
     set --
@@ -175,6 +176,12 @@ for x; do
     GOT_SOME=1
   elif [ x"$x" = x"-dumpmachine" ]; then
     GOT_SOME=1
+  elif [ x"$x" = x"-M" ] ||
+       [ x"$x" = x"-MM" ] ||
+       [ x"$x" = x"-MD" ] ||
+       [ x"$x" = x"-MMD" ] ||
+       [ x"$x" = x"-E" ]; then
+    OUTPUT_IS_TEXT=1
   fi
   set -- "$@" "$x"
 done
@@ -216,7 +223,10 @@ log_command "$@"
 
 if [ -n "$OUTPUT" ] && [ -f "$OUTPUT" ]; then
   if [ $INTENT = cc ] || [ $INTENT = ld ]; then
-    "$BIN/fixupobj" "$OUTPUT" || exit
+    if [ $OUTPUT_IS_TEXT -eq 0 ]; then
+      "$BIN/fixupobj" "$OUTPUT"
+    fi
+    exit
   fi
   if [ $INTENT = ld ]; then
     if [ x"$OUTPUT" != x"${OUTPUT%.com}" ] ||


### PR DESCRIPTION
Some compiler flags (such as -E or -MM) instruct GCC to only run the preprocessor and produce certain text files.

In this case, we do not want to run `fixupobj` and make the tool fail because the input is not an ELF64 binary.