### PR TITLE
remove zlib namespacing

### DIFF
--- a/test/libc/runtime/zipos_test.c
+++ b/test/libc/runtime/zipos_test.c
@@ -33,9 +33,9 @@
 
 __static_yoink("zipos");
 __static_yoink("libc/testlib/hyperion.txt");
-__static_yoink("_Cz_inflate");
-__static_yoink("_Cz_inflateInit2");
-__static_yoink("_Cz_inflateEnd");
+__static_yoink("inflate");
+__static_yoink("inflateInit2");
+__static_yoink("inflateEnd");
 
 void *Worker(void *arg) {
   int i, fd;

--- a/third_party/musl/pwd.c
+++ b/third_party/musl/pwd.c
@@ -45,9 +45,9 @@ __static_yoink("musl_libc_notice");
 // something as substantive as this library, then we shall assume the
 // application is meaty enough to benefit from the performance of the
 // chromium zlib library (costs ~40kb binary) versus just having puff
-__static_yoink("_Cz_inflateInit2");
-__static_yoink("_Cz_inflate");
-__static_yoink("_Cz_inflateEnd");
+__static_yoink("inflateInit2");
+__static_yoink("inflate");
+__static_yoink("inflateEnd");
 #endif
 
 static char *

--- a/third_party/zip/crc32.h
+++ b/third_party/zip/crc32.h
@@ -31,7 +31,7 @@
 #ifndef USE_ZLIB
    ZCONST ulg near *get_crc_table  OF((void));
 #endif
-#if (defined(USE_ZLIB) || defined(CRC_TABLE_ONLY))
+#if (1 || defined(USE_ZLIB) || defined(CRC_TABLE_ONLY))
 #  ifdef IZ_CRC_BE_OPTIMIZ
 #    undef IZ_CRC_BE_OPTIMIZ
 #  endif

--- a/third_party/zip/zipfile.c
+++ b/third_party/zip/zipfile.c
@@ -72,7 +72,7 @@
 #include "libc/nt/winsock.h"
 #endif
 
-unsigned _Cz_crc32(unsigned crc, const unsigned char *buf, unsigned len);
+unsigned crc32(unsigned crc, const unsigned char *buf, unsigned len);
 
 /*
  * XXX start of zipfile.h
@@ -867,7 +867,7 @@ local void read_Unicode_Path_entry(pZipListEntry)
   }
   strcpy(iname, pZipListEntry->iname);
 
-  chksum = _Cz_crc32(chksum, (uch *)(iname), strlen(iname));
+  chksum = crc32(chksum, (uch *)(iname), strlen(iname));
 
   free(iname);
 
@@ -972,7 +972,7 @@ local void read_Unicode_Path_local_entry(pZipListEntry)
   }
   strcpy(iname, pZipListEntry->iname);
 
-  chksum = _Cz_crc32(chksum, (uch *)(iname), strlen(iname));
+  chksum = crc32(chksum, (uch *)(iname), strlen(iname));
 
   free(iname);
 
@@ -1558,7 +1558,7 @@ local int add_Unicode_Path_local_extra_field(pZEntry)
 # define inameLocal (pZEntry->iname)
 #endif
 
-  chksum = _Cz_crc32(chksum, (uch *)(inameLocal), strlen(inameLocal));
+  chksum = crc32(chksum, (uch *)(inameLocal), strlen(inameLocal));
 
 #ifdef WIN32_OEM
   free(inameLocal);
@@ -1685,7 +1685,7 @@ local int add_Unicode_Path_cen_extra_field(pZEntry)
 # define inameLocal (pZEntry->iname)
 #endif
 
-  chksum = _Cz_crc32(chksum, (uch *)(inameLocal), strlen(inameLocal));
+  chksum = crc32(chksum, (uch *)(inameLocal), strlen(inameLocal));
 
 #ifdef WIN32_OEM
   free(inameLocal);

--- a/third_party/zlib/zconf.h
+++ b/third_party/zlib/zconf.h
@@ -13,6 +13,7 @@
 
 #define z_const const
 
+#if 0
 #define Z_COSMO_PREFIX_SET
 
 #define Bytef                    _Cz_Bytef
@@ -162,6 +163,9 @@
 #define zlibCompileFlags         _Cz_zlibCompileFlags
 #define zlibVersion              _Cz_zlibVersion
 
+#pragma message "zconf is included, so zlibVersion should be renamed"
+
+#endif
 
 typedef unsigned char Byte;
 typedef unsigned int uInt;   /* 16 bits or more */


### PR DESCRIPTION
it seems like we can handle the zlib dependency fine both inside and outside the monorepo without having to do any sort of namespacing.

I remember we added the namespacing for the zlib functions because it was clashing with some builds (but I don't remember the exact reason :disappointed: ). Do we still have those clashing builds now? The namespaced symbols are now causing an issue with https://github.com/ahgamut/superconfigure/pull/29