### PR TITLE
Move store after __asan_unpoison in __zipos_alloc

### DIFF
--- a/libc/runtime/zipos-open.c
+++ b/libc/runtime/zipos-open.c
@@ -114,7 +114,6 @@ StartOver:
   while ((h = *ph)) {
     if (h->mapsize >= mapsize) {
       if (!_cmpxchg(ph, h, h->next)) goto StartOver;
-      atomic_store_explicit(&h->refs, 0, memory_order_relaxed);
       break;
     }
     ph = &h->next;
@@ -130,6 +129,7 @@ StartOver:
                   kAsanHeapOverrun);
   }
   if (h) {
+    atomic_store_explicit(&h->refs, 0, memory_order_relaxed);
     h->size = size;
     h->zipos = zipos;
     h->mapsize = mapsize;


### PR DESCRIPTION
Previously, the atomic store looked like it was happening while the struct's memory was still poisoned. I was unable to observe any issues with this, but this change seems to make the code more obviously correct (at the cost of a redundant atomic store to zeroed space in case the map needed to be extended.)