### PR TITLE
ctl::string cleanup

### DIFF
--- a/ctl/string.cc
+++ b/ctl/string.cc
@@ -91,16 +91,13 @@ string::reserve(size_t c2) noexcept
     if (!isbig()) {
         if (!(p2 = (char*)malloc(c2)))
             __builtin_trap();
-        memcpy(p2, data(), size());
-        p2[size()] = 0;
+        memcpy(p2, data(), size() + 1);
     } else {
         if (!(p2 = (char*)realloc(big()->p, c2)))
             __builtin_trap();
     }
     std::atomic_signal_fence(std::memory_order_seq_cst);
-    set_big_capacity(c2);
-    big()->n = n;
-    big()->p = p2;
+    set_big_string(p2, n, c2);
 }
 
 void

--- a/ctl/string.cc
+++ b/ctl/string.cc
@@ -91,7 +91,7 @@ string::reserve(size_t c2) noexcept
     if (!isbig()) {
         if (!(p2 = (char*)malloc(c2)))
             __builtin_trap();
-        memcpy(p2, data(), size() + 1);
+        memcpy(p2, data(), __::string_size);
     } else {
         if (!(p2 = (char*)realloc(big()->p, c2)))
             __builtin_trap();


### PR DESCRIPTION
We now fully initialize a ctl::string’s memory, so that it is always set to a well-defined value, thus making it always safe to memcpy out of it. This incidentally makes our string::swap function legal, which it wasn’t before. This also saves us a store in string::reserve.

Now that we have made both big_string and smalL_string POD, I believe it is safe to elide the launder calls, and have done so, thus cleaning up a lot of the blob-related code.

I also got rid of set_big_capacity and replaced it with a set_big_string that leaves us in a well-defined state afterwards. This function also is able to be somewhat simpler; rather than delicate bit-twiddling, it just reaches straight into blob and rewrites it wholesale.

Overall, this shaves about 1–2ns off of most benchmarks, and adds 1ns to only one of them - creating a string from a char *.