### PR TITLE
Add LIST to khttpmethod.c

### DIFF
--- a/net/http/khttpmethod.c
+++ b/net/http/khttpmethod.c
@@ -37,4 +37,5 @@ const char kHttpMethod[18][8] = {
     "PATCH",    //
     "REPORT",   //
     "UNLOCK",   //
+    "LIST",     //
 };

--- a/net/http/khttpmethod.c
+++ b/net/http/khttpmethod.c
@@ -18,7 +18,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #include "net/http/http.h"
 
-const char kHttpMethod[18][8] = {
+const char kHttpMethod[19][8] = {
     "WUT",      //
     "GET",      //
     "HEAD",     //


### PR DESCRIPTION
Currently Redbean's Fetch() API does not seem to support arbitrary HTTP methods. This change will enable the use of LIST as one of the supported HTTP verbs to be able to interact with the Hashicorp Vault HTTP API.