### PR TITLE
Decouple swap from std

### DIFF
--- a/ctl/optional.h
+++ b/ctl/optional.h
@@ -118,8 +118,9 @@ class optional
 
     void swap(optional& other) noexcept
     {
+        using std::swap;
         if (present_ && other.present_) {
-            std::swap(value_, other.value_);
+            swap(value_, other.value_);
         } else if (present_) {
             other.emplace(std::move(value_));
             reset();


### PR DESCRIPTION
This allows you to implement your own swap function without it having to be part of the std namespace. std::swap is still used if it's available.