### PR TITLE
ntspawn: fix initializing NtStartupInfoEx

### DIFF
--- a/libc/calls/ntspawn.c
+++ b/libc/calls/ntspawn.c
@@ -177,9 +177,9 @@ static textwindows int ntspawn2(struct NtSpawnArgs *a, struct SpawnBlock *sb) {
   if (ok) {
     struct NtStartupInfoEx info = {
         .StartupInfo = *a->lpStartupInfo,
-        .StartupInfo.cb = sizeof(info),
         .lpAttributeList = alist,
     };
+    info.StartupInfo.cb = sizeof(info);
     if (ok) {
       if (CreateProcess(sb->path, sb->cmdline, 0, 0, true,
                         a->dwCreationFlags | kNtCreateUnicodeEnvironment |


### PR DESCRIPTION
Fixes https://github.com/jart/cosmopolitan/issues/1188

Initializing `info.StartupInfo.cb = sizeof(info)` inside of the initializer statement was clearing the rest of `info.StartupInfo`.

