### PR TITLE
recvfrom: don't convert address if addrsize is 0

### DIFF
--- a/libc/sock/recvfrom.c
+++ b/libc/sock/recvfrom.c
@@ -70,6 +70,9 @@ ssize_t recvfrom(int fd, void *buf, size_t size, int flags,
     if (__isfdkind(fd, kFdSocket)) {
       rc = sys_recvfrom_nt(fd, (struct iovec[]){{buf, size}}, 1, flags, &addr,
                            &addrsize);
+      if (rc != -1 && addrsize == sizeof(addr)) {
+        addrsize = 0;
+      }
     } else if (__isfdkind(fd, kFdFile) && !opt_out_srcaddr) { /* socketpair */
       if (!flags) {
         rc = sys_read_nt(fd, (struct iovec[]){{buf, size}}, 1, -1);

--- a/libc/sock/recvfrom.c
+++ b/libc/sock/recvfrom.c
@@ -84,10 +84,14 @@ ssize_t recvfrom(int fd, void *buf, size_t size, int flags,
   }
 
   if (rc != -1) {
-    if (IsBsd()) {
-      __convert_bsd_to_sockaddr(&addr);
+    if (addrsize) {
+      if (IsBsd()) {
+        __convert_bsd_to_sockaddr(&addr);
+      }
+      __write_sockaddr(&addr, opt_out_srcaddr, opt_inout_srcaddrsize);
+    } else {
+      *opt_inout_srcaddrsize = 0;
     }
-    __write_sockaddr(&addr, opt_out_srcaddr, opt_inout_srcaddrsize);
   }
 
   END_CANCELATION_POINT;


### PR DESCRIPTION
Fix malformed address from being returned from `recvfrom` on connection oriented sockets: pass through `addrsize` when it's 0. Additionally, set `addrsize` to 0 when it is unchanged as win32 `recvfrom` does not set `addrsize` on connection sockets.

This behavior is not required by POSIX, but observed on at least "Linux, OS/X and OpenBSD" so I think we should adapt this behavior.

Perl depends on either this behavior or returning `getpeername`. To work around win32 `recvfrom` with Cygwin it sets `addrsize` to 0 when addrsize is unchanged:
 https://github.com/Perl/perl5/commit/e122534c08d52962b50cef019dffa861efbfb801#diff-400754cb38a9f79143e9a5b9248562cfde2ec692b374136149a4bef3d0fdbbac. For Win32 directly, it returns `getpeername` when size is unchanged: https://github.com/Perl/perl5/blob/8c2652c1d9709e58ccf726121d1d7bb04c96b354/win32/win32sck.c#L427-L441

Perl's `t/io/socket.t` expects `recvfrom` to return a 0 length src address when called on a `PF_INET` socket.

https://github.com/Perl/perl5/issues/13101

ALSO, looking at `recvfrom_test.c` I'm not sure why other test was set to only run on Windows. I tested my new test on Windows and Linux.