### PR TITLE
`*scanf()` fixes to make TeX work

### DIFF
--- a/libc/stdio/vcscanf.c
+++ b/libc/stdio/vcscanf.c
@@ -550,6 +550,11 @@ int __vcscanf(int callback(void *),    //
               if (!j && c == -1 && !items) {
                 items = -1;
                 goto Done;
+              } else if (rawmode && j != width) {
+                /* The C standard says that %c "matches a sequence of characters of
+                 * **exactly** the number specified by the field width". If we have
+                 * fewer characters, what we've just read is invalid. */
+                goto Done;
               } else if (!rawmode && j < bufsize) {
                 if (charbytes == sizeof(char)) {
                   buf[j] = '\0';

--- a/libc/stdio/vcscanf.c
+++ b/libc/stdio/vcscanf.c
@@ -410,9 +410,6 @@ int __vcscanf(int callback(void *),    //
                   goto Done;
                 }
               } else {
-                if (c != -1 && unget) {
-                  unget(c, arg);
-                }
                 goto GotFloatingPointNumber;
               }
             } else {
@@ -465,9 +462,6 @@ int __vcscanf(int callback(void *),    //
         Continue:
           continue;
         Break:
-          if (c != -1 && unget) {
-            unget(c, arg);
-          }
           break;
         } while ((c = BUFFER) != -1);
       GotFloatingPointNumber:

--- a/test/libc/stdio/fscanf_test.c
+++ b/test/libc/stdio/fscanf_test.c
@@ -1,7 +1,7 @@
 /*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
 │ vi: set et ft=c ts=2 sts=2 sw=2 fenc=utf-8                               :vi │
 ╞══════════════════════════════════════════════════════════════════════════════╡
-│ Copyright 2022 Justine Alexandra Roberts Tunney                              │
+│ Copyright 2024 Ivan Komarov                                                  │
 │                                                                              │
 │ Permission to use, copy, modify, and/or distribute this software for         │
 │ any purpose with or without fee is hereby granted, provided that the         │

--- a/test/libc/stdio/fscanf_test.c
+++ b/test/libc/stdio/fscanf_test.c
@@ -1,0 +1,33 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│ vi: set et ft=c ts=2 sts=2 sw=2 fenc=utf-8                               :vi │
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ Copyright 2022 Justine Alexandra Roberts Tunney                              │
+│                                                                              │
+│ Permission to use, copy, modify, and/or distribute this software for         │
+│ any purpose with or without fee is hereby granted, provided that the         │
+│ above copyright notice and this permission notice appear in all copies.      │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL                │
+│ WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED                │
+│ WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE             │
+│ AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL         │
+│ DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR        │
+│ PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER               │
+│ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR             │
+│ PERFORMANCE OF THIS SOFTWARE.                                                │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "libc/math.h"
+#include "libc/stdio/stdio.h"
+#include "libc/testlib/testlib.h"
+
+TEST(fscanf, test_readAfterFloat) {
+  FILE *f = fmemopen("infDEAD-.125e-2BEEF", 19, "r");
+  float f1 = 666.666f, f2 = f1;
+  int i1 = 666, i2 = i1;
+  EXPECT_EQ(4, fscanf(f, "%f%x%f%x", &f1, &i1, &f2, &i2));
+  EXPECT_TRUE(isinf(f1));
+  EXPECT_EQ(0xDEAD, i1);
+  EXPECT_EQ(-0.125e-2f, f2);
+  EXPECT_EQ(0xBEEF, i2);
+  fclose(f);
+}

--- a/test/libc/stdio/sscanf_test.c
+++ b/test/libc/stdio/sscanf_test.c
@@ -69,9 +69,17 @@ TEST(sscanf, testNonDirectiveCharacterMatching) {
 }
 
 TEST(sscanf, testCharacter) {
-  char c = 0;
-  EXPECT_EQ(1, sscanf("a", "%c", &c));
-  EXPECT_EQ('a', c);
+  char c1 = 0, c2 = c1, c3 = c2, c4 = c3;
+  char s1[32] = {0}, s2[32] = {0};
+  EXPECT_EQ(1, sscanf("a", "%c", &c1));
+  EXPECT_EQ(2, sscanf("ab", "%c %c %c", &c2, &c3, &c4));
+  EXPECT_EQ(1, sscanf("abcde", "%5c", s1));
+  EXPECT_EQ(0, sscanf("abcd", "%5c", s2));
+
+  EXPECT_EQ('a', c1);
+  EXPECT_EQ('a', c2);
+  EXPECT_EQ('b', c3);
+  EXPECT_STREQ("abcde", &s1[0]);
 }
 
 TEST(sscanf, testStringBuffer) {

--- a/test/libc/stdio/sscanf_test.c
+++ b/test/libc/stdio/sscanf_test.c
@@ -394,6 +394,20 @@ TEST(sscanf, floating_point_infinity_double_precision) {
   EXPECT_TRUE(isinf(g));
 }
 
+TEST(sscanf, floating_point_invalid) {
+  float dummy;
+  EXPECT_EQ(0, sscanf("junk", "%f", &dummy));
+  EXPECT_EQ(0, sscanf("e9", "%f", &dummy));
+  EXPECT_EQ(0, sscanf("-e9", "%f", &dummy));
+}
+
+TEST(sscanf, floating_point_invalid_double_precision) {
+  double dummy;
+  EXPECT_EQ(0, sscanf("junk", "%lf", &dummy));
+  EXPECT_EQ(0, sscanf("e9", "%lf", &dummy));
+  EXPECT_EQ(0, sscanf("-e9", "%lf", &dummy));
+}
+
 TEST(sscanf, floating_point_documentation_examples) {
   float a = 666.666f, b = a, c = b, d = c, e = d, f = e, g = f, h = g, i = h,
         j = i;
@@ -401,7 +415,7 @@ TEST(sscanf, floating_point_documentation_examples) {
   EXPECT_EQ(2, sscanf("111.11 -2.22", "%f %f", &a, &b));
   EXPECT_EQ(3, sscanf("Nan nan(2) inF", "%f %f %f", &c, &d, &e));
   EXPECT_EQ(
-      5, sscanf("0X1.BC70A3D70A3D7P+6 1.18973e+4932zzz -0.0000000123junk junk",
+      2, sscanf("0X1.BC70A3D70A3D7P+6 1.18973e+4932zzz -0.0000000123junk junk",
                 "%f %f %f %f %f", &f, &g, &h, &i, &j));
 
   EXPECT_EQ(111.11f, a);
@@ -411,9 +425,6 @@ TEST(sscanf, floating_point_documentation_examples) {
   EXPECT_TRUE(isinf(e));
   EXPECT_EQ(0X1.BC70A3D70A3D7P+6f, f);
   EXPECT_TRUE(isinf(g));
-  EXPECT_EQ(-0.0000000123f, h);
-  EXPECT_EQ(.0f, i);
-  EXPECT_EQ(.0f, j);
 }
 
 TEST(sscanf, floating_point_documentation_examples_double_precision) {
@@ -423,7 +434,7 @@ TEST(sscanf, floating_point_documentation_examples_double_precision) {
   EXPECT_EQ(2, sscanf("111.11 -2.22", "%lf %lf", &a, &b));
   EXPECT_EQ(3, sscanf("Nan nan(2) inF", "%lf %lf %lf", &c, &d, &e));
   EXPECT_EQ(
-      5, sscanf("0X1.BC70A3D70A3D7P+6 1.18973e+4932zzz -0.0000000123junk junk",
+      2, sscanf("0X1.BC70A3D70A3D7P+6 1.18973e+4932zzz -0.0000000123junk junk",
                 "%lf %lf %lf %lf %lf", &f, &g, &h, &i, &j));
 
   EXPECT_EQ(111.11, a);
@@ -433,9 +444,6 @@ TEST(sscanf, floating_point_documentation_examples_double_precision) {
   EXPECT_TRUE(isinf(e));
   EXPECT_EQ(0X1.BC70A3D70A3D7P+6, f);
   EXPECT_TRUE(isinf(g));
-  EXPECT_EQ(-0.0000000123, h);
-  EXPECT_EQ(.0, i);
-  EXPECT_EQ(.0, j);
 }
 
 TEST(sscanf, luplus) {


### PR DESCRIPTION
TeX uses `sscanf()` extensively, and there is some breakage when it is compiled with Cosmpolitan, which I'm trying to fix with this PR.

For clarity, the fixes are split into three more-or-less independent commits. The commit messages describe *what* is being fixed, and below is some context on *why* this is being fixed.

The [first commit](https://github.com/jart/cosmopolitan/commit/a57c6067f0e151b3108437d87bf1e6d205e227f5) doesn't fix any actual breakage in TeX; it's a small fix for an edge case in the current code. It could be squashed with the second commit but I think it's cleaner if this change gets a separate commit.

The [second commit](https://github.com/jart/cosmopolitan/commit/e5d877ba4f46b0767333160e19fe308d88636cd9) fixes the mapfile parsing in TeX. It [uses](https://github.com/TeX-Live/texlive-source/blob/bc6f82f7bc771f34bf507951779251e0ec7300bd/texk/web2c/pdftexdir/mapfile.c#L481) `scanf()` with `%f` directive to check if the current config option contains a valid float.

The [third commit](https://github.com/jart/cosmopolitan/commit/a57c6067f0e151b3108437d87bf1e6d205e227f5) fixes a very weird error that looks like this:
```
! pdfTeX error (\pdfsetmatrix): Unrecognized format..
<argument> ...shipout:D \box_use:N \l_shipout_box
                                                  \__shipout_drop_firstpage_...
```

It turns out that TeX [uses](https://github.com/TeX-Live/texlive-source/blob/trunk/texk/web2c/pdftexdir/utils.c#L1415) `scanf()` with `%lf ... %c` directive, where the trailing `%c` is expected to fail (which would mean the last float actually terminates the string).