### PR TITLE
libcxx: Add missing implementation source files

### DIFF
--- a/third_party/libcxx/BUILD.mk
+++ b/third_party/libcxx/BUILD.mk
@@ -141,6 +141,7 @@ THIRD_PARTY_LIBCXX_A_HDRS =					\
 
 THIRD_PARTY_LIBCXX_A_SRCS_CC =					\
 	third_party/libcxx/algorithm.cc				\
+	third_party/libcxx/any.cc				\
 	third_party/libcxx/charconv.cc				\
 	third_party/libcxx/chrono.cc				\
 	third_party/libcxx/condition_variable.cc		\
@@ -170,6 +171,7 @@ THIRD_PARTY_LIBCXX_A_SRCS_CC =					\
 	third_party/libcxx/system_error.cc			\
 	third_party/libcxx/thread.cc				\
 	third_party/libcxx/valarray.cc				\
+	third_party/libcxx/variant.cc				\
 	third_party/libcxx/vector.cc
 
 THIRD_PARTY_LIBCXX_A_SRCS =					\

--- a/third_party/libcxx/any.cc
+++ b/third_party/libcxx/any.cc
@@ -1,0 +1,34 @@
+//===---------------------------- any.cpp ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "third_party/libcxx/any"
+
+namespace std {
+const char* bad_any_cast::what() const _NOEXCEPT {
+    return "bad any cast";
+}
+}
+
+
+#include "third_party/libcxx/experimental/__config"
+
+//  Preserve std::experimental::any_bad_cast for ABI compatibility
+//  Even though it no longer exists in a header file
+_LIBCPP_BEGIN_NAMESPACE_LFTS
+
+class _LIBCPP_EXCEPTION_ABI _LIBCPP_AVAILABILITY_BAD_ANY_CAST bad_any_cast : public bad_cast
+{
+public:
+    virtual const char* what() const _NOEXCEPT;
+};
+
+const char* bad_any_cast::what() const _NOEXCEPT {
+    return "bad any cast";
+}
+
+_LIBCPP_END_NAMESPACE_LFTS

--- a/third_party/libcxx/variant.cc
+++ b/third_party/libcxx/variant.cc
@@ -1,0 +1,17 @@
+//===------------------------ variant.cpp ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "third_party/libcxx/variant"
+
+namespace std {
+
+const char* bad_variant_access::what() const noexcept {
+  return "bad_variant_access";
+}
+
+}  // namespace std


### PR DESCRIPTION
Added the implementation for `std::bad_any_cast` from upstream `any.cpp` and `std::bad_variant_access` from upstream `variant.cpp`.

This fixes missing `vtable` and `typeinfo` symbols when trying to link code referencing these exception types.