### PR TITLE
Fix invalid XNU binaries generated by `apelink` in some edge cases

### DIFF
--- a/tool/build/apelink.c
+++ b/tool/build/apelink.c
@@ -102,7 +102,7 @@
   "               - 32: freebsd\n"                             \
   "               - 64: netbsd\n"                              \
   "\n"                                                         \
-  "             for example, `-s 0b1110001` may be used to\n"  \
+  "             for example, `-V 0b1110001` may be used to\n"  \
   "             produce ELF binaries that only support the\n"  \
   "             truly open unix systems. in this case when\n"  \
   "             a single input executable is supplied, the\n"  \
@@ -120,8 +120,8 @@
   "             also pass strings in a variety of intuitive\n" \
   "             supported representations. for example, bsd\n" \
   "             will enable freebsd+netbsd+openbsd and that\n" \
-  "             string too is a legal input. the -s flag is\n" \
-  "             also repeatable, e.g. `-s nt -s xnu` to use\n" \
+  "             string too is a legal input. the -V flag is\n" \
+  "             also repeatable, e.g. `-V nt -V xnu` to use\n" \
   "             the union of the two.\n"                       \
   "\n"                                                         \
   "             since the support vector controls the file\n"  \
@@ -988,7 +988,7 @@ static void GetOpts(int argc, char *argv[]) {
         if (ParseSupportVector(optarg, &bits)) {
           support_vector |= bits;
         } else {
-          Die(prog, "unrecognized token passed to -s support vector flag");
+          Die(prog, "unrecognized token passed to -V support vector flag");
           exit(1);
         }
         got_support_vector = true;

--- a/tool/build/apelink.c
+++ b/tool/build/apelink.c
@@ -2036,7 +2036,7 @@ int main(int argc, char *argv[]) {
     //      let our shell script compile the ape loader on first run.
     //
     if (support_vector & _HOSTXNU) {
-      bool gotsome;
+      bool gotsome = false;
       p = stpcpy(p, "else\n");  // if [ -d /Applications ]; then
 
       // output native mach-o morph
@@ -2136,6 +2136,7 @@ int main(int argc, char *argv[]) {
     }
 
     // extract the ape loader for open platforms
+    bool gotsome = false;
     if (inputs.n && (support_vector & _HOSTXNU)) {
       p = stpcpy(p, "if [ ! -d /Applications ]; then\n");
     }
@@ -2158,9 +2159,13 @@ int main(int argc, char *argv[]) {
                       "mv -f \"$t.$$\" \"$t\" ||exit\n");
         p = stpcpy(p, "exec \"$t\" \"$o\" \"$@\"\n"
                       "fi\n");
+        gotsome = true;
       }
     }
     if (inputs.n && (support_vector & _HOSTXNU)) {
+      if (!gotsome) {
+        p = stpcpy(p, "true\n");
+      }
       p = stpcpy(p, "fi\n");
     }
 


### PR DESCRIPTION
I was experimenting with `aarch64`-only APE binaries that don't contain any embedded loaders. You can generate one with:
```
> cat tmp.c
#include <stdio.h>

int main() {
    puts("wow");
}
> aarch64-unknown-cosmo-cc -O2 -o tmp.aarch64 tmp.c
> apelink -o tmp.com tmp.aarch64
```

When I copied the resulting binary to an M1 machine and tried to run it, I got the following confusing error:
```
> ./tmp.com
./tmp.com: line 19: syntax error near unexpected token `fi'
./tmp.com: line 19: `fi'
```

The details of what's going on and how this it was fixed are in the commit message. The generated binaries still don't work because apparently you can't assimilate on Apple Silicon, but the error message is clearer:
```
> ./tmp.com
./tmp.com: this ape program lacks arm64 support
```

While I'm at it, also fix slightly outdated apelink documentation.