### PR TITLE
Loaders rewrite argv[0] for old binaries

### DIFF
--- a/ape/ape-m1.c
+++ b/ape/ape-m1.c
@@ -124,6 +124,7 @@ struct Syslib {
 #define PT_INTERP                   3
 #define EI_CLASS                    4
 #define EI_DATA                     5
+#define EF_APE_MODERN               1
 #define PF_X                        1
 #define PF_W                        2
 #define PF_R                        4
@@ -799,7 +800,7 @@ __attribute__((__noreturn__)) static void Spawn(const char *exe, int fd,
 }
 
 static const char *TryElf(struct ApeLoader *M, union ElfEhdrBuf *ebuf,
-                          const char *exe, int fd, long *sp, long *auxv,
+                          char *exe, int fd, long *sp, long *auxv,
                           char *execfn) {
   long i, rc;
   unsigned size;
@@ -819,6 +820,10 @@ static const char *TryElf(struct ApeLoader *M, union ElfEhdrBuf *ebuf,
   }
   if (e->e_machine != EM_AARCH64) {
     return "couldn't find ELF header with ARM64 machine type";
+  }
+  if (!(e->e_flags & EF_APE_MODERN)) {
+    /* change argv[0] to resolved path for older binaries */
+    ((char **)(sp + 1))[0] = exe;
   }
   if (e->e_phentsize != sizeof(struct ElfPhdr)) {
     Pexit(exe, 0, "e_phentsize is wrong");

--- a/ape/ape-m1.c
+++ b/ape/ape-m1.c
@@ -821,7 +821,7 @@ static const char *TryElf(struct ApeLoader *M, union ElfEhdrBuf *ebuf,
   if (e->e_machine != EM_AARCH64) {
     return "couldn't find ELF header with ARM64 machine type";
   }
-  if (!(e->e_flags & EF_APE_MODERN)) {
+  if (!(e->e_flags & EF_APE_MODERN) && sp[0]) {
     /* change argv[0] to resolved path for older binaries */
     ((char **)(sp + 1))[0] = exe;
   }

--- a/ape/ape-m1.c
+++ b/ape/ape-m1.c
@@ -124,7 +124,6 @@ struct Syslib {
 #define PT_INTERP                   3
 #define EI_CLASS                    4
 #define EI_DATA                     5
-#define EF_APE_MODERN               1
 #define PF_X                        1
 #define PF_W                        2
 #define PF_R                        4
@@ -146,6 +145,9 @@ struct Syslib {
 #define AT_SECURE                   23
 #define AT_RANDOM                   25
 #define AT_EXECFN                   31
+
+#define EF_APE_MODERN      0x101ca75
+#define EF_APE_MODERN_MASK 0x1ffffff
 
 #define AUXV_WORDS 31
 
@@ -821,7 +823,7 @@ static const char *TryElf(struct ApeLoader *M, union ElfEhdrBuf *ebuf,
   if (e->e_machine != EM_AARCH64) {
     return "couldn't find ELF header with ARM64 machine type";
   }
-  if (!(e->e_flags & EF_APE_MODERN) && sp[0]) {
+  if ((e->e_flags & EF_APE_MODERN_MASK) != EF_APE_MODERN && sp[0] > 0) {
     /* change argv[0] to resolved path for older binaries */
     ((char **)(sp + 1))[0] = exe;
   }

--- a/ape/ape.S
+++ b/ape/ape.S
@@ -196,7 +196,7 @@ ape_mz:
 	.quad	ape_elf_entry			//  18: e_entry
 	.quad	ape_elf_phoff			//  20: e_phoff
 	.quad	ape_elf_shoff			//  28: e_shoff
-	.long	0				//  30: e_flags
+	.long	1				//  30: e_flags
 	.short	64				//  34: e_ehsize
 	.short	56				//  36: e_phentsize
 	.short	ape_elf_phnum			//  38: e_phnum
@@ -669,7 +669,7 @@ apesh:	.ascii	"\n@\n#'\"\n"			// sixth edition shebang
 	.shstub	    ape_elf_entry,8		//  18: e_entry
 	.shstub	    ape_elf_phoff,8		//  20: e_phoff
 	.shstub	    ape_elf_shoff,8		//  28: e_shoff
-	.ascii	    "\\0\\0\\0\\0"		//  30: e_flags
+	.ascii	    "\\1\\0\\0\\0"		//  30: e_flags
 	.ascii	    "\\100\\0"			//  34: e_ehsize
 	.ascii	    "\\070\\0"			//  36: e_phentsize
 	.shstub	    ape_elf_phnum,2		//  38: e_phnum

--- a/ape/ape.S
+++ b/ape/ape.S
@@ -196,7 +196,7 @@ ape_mz:
 	.quad	ape_elf_entry			//  18: e_entry
 	.quad	ape_elf_phoff			//  20: e_phoff
 	.quad	ape_elf_shoff			//  28: e_shoff
-	.long	1				//  30: e_flags
+	.long	0x101ca75			//  30: ape e_flags
 	.short	64				//  34: e_ehsize
 	.short	56				//  36: e_phentsize
 	.short	ape_elf_phnum			//  38: e_phnum
@@ -669,7 +669,7 @@ apesh:	.ascii	"\n@\n#'\"\n"			// sixth edition shebang
 	.shstub	    ape_elf_entry,8		//  18: e_entry
 	.shstub	    ape_elf_phoff,8		//  20: e_phoff
 	.shstub	    ape_elf_shoff,8		//  28: e_shoff
-	.ascii	    "\\1\\0\\0\\0"		//  30: e_flags
+	.ascii	    "\\165\\312\\1\\1"		//  30: ape e_flags
 	.ascii	    "\\100\\0"			//  34: e_ehsize
 	.ascii	    "\\070\\0"			//  36: e_phentsize
 	.shstub	    ape_elf_phnum,2		//  38: e_phnum

--- a/ape/loader.c
+++ b/ape/loader.c
@@ -134,6 +134,7 @@
 #define PT_INTERP                   3
 #define EI_CLASS                    4
 #define EI_DATA                     5
+#define EF_APE_MODERN               1
 #define PF_X                        1
 #define PF_W                        2
 #define PF_R                        4
@@ -834,6 +835,10 @@ static const char *TryElf(struct ApeLoader *M, union ElfEhdrBuf *ebuf,
     return "couldn't find ELF header with x86-64 machine type";
   }
 #endif
+  if (!(e->e_flags & EF_APE_MODERN)) {
+    /* change argv[0] to resolved path for older binaries */
+    ((char **)(sp + 1))[0] = exe;
+  }
   if (e->e_phentsize != sizeof(struct ElfPhdr)) {
     Pexit(os, exe, 0, "e_phentsize is wrong");
   }

--- a/ape/loader.c
+++ b/ape/loader.c
@@ -134,7 +134,6 @@
 #define PT_INTERP                   3
 #define EI_CLASS                    4
 #define EI_DATA                     5
-#define EF_APE_MODERN               1
 #define PF_X                        1
 #define PF_W                        2
 #define PF_R                        4
@@ -152,6 +151,9 @@
 #define XCR0_AVX                    4
 #define PR_SET_MM                   35
 #define PR_SET_MM_EXE_FILE          13
+
+#define EF_APE_MODERN      0x101ca75
+#define EF_APE_MODERN_MASK 0x1ffffff
 
 #define READ32(S)                                                      \
   ((unsigned)(255 & (S)[3]) << 030 | (unsigned)(255 & (S)[2]) << 020 | \
@@ -835,7 +837,7 @@ static const char *TryElf(struct ApeLoader *M, union ElfEhdrBuf *ebuf,
     return "couldn't find ELF header with x86-64 machine type";
   }
 #endif
-  if (!(e->e_flags & EF_APE_MODERN) && sp[0]) {
+  if ((e->e_flags & EF_APE_MODERN_MASK) != EF_APE_MODERN && sp[0] > 0) {
     /* change argv[0] to resolved path for older binaries */
     ((char **)(sp + 1))[0] = exe;
   }

--- a/ape/loader.c
+++ b/ape/loader.c
@@ -835,7 +835,7 @@ static const char *TryElf(struct ApeLoader *M, union ElfEhdrBuf *ebuf,
     return "couldn't find ELF header with x86-64 machine type";
   }
 #endif
-  if (!(e->e_flags & EF_APE_MODERN)) {
+  if (!(e->e_flags & EF_APE_MODERN) && sp[0]) {
     /* change argv[0] to resolved path for older binaries */
     ((char **)(sp + 1))[0] = exe;
   }

--- a/libc/elf/def.h
+++ b/libc/elf/def.h
@@ -85,7 +85,8 @@
 #define EM_RISCV     243
 #define EM_BPF       247
 
-#define EF_APE_MODERN 1
+/* the ape flag, "lol cat 5" */
+#define EF_APE_MODERN 0x101ca75
 
 #define GRP_COMDAT 1
 #define STN_UNDEF  0

--- a/libc/elf/def.h
+++ b/libc/elf/def.h
@@ -86,7 +86,8 @@
 #define EM_BPF       247
 
 /* the ape flag, "lol cat 5" */
-#define EF_APE_MODERN 0x101ca75
+#define EF_APE_MODERN      0x101ca75
+#define EF_APE_MODERN_MASK 0x1ffffff
 
 #define GRP_COMDAT 1
 #define STN_UNDEF  0

--- a/libc/elf/def.h
+++ b/libc/elf/def.h
@@ -85,6 +85,8 @@
 #define EM_RISCV     243
 #define EM_BPF       247
 
+#define EF_APE_MODERN 1
+
 #define GRP_COMDAT 1
 #define STN_UNDEF  0
 

--- a/tool/build/fixupobj.c
+++ b/tool/build/fixupobj.c
@@ -332,7 +332,8 @@ static void UseFreebsdOsAbi(void) {
 }
 
 static void WriteApeFlags(void) {
-  elf->e_flags |= EF_APE_MODERN;
+  /* try to be forward-compatible */
+  elf->e_flags = (elf->e_flags & ~EF_APE_MODERN_MASK) | EF_APE_MODERN;
 }
 
 /**

--- a/tool/build/fixupobj.c
+++ b/tool/build/fixupobj.c
@@ -331,6 +331,10 @@ static void UseFreebsdOsAbi(void) {
   elf->e_ident[EI_OSABI] = ELFOSABI_FREEBSD;
 }
 
+static void WriteApeFlags(void) {
+  elf->e_flags |= EF_APE_MODERN;
+}
+
 /**
  * Improve GCC11 `-fpatchable-function-entry` codegen.
  *
@@ -692,6 +696,7 @@ static void FixupObject(void) {
         }
       }
       if (elf->e_type != ET_REL) {
+        WriteApeFlags();
         PurgeIfuncSections();
         RelinkZipFiles();
       }


### PR DESCRIPTION
For this to work, a loader has to be able to tell the difference between
an ‘old’ and a ‘new’ binary. This is achieved via a repurposing of ELF’s
e_flags field. We previously tried to use the padding in e_ident for it,
but binutils was resetting it to zero in e.g. strip.

This introduces one new ELF flag for cosmopolitan binaries. It is called
\``EF_APE_MODERN`\`, and it is bit 1.

It should now be safe to install the ape loader binfmt registration with
the \``P`\` flag.