### PR TITLE
Various paginate improvements

### DIFF
--- a/libc/runtime/runtime.h
+++ b/libc/runtime/runtime.h
@@ -103,6 +103,7 @@ int verynice(void);
 void __warn_if_powersave(void);
 void _Exit1(int) libcesque wontreturn;
 void __paginate(int, const char *);
+void __paginate_file(int, const char *);
 /* memory management */
 void _weakfree(void *);
 void *_mapanon(size_t) attributeallocsize((1)) mallocesque;

--- a/libc/x/paginate.c
+++ b/libc/x/paginate.c
@@ -70,17 +70,17 @@ void __paginate(int fd, const char *s) {
   char *args[3] = {0};
   char tmppath[] = "/tmp/paginate.XXXXXX";
   char progpath[PATH_MAX];
+  bool done;
   if ((args[0] = get_pagerpath(progpath, sizeof(progpath)))) {
     if ((tfd = mkstemp(tmppath)) != -1) {
-      // defer((void*)unlink, tmppath);
       write(tfd, s, strlen(s));
       close(tfd);
       args[1] = tmppath;
-      if (run_pager(args)) {
-        unlink(tmppath);
+      done = run_pager(args);
+      unlink(tmppath);
+      if (done) {
         return;
       }
-      unlink(tmppath);
     }
   }
   write(fd, s, strlen(s));

--- a/libc/x/paginate.c
+++ b/libc/x/paginate.c
@@ -16,7 +16,9 @@
 │ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR             │
 │ PERFORMANCE OF THIS SOFTWARE.                                                │
 ╚─────────────────────────────────────────────────────────────────────────────*/
+#include "libc/dce.h"
 #include "libc/calls/calls.h"
+#include "libc/calls/syscall_support-nt.internal.h"
 #include "libc/intrin/safemacros.internal.h"
 #include "libc/limits.h"
 #include "libc/runtime/runtime.h"
@@ -29,16 +31,22 @@
 void __paginate(int fd, const char *s) {
   int tfd, pid;
   char *args[3] = {0};
-  char tmppath[] = "/tmp/paginate.XXXXXX";
+  char tmppath[PATH_MAX-32] = "/tmp/paginate.XXXXXX";
   char progpath[PATH_MAX];
   if (strcmp(nulltoempty(getenv("TERM")), "dumb") && isatty(0) && isatty(1) &&
       ((args[0] = commandv("less", progpath, sizeof(progpath))) ||
        (args[0] = commandv("more", progpath, sizeof(progpath))) ||
-       (args[0] = commandv("more.exe", progpath, sizeof(progpath))))) {
+       (args[0] = commandv("more.exe", progpath, sizeof(progpath))) ||
+       (args[0] = commandv("more.com", progpath, sizeof(progpath))))) {
     if ((tfd = mkstemp(tmppath)) != -1) {
       write(tfd, s, strlen(s));
       close(tfd);
       args[1] = tmppath;
+      if (IsWindows() && strcmp(args[0], "/C/Windows/System32/more.com") == 0) {
+        char16_t widepath[PATH_MAX];
+        __mkntpath(tmppath, widepath);
+        tprecode16to8(tmppath, sizeof(tmppath), widepath);
+      }
       if ((pid = fork()) != -1) {
         putenv("LC_ALL=C.UTF-8");
         putenv("LESSCHARSET=utf-8");

--- a/libc/x/paginate.c
+++ b/libc/x/paginate.c
@@ -19,9 +19,7 @@
 #include "libc/calls/calls.h"
 #include "libc/calls/syscall_support-nt.internal.h"
 #include "libc/dce.h"
-#include "libc/intrin/kprintf.h"
 #include "libc/intrin/safemacros.internal.h"
-#include "libc/intrin/weaken.h"
 #include "libc/limits.h"
 #include "libc/mem/gc.h"
 #include "libc/runtime/runtime.h"
@@ -29,8 +27,6 @@
 #include "libc/sysv/consts/o.h"
 #include "libc/temp.h"
 #include "libc/x/x.h"
-
-__static_yoink("__utf16to8");
 
 static char *get_pagerpath(char *pathbuf, size_t pathbufsz) {
   char *pagerpath;
@@ -47,10 +43,9 @@ static char *get_pagerpath(char *pathbuf, size_t pathbufsz) {
 static bool run_pager(char *args[hasatleast 3]) {
   char16_t widepath[PATH_MAX];
   int n, pid;
-  kprintf("utf16to8 %p\n", _weaken(__utf16to8));
   if (IsWindows() && !strcasecmp(args[0], "/C/Windows/System32/more.com") &&
-      (!_weaken(__utf16to8) || ((n = __mkntpath(args[1], widepath)) == -1) ||
-       !(args[1] = gc(_weaken(__utf16to8)(widepath, n, 0))))) {
+      (((n = __mkntpath(args[1], widepath)) == -1) ||
+       !(args[1] = gc(utf16to8(widepath, n, 0))))) {
     return false;
   }
   if ((pid = fork()) != -1) {


### PR DESCRIPTION
* Support `C:\Windows\System32\more.com` so paging should work out of the box on win32
* Add `__paginate_file` to paginate an existing file

`paginate.c` was moved from `libc/proc` to `libc/x` mainly to get `utf16to8`. However, it seems to fit as pagination is not standard, but is implemented in a variety of codebases.

This patch will be helpful for getting `perldoc` working again in APPerl. Running a pager via a shell broke when cosmo stopped converting cli arguments to native file paths.