### PR TITLE
Fix a couple of minor things needed to compile TeX

### DIFF
--- a/libc/complex.h
+++ b/libc/complex.h
@@ -1,5 +1,5 @@
-#ifndef _COMPLEX_H
-#define _COMPLEX_H
+#ifndef COSMOPOLITAN_LIBC_COMPLEX_H_
+#define COSMOPOLITAN_LIBC_COMPLEX_H_
 COSMOPOLITAN_C_START_
 #if __STDC_VERSION__ + 0 >= 201112 && !defined(__STDC_NO_COMPLEX__)
 
@@ -116,4 +116,4 @@ complex long double cpowl(complex long double, complex long double) libcesque;
 
 #endif /* C11 */
 COSMOPOLITAN_C_END_
-#endif /* _COMPLEX_H */
+#endif /* COSMOPOLITAN_LIBC_COMPLEX_H_ */

--- a/libc/isystem/netdb.h
+++ b/libc/isystem/netdb.h
@@ -5,6 +5,7 @@
 #include "libc/sock/struct/in6_pktinfo.h"
 #include "libc/sock/struct/in_pktinfo.h"
 #include "libc/sock/struct/ip_mreq.h"
+#include "libc/sock/struct/ipv6_mreq.h"
 #include "libc/sock/struct/sockaddr.h"
 #include "libc/sock/struct/sockaddr6.h"
 #include "libc/sysv/consts/in.h"

--- a/libc/isystem/netinet/in.h
+++ b/libc/isystem/netinet/in.h
@@ -6,6 +6,7 @@
 #include "libc/sock/struct/in6_pktinfo.h"
 #include "libc/sock/struct/in_pktinfo.h"
 #include "libc/sock/struct/ip_mreq.h"
+#include "libc/sock/struct/ipv6_mreq.h"
 #include "libc/sock/struct/sockaddr.h"
 #include "libc/sock/struct/sockaddr6.h"
 #include "libc/sysv/consts/in.h"

--- a/libc/sock/struct/ipv6_mreq.h
+++ b/libc/sock/struct/ipv6_mreq.h
@@ -1,0 +1,12 @@
+#ifndef COSMOPOLITAN_LIBC_SOCK_STRUCT_IPV6_MREQ_H_
+#define COSMOPOLITAN_LIBC_SOCK_STRUCT_IPV6_MREQ_H_
+#include "libc/sock/struct/sockaddr6.h"
+COSMOPOLITAN_C_START_
+
+struct ipv6_mreq {
+  struct in6_addr ipv6mr_multiaddr; /* IPv6 multicast address of group */
+  unsigned ipv6mr_interface;        /* local interface */
+};
+
+COSMOPOLITAN_C_END_
+#endif /* COSMOPOLITAN_LIBC_SOCK_STRUCT_IPV6_MREQ_H_ */


### PR DESCRIPTION
We're currently trying to make [busytex](https://github.com/busytex/busytex) Actually Portable. Overall it's going pretty smooth, but there are a couple of changes we had to made that I believe should preferably be upstreamed. Amusingly, they were needed to compile not the TeX project proper but the [Lua modules](https://github.com/TeX-Live/texlive-source/tree/trunk/texk/web2c/luatexdir) they bundle with TeX-Live (so this might be useful even for those who don't care about TeX).

The detailed description of what was changed is in the commit message.