### PR TITLE
Don't include <crypt.h> from <stdlib.h>

### DIFF
--- a/libc/isystem/stdlib.h
+++ b/libc/isystem/stdlib.h
@@ -14,6 +14,5 @@
 #include "libc/str/str.h"
 #include "libc/sysv/consts/exit.h"
 #include "libc/temp.h"
-#include "third_party/musl/crypt.h"
 #include "third_party/musl/rand48.h"
 #endif /* _STDLIB_H */


### PR DESCRIPTION
*This PR tries to re-land #1104, which was closed because I had tried to make a PR directly from my master and messed up.
Except for the branch name, this PR is identical to #1104, so I'm copying the original PR description below verbatim.*

POSIX says that [crypt()](https://pubs.opengroup.org/onlinepubs/9699919799/functions/crypt.html) resides in `<unistd.h>`. As far as I know, `crypt()` doesn't have anything to do with the C standard library, so including it unconditionally from `<stdlib.h>` is somewhat strange and breaks the build of the [Lua MD5 implementation](https://github.com/TeX-Live/texlive-source/blob/tags/texlive-2023.0/texk/web2c/luatexdir/luamd5/md5lib.c#L117) bundled with LuaTeX: 

```
/home/dfyz/busytex/source/texlive/texk/web2c/luatexdir/luamd5/md5lib.c:117:12: error: conflicting types for ‘crypt’; have ‘int(lua_State *)’
  117 | static int crypt (lua_State *L) {
      |            ^~~~~
In file included from /home/dfyz/cosmopolitan/cosmocc/include/stdlib.h:17,
                 from /home/dfyz/busytex/source/texlive/texk/web2c/luatexdir/luamd5/md5lib.c:8:
/home/dfyz/cosmopolitan/cosmocc/include/third_party/musl/crypt.h:12:7: note: previous declaration of ‘crypt’ with type ‘char *(const char *, const char *)’
   12 | char *crypt(const char *, const char *);
      |       ^~~~~
```

A simpler test program is just:
```c
#include <stdlib.h>

void crypt() {
}

int main() {
}
```

It builds successfully with both `gcc` (glibc) and `musl-gcc` (musl), but fails to build with `cosmocc` (with an error very similar to the above).
Given that `crypt()` is a very short word and is likely to clash with other real-world programs in the future, I suggest removing this include.