### PR TITLE
Fix binary formatting for integers 2 and 3

### DIFF
--- a/libc/fmt/formatbinary64.c
+++ b/libc/fmt/formatbinary64.c
@@ -21,7 +21,7 @@
 
 static inline int PickGoodWidth(unsigned x) {
   if (x < 16) {
-    if (x < 2) return 0;
+    if (x < 2) return 1;
     if (x < 8) return 7;
     return 15;
   } else {

--- a/test/libc/fmt/formatbinary64_test.c
+++ b/test/libc/fmt/formatbinary64_test.c
@@ -40,13 +40,13 @@ TEST(FormatBinary64, test2) {
 }
 
 TEST(FormatBinary64, test3) {
-  EXPECT_EQ(3, FormatBinary64(buf, 1, 2) - buf);
-  EXPECT_STREQ("0b1", buf);
+  EXPECT_EQ(4, FormatBinary64(buf, 1, 2) - buf);
+  EXPECT_STREQ("0b01", buf);
 }
 
 TEST(FormatBinary64, test4) {
-  EXPECT_EQ(1, FormatBinary64(buf, 1, 0) - buf);
-  EXPECT_STREQ("1", buf);
+  EXPECT_EQ(2, FormatBinary64(buf, 1, 0) - buf);
+  EXPECT_STREQ("01", buf);
 }
 
 TEST(FormatBinary64, test5) {


### PR DESCRIPTION
Cosmopolitan's `FormatBinary64` function gives incomplete representations of integers 2 and 3.
Shown in redbean's interpreter:
```
>: for i = 0, 8 do print(i, bin(i)) end
0       0
1       0b1
2       0b0
3       0b1
4       0b00000100
5       0b00000101
6       0b00000110
7       0b00000111
8       0b00001000
```

With the proposed patch, the ouput will look like this:
```
>: for i = 0, 8 do print(i, bin(i)) end
0       0
1       0b01
2       0b10
3       0b11
4       0b00000100
5       0b00000101
6       0b00000110
7       0b00000111
8       0b00001000
```

A different approach could be:
```diff
--- a/libc/fmt/formatbinary64.c
+++ b/libc/fmt/formatbinary64.c
@@ -21,7 +21,7 @@

 static inline int PickGoodWidth(unsigned x) {
   if (x < 16) {
-    if (x < 2) return 0;
+    if (x < 1) return 0;
     if (x < 8) return 7;
     return 15;
   } else {
```
Resulting:
```
0       0
1       0b1
2       0b00000010
3       0b00000011
4       0b00000100
```