### PR TITLE
Fix bugs in in ctl::optional

### DIFF
--- a/test/ctl/optional_test.cc
+++ b/test/ctl/optional_test.cc
@@ -26,6 +26,8 @@
 // #include <string>
 // #define ctl std
 
+static int g = 0;
+
 int
 main()
 {
@@ -112,6 +114,13 @@ main()
             return 23;
         if (x.value() != "hello")
             return 24;
+    }
+
+    {
+        struct A { int* p = &g; A() {++*p; } };
+        ctl::optional<A> x;
+        if (g != 0)
+            return 25;
     }
 
     CheckForMemoryLeaks();


### PR DESCRIPTION
Manually manage the lifetime of `value_` by using an anonymous
`union`. This fixes a bunch of double-frees and double-constructs.

Additionally move the `present_` flag last. When `T` has padding
`present_` will be placed there saving `alignof(T)` bytes from
`sizeof(optional<T>)`.