### PR TITLE
Fix some memory issues with ctl::string

### DIFF
--- a/ctl/string.cc
+++ b/ctl/string.cc
@@ -99,7 +99,8 @@ string::reserve(size_t c2) noexcept
     if (!isbig()) {
         if (!(p2 = (char*)malloc(c2)))
             __builtin_trap();
-        memcpy(p2, data(), size() + 1);
+        memcpy(p2, data(), size());
+        p2[size()] = 0;
     } else {
         if (!(p2 = (char*)realloc(big()->p, c2)))
             __builtin_trap();
@@ -134,18 +135,18 @@ string::append(char ch) noexcept
     if (ckd_add(&n2, size(), 2))
         __builtin_trap();
     if (n2 > capacity()) {
-        size_t c2 = capacity() + 2;
+        size_t c2 = capacity();
         if (ckd_add(&c2, c2, c2 >> 1))
             __builtin_trap();
         reserve(c2);
     }
     data()[size()] = ch;
-    data()[size() + 1] = 0;
     if (isbig()) {
         ++big()->n;
     } else {
         --small()->rem;
     }
+    data()[size()] = 0;
 }
 
 void

--- a/ctl/string.h
+++ b/ctl/string.h
@@ -151,7 +151,7 @@ class string
         if (isbig() && big()->c <= __::sso_max)
             __builtin_trap();
 #endif
-        return isbig() ? __::big_mask & big()->c : __::sso_max;
+        return isbig() ? __::big_mask & big()->c : __::string_size;
     }
 
     iterator begin() noexcept

--- a/test/ctl/string_test.cc
+++ b/test/ctl/string_test.cc
@@ -24,16 +24,15 @@
 #include "libc/runtime/runtime.h"
 #include "libc/str/str.h"
 
-using String = ctl::string;
 // #include <string>
-// using String = std::string;
+// #define ctl std
 
 int
 main()
 {
 
     {
-        String s;
+        ctl::string s;
         s += 'h';
         s += 'i';
         if (s != "hi")
@@ -41,7 +40,7 @@ main()
     }
 
     {
-        String s;
+        ctl::string s;
         if (!s.empty())
             return 6;
         s.reserve(32);
@@ -57,7 +56,7 @@ main()
     }
 
     {
-        String s;
+        ctl::string s;
         s += "hello world how are you";
         s.reserve(3);
         if (s != "hello world how are you")
@@ -65,7 +64,7 @@ main()
     }
 
     {
-        String s(4, 'x');
+        ctl::string s(4, 'x');
         if (s != "xxxx")
             return 12;
         s.resize(3);
@@ -77,42 +76,42 @@ main()
     }
 
     {
-        String a = "a";
-        String b = "a";
+        ctl::string a = "a";
+        ctl::string b = "a";
         if (a.compare(b) != 0)
             return 17;
     }
 
     {
-        String a = "a";
-        String b = "b";
+        ctl::string a = "a";
+        ctl::string b = "b";
         if (a.compare(b) >= 0)
             return 18;
     }
 
     {
-        String a = "a";
-        String b = "ab";
+        ctl::string a = "a";
+        ctl::string b = "ab";
         if (a.compare(b) >= 0)
             return 19;
     }
 
     {
-        String a = "ab";
-        String b = "a";
+        ctl::string a = "ab";
+        ctl::string b = "a";
         if (a.compare(b) <= 0)
             return 20;
     }
 
     {
-        String a = "";
-        String b = "";
+        ctl::string a = "";
+        ctl::string b = "";
         if (a.compare(b) != 0)
             return 21;
     }
 
     {
-        String a = "fooBARbaz";
+        ctl::string a = "fooBARbaz";
         if (a.substr(3, 3) != "BAR")
             return 22;
         if (a.replace(3, 3, "MOO") != "fooMOObaz")
@@ -120,7 +119,7 @@ main()
     }
 
     {
-        String a = "fooBAR";
+        ctl::string a = "fooBAR";
         if (a.substr(3, 3) != "BAR")
             return 24;
         if (a.replace(3, 3, "MOO") != "fooMOO")
@@ -128,7 +127,7 @@ main()
     }
 
     {
-        String a = "fooBAR";
+        ctl::string a = "fooBAR";
         if (a.substr(1, 0) != "")
             return 26;
         if (a.replace(1, 0, "MOO") != "fMOOooBAR")
@@ -144,15 +143,15 @@ main()
     }
 
     {
-        String s1 = "hello";
-        String s2 = "world";
-        String s3 = s1 + " " + s2;
+        ctl::string s1 = "hello";
+        ctl::string s2 = "world";
+        ctl::string s3 = s1 + " " + s2;
         if (s3 != "hello world")
             return 32;
     }
 
     {
-        String s = "hello";
+        ctl::string s = "hello";
         if (s.size() != 5)
             return 33;
         if (s.length() != 5)
@@ -162,7 +161,7 @@ main()
     }
 
     {
-        String s = "hello";
+        ctl::string s = "hello";
         if (s[0] != 'h' || s[1] != 'e' || s[2] != 'l' || s[3] != 'l' ||
             s[4] != 'o')
             return 36;
@@ -172,17 +171,17 @@ main()
     }
 
     {
-        String s = "hello";
+        ctl::string s = "hello";
         if (s.find('e') != 1)
             return 38;
         if (s.find('l') != 2)
             return 39;
-        if (s.find('x') != s.npos)
+        if (s.find('x') != ctl::string::npos)
             return 40;
     }
 
     {
-        String s = "hello";
+        ctl::string s = "hello";
         if (!s.ends_with("lo"))
             return 41;
         if (s.ends_with("el"))
@@ -190,8 +189,8 @@ main()
     }
 
     {
-        String s = "hello";
-        String sub = s.substr(1, 3);
+        ctl::string s = "hello";
+        ctl::string sub = s.substr(1, 3);
         if (sub != "ell")
             return 43;
         sub = s.substr(2);
@@ -200,8 +199,8 @@ main()
     }
 
     {
-        String s = "hello";
-        String s2 = s;
+        ctl::string s = "hello";
+        ctl::string s2 = s;
         if (s != s2)
             return 45;
         s2[0] = 'H';
@@ -210,8 +209,8 @@ main()
     }
 
     {
-        String s = "hello";
-        String s2 = std::move(s);
+        ctl::string s = "hello";
+        ctl::string s2 = std::move(s);
         if (s2 != "hello")
             return 47;
         if (!s.empty())
@@ -219,14 +218,14 @@ main()
     }
 
     {
-        String s = "hello";
+        ctl::string s = "hello";
         const char* cstr = s.c_str();
         if (strcmp(cstr, "hello") != 0)
             return 49;
     }
 
     // {
-    //     String s = "hello";
+    //     ctl::string s = "hello";
     //     char buffer[10];
     //     s.copy(buffer, sizeof(buffer));
     //     if (strcmp(buffer, "hello") != 0)
@@ -234,7 +233,7 @@ main()
     // }
 
     {
-        String s = "hello";
+        ctl::string s = "hello";
         s.resize(3);
         if (s != "hel")
             return 51;
@@ -244,14 +243,14 @@ main()
     }
 
     {
-        String s = "hello";
+        ctl::string s = "hello";
         s.clear();
         if (!s.empty())
             return 53;
     }
 
     {
-        String s = "hello";
+        ctl::string s = "hello";
         auto it = s.begin();
         if (*it != 'h')
             return 54;
@@ -261,21 +260,21 @@ main()
     }
 
     // {
-    //     String s = "hello";
-    //     String s2 = "world";
+    //     ctl::string s = "hello";
+    //     ctl::string s2 = "world";
     //     s.swap(s2);
     //     if (s != "world" || s2 != "hello")
     //         return 56;
     // }
 
     {
-        String s = "hello";
+        ctl::string s = "hello";
         if (s.front() != 'h' || s.back() != 'o')
             return 57;
     }
 
     {
-        String s = "hello";
+        ctl::string s = "hello";
         s.push_back('!');
         if (s != "hello!")
             return 58;
@@ -285,28 +284,28 @@ main()
     }
 
     {
-        String s = "hello";
+        ctl::string s = "hello";
         s.insert(2, "XYZ");
         if (s != "heXYZllo")
             return 60;
     }
 
     {
-        String s = "hello";
+        ctl::string s = "hello";
         s.erase(1, 2);
         if (s != "hlo")
             return 61;
     }
 
     {
-        String s = "hello";
+        ctl::string s = "hello";
         s.replace(1, 2, "XYZ");
         if (s != "hXYZlo")
             return 62;
     }
 
     {
-        String s = "hello";
+        ctl::string s = "hello";
         s.append(" world");
         if (s != "hello world")
             return 63;
@@ -320,14 +319,14 @@ main()
     }
 
     // {
-    //     String s = "hello";
+    //     ctl::string s = "hello";
     //     s.assign("world");
     //     if (s != "world")
     //         return 64;
     // }
 
     {
-        String s = "hello";
+        ctl::string s = "hello";
         if (s.compare("world") >= 0)
             return 65;
         if (s.compare("hello") != 0)
@@ -337,7 +336,7 @@ main()
     }
 
     {
-        String s = "hello";
+        ctl::string s = "hello";
         if (s == "world")
             return 68;
         if (s != "hello")
@@ -356,7 +355,8 @@ main()
     }
 
     {
-        String s;
+        ctl::string s;
+#undef ctl
         if constexpr (std::is_same_v<ctl::string, decltype(s)>) {
             // tests the small-string optimization on ctl::string
             char* d = s.data();

--- a/test/ctl/string_test.cc
+++ b/test/ctl/string_test.cc
@@ -23,7 +23,7 @@
 #include "libc/runtime/runtime.h"
 #include "libc/str/str.h"
 
-// #include <string>
+#include <string>
 // #define ctl std
 
 int
@@ -351,6 +351,22 @@ main()
             return 77;
         if ("hell"s + "o" != "hello")
             return 78;
+    }
+
+    if constexpr (!std::is_same_v<ctl::string, std::string>) {
+        // tests the small-string optimization on ctl::string
+        ctl::string s;
+        char *d = s.data();
+        for (int i = 0; i < 23; ++i) {
+            s.append('a');
+            if (s.data() != d) {
+                return 79 + i;
+            }
+        }
+        s.append('a');
+        if (s.data() == d) {
+            return 103;
+        }
     }
 
     CheckForMemoryLeaks();

--- a/test/ctl/string_test.cc
+++ b/test/ctl/string_test.cc
@@ -18,12 +18,13 @@
 
 #include "ctl/string.h"
 
+#include <__type_traits/is_same.h>
 #include <__utility/move.h>
 
 #include "libc/runtime/runtime.h"
 #include "libc/str/str.h"
 
-#include <string>
+// #include <string>
 // #define ctl std
 
 int
@@ -312,7 +313,7 @@ main()
             s.append(" world");
         }
         if (s != "hello world world world world world world world world world "
-            "world world") {
+                 "world world") {
             return 64;
         }
     }
@@ -355,9 +356,10 @@ main()
 
     {
         ctl::string s;
-        if constexpr (!std::is_same_v<ctl::string, std::string>) {
+#undef ctl
+        if constexpr (std::is_same_v<ctl::string, decltype(s)>) {
             // tests the small-string optimization on ctl::string
-            char *d = s.data();
+            char* d = s.data();
             for (int i = 0; i < 23; ++i) {
                 s.append('a');
                 if (s.data() != d) {

--- a/test/ctl/string_test.cc
+++ b/test/ctl/string_test.cc
@@ -353,19 +353,29 @@ main()
             return 78;
     }
 
-    if constexpr (!std::is_same_v<ctl::string, std::string>) {
-        // tests the small-string optimization on ctl::string
+    {
         ctl::string s;
-        char *d = s.data();
-        for (int i = 0; i < 23; ++i) {
+        if constexpr (!std::is_same_v<ctl::string, std::string>) {
+            // tests the small-string optimization on ctl::string
+            char *d = s.data();
+            for (int i = 0; i < 23; ++i) {
+                s.append('a');
+                if (s.data() != d) {
+                    return 79 + i;
+                }
+            }
             s.append('a');
-            if (s.data() != d) {
-                return 79 + i;
+            if (s.data() == d) {
+                return 103;
+            }
+        } else {
+            // just check that append in a loop works
+            for (int i = 0; i < 24; ++i) {
+                s.append('a');
             }
         }
-        s.append('a');
-        if (s.data() == d) {
-            return 103;
+        if (s != "aaaaaaaaaaaaaaaaaaaaaaaa") {
+            return 104;
         }
     }
 

--- a/test/ctl/string_test.cc
+++ b/test/ctl/string_test.cc
@@ -24,15 +24,16 @@
 #include "libc/runtime/runtime.h"
 #include "libc/str/str.h"
 
+using String = ctl::string;
 // #include <string>
-// #define ctl std
+// using String = std::string;
 
 int
 main()
 {
 
     {
-        ctl::string s;
+        String s;
         s += 'h';
         s += 'i';
         if (s != "hi")
@@ -40,7 +41,7 @@ main()
     }
 
     {
-        ctl::string s;
+        String s;
         if (!s.empty())
             return 6;
         s.reserve(32);
@@ -56,7 +57,7 @@ main()
     }
 
     {
-        ctl::string s;
+        String s;
         s += "hello world how are you";
         s.reserve(3);
         if (s != "hello world how are you")
@@ -64,7 +65,7 @@ main()
     }
 
     {
-        ctl::string s(4, 'x');
+        String s(4, 'x');
         if (s != "xxxx")
             return 12;
         s.resize(3);
@@ -76,42 +77,42 @@ main()
     }
 
     {
-        ctl::string a = "a";
-        ctl::string b = "a";
+        String a = "a";
+        String b = "a";
         if (a.compare(b) != 0)
             return 17;
     }
 
     {
-        ctl::string a = "a";
-        ctl::string b = "b";
+        String a = "a";
+        String b = "b";
         if (a.compare(b) >= 0)
             return 18;
     }
 
     {
-        ctl::string a = "a";
-        ctl::string b = "ab";
+        String a = "a";
+        String b = "ab";
         if (a.compare(b) >= 0)
             return 19;
     }
 
     {
-        ctl::string a = "ab";
-        ctl::string b = "a";
+        String a = "ab";
+        String b = "a";
         if (a.compare(b) <= 0)
             return 20;
     }
 
     {
-        ctl::string a = "";
-        ctl::string b = "";
+        String a = "";
+        String b = "";
         if (a.compare(b) != 0)
             return 21;
     }
 
     {
-        ctl::string a = "fooBARbaz";
+        String a = "fooBARbaz";
         if (a.substr(3, 3) != "BAR")
             return 22;
         if (a.replace(3, 3, "MOO") != "fooMOObaz")
@@ -119,7 +120,7 @@ main()
     }
 
     {
-        ctl::string a = "fooBAR";
+        String a = "fooBAR";
         if (a.substr(3, 3) != "BAR")
             return 24;
         if (a.replace(3, 3, "MOO") != "fooMOO")
@@ -127,7 +128,7 @@ main()
     }
 
     {
-        ctl::string a = "fooBAR";
+        String a = "fooBAR";
         if (a.substr(1, 0) != "")
             return 26;
         if (a.replace(1, 0, "MOO") != "fMOOooBAR")
@@ -143,15 +144,15 @@ main()
     }
 
     {
-        ctl::string s1 = "hello";
-        ctl::string s2 = "world";
-        ctl::string s3 = s1 + " " + s2;
+        String s1 = "hello";
+        String s2 = "world";
+        String s3 = s1 + " " + s2;
         if (s3 != "hello world")
             return 32;
     }
 
     {
-        ctl::string s = "hello";
+        String s = "hello";
         if (s.size() != 5)
             return 33;
         if (s.length() != 5)
@@ -161,7 +162,7 @@ main()
     }
 
     {
-        ctl::string s = "hello";
+        String s = "hello";
         if (s[0] != 'h' || s[1] != 'e' || s[2] != 'l' || s[3] != 'l' ||
             s[4] != 'o')
             return 36;
@@ -171,17 +172,17 @@ main()
     }
 
     {
-        ctl::string s = "hello";
+        String s = "hello";
         if (s.find('e') != 1)
             return 38;
         if (s.find('l') != 2)
             return 39;
-        if (s.find('x') != ctl::string::npos)
+        if (s.find('x') != s.npos)
             return 40;
     }
 
     {
-        ctl::string s = "hello";
+        String s = "hello";
         if (!s.ends_with("lo"))
             return 41;
         if (s.ends_with("el"))
@@ -189,8 +190,8 @@ main()
     }
 
     {
-        ctl::string s = "hello";
-        ctl::string sub = s.substr(1, 3);
+        String s = "hello";
+        String sub = s.substr(1, 3);
         if (sub != "ell")
             return 43;
         sub = s.substr(2);
@@ -199,8 +200,8 @@ main()
     }
 
     {
-        ctl::string s = "hello";
-        ctl::string s2 = s;
+        String s = "hello";
+        String s2 = s;
         if (s != s2)
             return 45;
         s2[0] = 'H';
@@ -209,8 +210,8 @@ main()
     }
 
     {
-        ctl::string s = "hello";
-        ctl::string s2 = std::move(s);
+        String s = "hello";
+        String s2 = std::move(s);
         if (s2 != "hello")
             return 47;
         if (!s.empty())
@@ -218,14 +219,14 @@ main()
     }
 
     {
-        ctl::string s = "hello";
+        String s = "hello";
         const char* cstr = s.c_str();
         if (strcmp(cstr, "hello") != 0)
             return 49;
     }
 
     // {
-    //     ctl::string s = "hello";
+    //     String s = "hello";
     //     char buffer[10];
     //     s.copy(buffer, sizeof(buffer));
     //     if (strcmp(buffer, "hello") != 0)
@@ -233,7 +234,7 @@ main()
     // }
 
     {
-        ctl::string s = "hello";
+        String s = "hello";
         s.resize(3);
         if (s != "hel")
             return 51;
@@ -243,14 +244,14 @@ main()
     }
 
     {
-        ctl::string s = "hello";
+        String s = "hello";
         s.clear();
         if (!s.empty())
             return 53;
     }
 
     {
-        ctl::string s = "hello";
+        String s = "hello";
         auto it = s.begin();
         if (*it != 'h')
             return 54;
@@ -260,21 +261,21 @@ main()
     }
 
     // {
-    //     ctl::string s = "hello";
-    //     ctl::string s2 = "world";
+    //     String s = "hello";
+    //     String s2 = "world";
     //     s.swap(s2);
     //     if (s != "world" || s2 != "hello")
     //         return 56;
     // }
 
     {
-        ctl::string s = "hello";
+        String s = "hello";
         if (s.front() != 'h' || s.back() != 'o')
             return 57;
     }
 
     {
-        ctl::string s = "hello";
+        String s = "hello";
         s.push_back('!');
         if (s != "hello!")
             return 58;
@@ -284,28 +285,28 @@ main()
     }
 
     {
-        ctl::string s = "hello";
+        String s = "hello";
         s.insert(2, "XYZ");
         if (s != "heXYZllo")
             return 60;
     }
 
     {
-        ctl::string s = "hello";
+        String s = "hello";
         s.erase(1, 2);
         if (s != "hlo")
             return 61;
     }
 
     {
-        ctl::string s = "hello";
+        String s = "hello";
         s.replace(1, 2, "XYZ");
         if (s != "hXYZlo")
             return 62;
     }
 
     {
-        ctl::string s = "hello";
+        String s = "hello";
         s.append(" world");
         if (s != "hello world")
             return 63;
@@ -319,14 +320,14 @@ main()
     }
 
     // {
-    //     ctl::string s = "hello";
+    //     String s = "hello";
     //     s.assign("world");
     //     if (s != "world")
     //         return 64;
     // }
 
     {
-        ctl::string s = "hello";
+        String s = "hello";
         if (s.compare("world") >= 0)
             return 65;
         if (s.compare("hello") != 0)
@@ -336,7 +337,7 @@ main()
     }
 
     {
-        ctl::string s = "hello";
+        String s = "hello";
         if (s == "world")
             return 68;
         if (s != "hello")
@@ -355,8 +356,7 @@ main()
     }
 
     {
-        ctl::string s;
-#undef ctl
+        String s;
         if constexpr (std::is_same_v<ctl::string, decltype(s)>) {
             // tests the small-string optimization on ctl::string
             char* d = s.data();

--- a/test/ctl/string_test.cc
+++ b/test/ctl/string_test.cc
@@ -361,19 +361,19 @@ main()
             // tests the small-string optimization on ctl::string
             char* d = s.data();
             for (int i = 0; i < 23; ++i) {
-                s.append('a');
+                s.append("a");
                 if (s.data() != d) {
                     return 79 + i;
                 }
             }
-            s.append('a');
+            s.append("a");
             if (s.data() == d) {
                 return 103;
             }
         } else {
             // just check that append in a loop works
             for (int i = 0; i < 24; ++i) {
-                s.append('a');
+                s.append("a");
             }
         }
         if (s != "aaaaaaaaaaaaaaaaaaaaaaaa") {


### PR DESCRIPTION
There were a few errors in how capacity and memory was being handled for small strings. The capacity errors meant that small strings would become big strings too soon, and the memory error introduced undefined behavior that was caught by CheckMemoryLeaks in our test file but only sometimes.

The crucial change is in reserve: we only copy n bytes into p2, and then we manually set the null terminator instead of expecting it to have been there already. (E.g. it might not be there for an empty small string.)

We also fix one other doozy in append when we were exactly at the small- to-big string boundary: we set the last byte (i.e., the remainder field) to 0, then decremented it, giving us size_t max. Whoops. We boneheadedly fix this by setting the 0 byte after we've fixed up the remainder, so it is at worst a no-op.

Otherwise, capacity now works the same for small strings as it does with big strings: it's the amount of space available including the null byte.

We test all of this with a new test that only gets included if our class under test is not std::string (presumably meaning it's ctl::string.) The test manually verifies that the small string optimization behaves how we expect.

Since this test checks against std::string, we go ahead and include that other header from the STL.