### PR TITLE
Make big_string pod

### DIFF
--- a/ctl/string.cc
+++ b/ctl/string.cc
@@ -23,27 +23,19 @@
 
 namespace ctl {
 
-namespace __ {
-
-big_string::~big_string() /* noexcept */
-{
-    if (n) {
-        if (n >= c)
-            __builtin_trap();
-        if (p[n])
-            __builtin_trap();
-    }
-    if (c && !p)
-        __builtin_trap();
-    free(p);
-}
-
-} // namespace __
-
-string::~string() /* noexcept */
+string::~string() noexcept
 {
     if (isbig()) {
-        big()->~big_string();
+        auto* b = big();
+        if (b->n) {
+            if (b->n >= b->c)
+                __builtin_trap();
+            if (b->p[b->n])
+                __builtin_trap();
+        }
+        if (b->c && !b->p)
+            __builtin_trap();
+        free(b->p);
     }
 }
 

--- a/ctl/string.h
+++ b/ctl/string.h
@@ -38,8 +38,6 @@ struct big_string
     size_t c : sizeof(size_t) * 8 - 1;
     size_t big : 1 /* = 1 */;
 #endif
-
-    ~big_string() /* noexcept */;
 };
 
 } // namespace __


### PR DESCRIPTION
`big_string` is not pod which means it needs to be properly constructed and destroyed. Instead make it POD and destroy it manually in `string` destructor.