### PR TITLE
change 15.6 to 10.15.6 under macos support

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ server. You're welcome to join us! <https://discord.gg/FwAVVu7eJ4>
 | Intel           | Core        | 2006  |
 | Linux           | 2.6.18      | 2007  |
 | Windows         | 8 [1]       | 2012  |
-| Mac OS X        | 15.6        | 2018  |
+| Mac OS X        | 10.15.6     | 2018  |
 | OpenBSD         | 7           | 2021  |
 | FreeBSD         | 13          | 2020  |
 | NetBSD          | 9.2         | 2021  |


### PR DESCRIPTION
resolves ambiguity because there is likely to be a macOS 15.6 some point in the next year (or at least a 15.4), when I assume what was actually meant is 10.15.6 (which actually was released in 2018).