### PR TITLE
libc: Fix cxxabi.h header

### DIFF
--- a/libc/cxxabi.h
+++ b/libc/cxxabi.h
@@ -2,16 +2,18 @@
 #define _CXXABI_H
 COSMOPOLITAN_C_START_
 
-union CxaGuardValue;
+#ifdef __cplusplus
+namespace __cxxabiv1 {
+#endif /* __cplusplus */
 
 char *__cxa_demangle(const char *, char *, size_t *, int *);
 int __cxa_atexit(void (*)(void *), void *, void *) paramsnonnull((1)) dontthrow;
-int __cxa_guard_acquire(union CxaGuardValue *) libcesque;
 int __cxa_thread_atexit(void *, void *, void *) dontthrow;
 void __cxa_finalize(void *);
-void __cxa_guard_abort(union CxaGuardValue *) dontthrow;
-void __cxa_guard_release(union CxaGuardValue *) dontthrow;
-void __cxa_pure_virtual(void) wontreturn;
+
+#ifdef __cplusplus
+} /* namespace __cxxabiv1 */
+#endif /* __cplusplus */
 
 COSMOPOLITAN_C_END_
 #endif /* _CXXABI_H */

--- a/libc/isystem/cxxabi.h
+++ b/libc/isystem/cxxabi.h
@@ -1,1 +1,5 @@
+#ifndef COSMOPOLITAN_LIBC_ISYSTEM_CXXABI_H_
+#define COSMOPOLITAN_LIBC_ISYSTEM_CXXABI_H_
+#include "third_party/libcxxabi/include/cxxabi.h"
 #include "libc/cxxabi.h"
+#endif /* COSMOPOLITAN_LIBC_ISYSTEM_CXXABI_H_ */


### PR DESCRIPTION
- `__cxa_*` runtime functions are expected to be in the `abi` namespace, which is currently an alias for `__cxxabiv1`.
- Rely on the header provided by `libcxxabi` for functions that we do not implement ourselves anymore.