### PR TITLE
Rerun clang-format on the repo

### DIFF
--- a/ape/macros.internal.h
+++ b/ape/macros.internal.h
@@ -84,9 +84,10 @@
 /* clang-format on */
 #elif defined(__LINKER__)
 
-#define BCX_NIBBLE(X) ((((X)&0xf) > 0x9) ? ((X)&0xf) + 0x37 : ((X)&0xf) + 0x30)
-#define BCX_OCTET(X)  ((BCX_NIBBLE((X) >> 4) << 8) | (BCX_NIBBLE((X) >> 0) << 0))
-#define BCX_INT16(X)  ((BCX_OCTET((X) >> 8) << 16) | (BCX_OCTET((X) >> 0) << 0))
+#define BCX_NIBBLE(X) \
+  ((((X) & 0xf) > 0x9) ? ((X) & 0xf) + 0x37 : ((X) & 0xf) + 0x30)
+#define BCX_OCTET(X) ((BCX_NIBBLE((X) >> 4) << 8) | (BCX_NIBBLE((X) >> 0) << 0))
+#define BCX_INT16(X) ((BCX_OCTET((X) >> 8) << 16) | (BCX_OCTET((X) >> 0) << 0))
 #define BCXSTUB(SYM, X)                      \
   HIDDEN(SYM##_bcx0 = BCX_INT16((X) >> 48)); \
   HIDDEN(SYM##_bcx1 = BCX_INT16((X) >> 32)); \
@@ -98,12 +99,12 @@
  *
  * <p>This allows linker scripts to generate printf commands.
  */
-#define BCO_OCTET(X) (((X)&0x7) + 0x30)
+#define BCO_OCTET(X) (((X) & 0x7) + 0x30)
 #define BCOB_UNIT(X)                                           \
   ((BCO_OCTET((X) >> 0) << 24) | (BCO_OCTET((X) >> 3) << 16) | \
-   (BCO_OCTET(((X)&0xff) >> 6) << 8) | 0x5c)
+   (BCO_OCTET(((X) & 0xff) >> 6) << 8) | 0x5c)
 
-#define PFBYTE(SYM, X, I) HIDDEN(SYM##_bcs##I = BCOB_UNIT((X) >> ((I)*8)))
+#define PFBYTE(SYM, X, I) HIDDEN(SYM##_bcs##I = BCOB_UNIT((X) >> ((I) * 8)))
 #define PFSTUB2(SYM, X) \
   HIDDEN(SYM = (X));    \
   PFBYTE(SYM, X, 0);    \
@@ -132,7 +133,7 @@
 #define SHSTUB2(SYM, X)             \
   HIDDEN(SYM##_bcs0 = BCD_LEFT(X)); \
   HIDDEN(SYM##_bcs1 = BCD_RIGHT(X))
-#define BCD_SMEAR(X) ((X) + (X)*10000)
+#define BCD_SMEAR(X) ((X) + (X) * 10000)
 #define BCD_LEFT(X)                                      \
   (((X)) < 10000     ? BCD_RIGHT(BCD_SMEAR(X)) | 0x10    \
    : (X) < 100000    ? BCD_RIGHT(BCD_SMEAR((X) / 10))    \

--- a/ctl/string.h
+++ b/ctl/string.h
@@ -83,7 +83,7 @@ class string
     {
         __builtin_memset(blob, 0, sizeof(size_t) * 2);
         // equivalent to set_small_size(0) but also zeroes memory
-        *(((size_t *)blob) + 2) = __::sso_max << (sizeof(size_t) - 1) * 8;
+        *(((size_t*)blob) + 2) = __::sso_max << (sizeof(size_t) - 1) * 8;
     }
 
     void swap(string& s) noexcept
@@ -293,13 +293,13 @@ class string
         *(blob + __::sso_max) = (__::sso_max - size);
     }
 
-    inline void set_big_string(char *p, size_t n, size_t c2) noexcept
+    inline void set_big_string(char* p, size_t n, size_t c2) noexcept
     {
         if (c2 > __::big_mask)
             __builtin_trap();
-        *(char **)blob = p;
-        *(((size_t *)blob) + 1) = n;
-        *(((size_t *)blob) + 2) = c2 | ~__::big_mask;
+        *(char**)blob = p;
+        *(((size_t*)blob) + 1) = n;
+        *(((size_t*)blob) + 2) = c2 | ~__::big_mask;
     }
 
     inline __::small_string* small() noexcept

--- a/examples/unbourne.c
+++ b/examples/unbourne.c
@@ -3051,7 +3051,7 @@ static const char *updatepwd(const char *dir) {
   if (*dir != '/') {
     if (new[-1] != '/')
       USTPUTC('/', new);
-    if (new > lim &&*lim == '/')
+    if (new > lim && *lim == '/')
       lim++;
   } else {
     USTPUTC('/', new);
@@ -8917,7 +8917,7 @@ static int readtoken1(int firstc, char const *syntax, char *eofmark,
   quotef = 0;
   bqlist = NULL;
   STARTSTACKSTR(out);
-loop : {                   /* for each line, until end of word */
+loop: {                    /* for each line, until end of word */
   CHECKEND();              /* set c to PEOF if at end of here document */
   for (;;) {               /* until end of line or end of word */
     CHECKSTRSPACE(4, out); /* permit 4 calls to USTPUTC */
@@ -9069,7 +9069,7 @@ endword:
    * is called, c is set to the first character of the next input line.  If
    * we are at the end of the here document, this routine sets the c to PEOF.
    */
-checkend : {
+checkend: {
   if (realeofmark(eofmark)) {
     int markloc;
     char *p;
@@ -9112,7 +9112,7 @@ checkend : {
    * specifying the fd to be redirected.  The variable "c" contains the
    * first character of the redirection operator.
    */
-parseredir : {
+parseredir: {
   char fd = *out;
   union node *np;
   np = (union node *)stalloc(sizeof(struct nfile));
@@ -9169,7 +9169,7 @@ parseredir : {
    * Parse a substitution.  At this point, we have read the dollar sign
    * and nothing else.
    */
-parsesub : {
+parsesub: {
   int subtype;
   int typeloc;
   char *p;
@@ -9287,7 +9287,7 @@ parsesub : {
    * list of commands (passed by reference), and savelen is the number of
    * characters on the top of the stack which must be preserved.
    */
-parsebackq : {
+parsebackq: {
   struct nodelist **nlpp;
   union node *n;
   char *str;
@@ -9382,7 +9382,7 @@ parsebackq : {
 /*
  * Parse an arithmetic expansion (indicate start of one and set state)
  */
-parsearith : {
+parsearith: {
   synstack_push(&synstack, synstack->prev ?: alloca(sizeof(*synstack)),
                 ARISYNTAX);
   synstack->dblquote = 1;

--- a/libc/calls/struct/bpf.internal.h
+++ b/libc/calls/struct/bpf.internal.h
@@ -4,7 +4,7 @@ COSMOPOLITAN_C_START_
 
 #define BPF_MAXINSNS 4096
 
-#define BPF_CLASS(code) ((code)&0x07)
+#define BPF_CLASS(code) ((code) & 0x07)
 #define BPF_LD          0x00 /* load into accumulator */
 #define BPF_LDX         0x01 /* load into index register */
 #define BPF_ST          0x02 /* store from immediate */
@@ -14,13 +14,13 @@ COSMOPOLITAN_C_START_
 #define BPF_RET         0x06
 #define BPF_MISC        0x07
 
-#define BPF_SIZE(code) ((code)&0x18)
+#define BPF_SIZE(code) ((code) & 0x18)
 #define BPF_W          0x00 /* 32-bit */
 #define BPF_H          0x08 /* 16-bit */
 #define BPF_B          0x10 /*  8-bit */
 #define BPF_DW         0x18 /* 64-bit (eBPF only) */
 
-#define BPF_MODE(code) ((code)&0xe0)
+#define BPF_MODE(code) ((code) & 0xe0)
 #define BPF_IMM        0x00 /* 64-bit immediate */
 #define BPF_ABS        0x20
 #define BPF_IND        0x40
@@ -28,7 +28,7 @@ COSMOPOLITAN_C_START_
 #define BPF_LEN        0x80
 #define BPF_MSH        0xa0
 
-#define BPF_OP(code) ((code)&0xf0)
+#define BPF_OP(code) ((code) & 0xf0)
 #define BPF_ADD      0x00
 #define BPF_SUB      0x10
 #define BPF_MUL      0x20
@@ -41,7 +41,7 @@ COSMOPOLITAN_C_START_
 #define BPF_MOD      0x90
 #define BPF_XOR      0xa0
 
-#define BPF_SRC(code) ((code)&0x08)
+#define BPF_SRC(code) ((code) & 0x08)
 #define BPF_JA        0x00
 #define BPF_JEQ       0x10
 #define BPF_JGT       0x20
@@ -442,7 +442,7 @@ COSMOPOLITAN_C_START_
 #define BPF_FLOW_DISSECTOR_F_STOP_AT_ENCAP      (1U << 2)
 
 #define BPF_LINE_INFO_LINE_NUM(line_col) ((line_col) >> 10)
-#define BPF_LINE_INFO_LINE_COL(line_col) ((line_col)&0x3ff)
+#define BPF_LINE_INFO_LINE_COL(line_col) ((line_col) & 0x3ff)
 
 #define BTF_F_COMPACT (1ULL << 0)
 #define BTF_F_NONAME  (1ULL << 1)

--- a/libc/calls/struct/filter.internal.h
+++ b/libc/calls/struct/filter.internal.h
@@ -17,16 +17,15 @@ struct sock_fprog {
   const struct sock_filter *filter;
 };
 
-#define BPF_RVAL(code)   ((code)&0x18)
+#define BPF_RVAL(code)   ((code) & 0x18)
 #define BPF_A            0x10
-#define BPF_MISCOP(code) ((code)&0xf8)
+#define BPF_MISCOP(code) ((code) & 0xf8)
 #define BPF_TAX          0x00
 #define BPF_TXA          0x80
 
-#define BPF_STMT(code, k) \
-  { (unsigned short)(code), 0, 0, k }
+#define BPF_STMT(code, k) {(unsigned short)(code), 0, 0, k}
 #define BPF_JUMP(code, k, jumptrue, jumpfalse) \
-  { (unsigned short)(code), jumptrue, jumpfalse, k }
+  {(unsigned short)(code), jumptrue, jumpfalse, k}
 
 #define BPF_MEMWORDS 16
 

--- a/libc/calls/struct/filter.internal.h
+++ b/libc/calls/struct/filter.internal.h
@@ -23,9 +23,10 @@ struct sock_fprog {
 #define BPF_TAX          0x00
 #define BPF_TXA          0x80
 
-#define BPF_STMT(code, k) {(unsigned short)(code), 0, 0, k}
+#define BPF_STMT(code, k) \
+  { (unsigned short)(code), 0, 0, k }
 #define BPF_JUMP(code, k, jumptrue, jumpfalse) \
-  {(unsigned short)(code), jumptrue, jumpfalse, k}
+  { (unsigned short)(code), jumptrue, jumpfalse, k }
 
 #define BPF_MEMWORDS 16
 

--- a/libc/calls/sys_ptrace.c
+++ b/libc/calls/sys_ptrace.c
@@ -24,7 +24,7 @@
 #include "libc/intrin/strace.internal.h"
 #include "libc/runtime/runtime.h"
 
-#define IsPeek(request) (IsLinux() && (request)-1u < 3)
+#define IsPeek(request) (IsLinux() && (request) - 1u < 3)
 
 /**
  * Traces process.

--- a/libc/dos.internal.h
+++ b/libc/dos.internal.h
@@ -2,7 +2,7 @@
 #define COSMOPOLITAN_LIBC_DOS_H_
 
 #define DOS_DATE(YEAR, MONTH_IDX1, DAY_IDX1) \
-  (((YEAR)-1980) << 9 | (MONTH_IDX1) << 5 | (DAY_IDX1))
+  (((YEAR) - 1980) << 9 | (MONTH_IDX1) << 5 | (DAY_IDX1))
 #define DOS_TIME(HOUR, MINUTE, SECOND) \
   ((HOUR) << 11 | (MINUTE) << 5 | (SECOND) >> 1)
 

--- a/libc/elf/def.h
+++ b/libc/elf/def.h
@@ -456,12 +456,12 @@
 #define DF_P1_GROUPPERM 0x00000002
 
 #define ELF64_ST_BIND(val)        (((unsigned char)(val)) >> 4)
-#define ELF64_ST_TYPE(val)        ((val)&0xf)
-#define ELF64_ST_INFO(bind, type) (((bind) << 4) + ((type)&0xf))
-#define ELF64_ST_VISIBILITY(o)    ((o)&0x03)
+#define ELF64_ST_TYPE(val)        ((val) & 0xf)
+#define ELF64_ST_INFO(bind, type) (((bind) << 4) + ((type) & 0xf))
+#define ELF64_ST_VISIBILITY(o)    ((o) & 0x03)
 
 #define ELF64_R_SYM(i)          ((i) >> 32)
-#define ELF64_R_TYPE(i)         ((i)&0xffffffff)
+#define ELF64_R_TYPE(i)         ((i) & 0xffffffff)
 #define ELF64_R_INFO(sym, type) ((((Elf64_Xword)(sym)) << 32) + (type))
 
 #define ELF64_M_SYM(info)       ((info) >> 8)

--- a/libc/intrin/describeframe.c
+++ b/libc/intrin/describeframe.c
@@ -25,7 +25,7 @@
 #include "libc/runtime/runtime.h"
 #include "libc/runtime/winargs.internal.h"
 
-#define UNSHADOW(x) ((int64_t)(MAX(0, (x)-0x7fff8000)) << 3)
+#define UNSHADOW(x) ((int64_t)(MAX(0, (x) - 0x7fff8000)) << 3)
 #define FRAME(x)    ((int)((x) >> 16))
 
 static const char *GetFrameName(int x) {

--- a/libc/intrin/float16.c
+++ b/libc/intrin/float16.c
@@ -22,7 +22,7 @@
  */
 
 #define asint(x) ((union pun){x}).i
-#define isnan(x) (((x)&0x7fff) > 0x7c00)
+#define isnan(x) (((x) & 0x7fff) > 0x7c00)
 
 union pun {
   _Float16 f;

--- a/libc/intrin/magicu.c
+++ b/libc/intrin/magicu.c
@@ -50,19 +50,22 @@ struct magicu __magicu_get(uint32_t d) {
       p32 = 2 * p32;
     }
     if (r + 1 >= d - r) {
-      if (q >= 0x7FFFFFFF) a = 1;
+      if (q >= 0x7FFFFFFF)
+        a = 1;
       q = 2 * q + 1;      // Update q.
       r = 2 * r + 1 - d;  // Update r.
     } else {
-      if (q >= 0x80000000) a = 1;
+      if (q >= 0x80000000)
+        a = 1;
       q = 2 * q;
       r = 2 * r + 1;
     }
     delta = d - 1 - r;
   } while (p < 64 && p32 < delta);
-  magu.M = q + 1;              // Magic number and
-  magu.s = p - 32;             // Shift amount to return
-  if (a) magu.s |= 64;         // Sets "add" indicator
+  magu.M = q + 1;   // Magic number and
+  magu.s = p - 32;  // Shift amount to return
+  if (a)
+    magu.s |= 64;              // Sets "add" indicator
   npassert(magu.M || magu.s);  // Never returns zero.
   return magu;
 }

--- a/libc/intrin/magicu.h
+++ b/libc/intrin/magicu.h
@@ -24,8 +24,10 @@ forceinline uint32_t __magicu_div(uint32_t x, struct magicu d) {
  * Checks if 𝑑 contains a valid initialized divisor.
  */
 static inline bool32 __magicu_valid(struct magicu d) {
-  if (!d.M && !d.s) return false;     /* uninitialized */
-  if (d.s & ~(64 | 63)) return false; /* corrupted */
+  if (!d.M && !d.s)
+    return false; /* uninitialized */
+  if (d.s & ~(64 | 63))
+    return false; /* corrupted */
   return true;
 }
 

--- a/libc/intrin/mman.greg.c
+++ b/libc/intrin/mman.greg.c
@@ -45,7 +45,7 @@
 #ifdef __x86_64__
 
 #define INVERT(x) (BANE + PHYSICAL((uintptr_t)(x)))
-#define NOPAGE    ((uint64_t)-1)
+#define NOPAGE    ((uint64_t) - 1)
 
 #define APE_STACK_VADDR                   \
   ({                                      \

--- a/libc/intrin/palignr.h
+++ b/libc/intrin/palignr.h
@@ -8,36 +8,36 @@ void palignr(void *, const void *, const void *, unsigned long);
 
 #if !defined(__STRICT_ANSI__) && !defined(__chibicc__) && defined(__x86_64__)
 __intrin_xmm_t __palignrs(__intrin_xmm_t, __intrin_xmm_t);
-#define palignr(C, B, A, I)                                                \
-  do {                                                                     \
-    if (__builtin_expect(!IsModeDbg() && X86_NEED(SSE) && X86_HAVE(SSSE3), \
-                         1)) {                                             \
-      __intrin_xmm_t *Xmm0 = (void *)(C);                                  \
-      const __intrin_xmm_t *Xmm1 = (const __intrin_xmm_t *)(B);            \
-      const __intrin_xmm_t *Xmm2 = (const __intrin_xmm_t *)(A);            \
-      if (__builtin_constant_p(I)) {                                       \
-        if (!X86_NEED(AVX)) {                                              \
-          asm("palignr\t%2,%1,%0"                                          \
-              : "=x"(*Xmm0)                                                \
-              : "x"(*Xmm2), "i"(I), "0"(*Xmm1));                           \
-        } else {                                                           \
-          asm("vpalignr\t%3,%2,%1,%0"                                      \
-              : "=x"(*Xmm0)                                                \
-              : "x"(*Xmm1), "x"(*Xmm2), "i"(I));                           \
-        }                                                                  \
-      } else {                                                             \
-        unsigned long Vimm = (I);                                          \
-        typeof(__palignrs) *Fn;                                            \
-        if (__builtin_expect(Vimm < 32, 1)) {                              \
-          Fn = (typeof(__palignrs) *)((uintptr_t)&__palignrs + Vimm * 8);  \
-          *Xmm0 = Fn(*Xmm1, *Xmm2);                                        \
-        } else {                                                           \
-          memset(Xmm0, 0, 16);                                             \
-        }                                                                  \
-      }                                                                    \
-    } else {                                                               \
-      palignr(C, B, A, I);                                                 \
-    }                                                                      \
+#define palignr(C, B, A, I)                                                 \
+  do {                                                                      \
+    if (__builtin_expect(!IsModeDbg() && X86_NEED(SSE) && X86_HAVE(SSSE3),  \
+                         1)) {                                              \
+      __intrin_xmm_t *Xmm0 = (void *)(C);                                   \
+      const __intrin_xmm_t *Xmm1 = (const __intrin_xmm_t *)(B);             \
+      const __intrin_xmm_t *Xmm2 = (const __intrin_xmm_t *)(A);             \
+      if (__builtin_constant_p(I)) {                                        \
+        if (!X86_NEED(AVX)) {                                               \
+          asm("palignr\t%2,%1,%0"                                           \
+              : "=x"(*Xmm0)                                                 \
+              : "x"(*Xmm2), "i"(I), "0"(*Xmm1));                            \
+        } else {                                                            \
+          asm("vpalignr\t%3,%2,%1,%0"                                       \
+              : "=x"(*Xmm0)                                                 \
+              : "x"(*Xmm1), "x"(*Xmm2), "i"(I));                            \
+        }                                                                   \
+      } else {                                                              \
+        unsigned long Vimm = (I);                                           \
+        typeof(__palignrs) *Fn;                                             \
+        if (__builtin_expect(Vimm < 32, 1)) {                               \
+          Fn = (typeof(__palignrs) *)((uintptr_t) & __palignrs + Vimm * 8); \
+          *Xmm0 = Fn(*Xmm1, *Xmm2);                                         \
+        } else {                                                            \
+          memset(Xmm0, 0, 16);                                              \
+        }                                                                   \
+      }                                                                     \
+    } else {                                                                \
+      palignr(C, B, A, I);                                                  \
+    }                                                                       \
   } while (0)
 #endif
 

--- a/libc/intrin/strlen.c
+++ b/libc/intrin/strlen.c
@@ -31,7 +31,7 @@ static __vex size_t __strlen(const char *s) {
     m = __builtin_ia32_pmovmskb128(*++p == z);
   return (const char *)p + __builtin_ctzl(m) - s;
 #else
-#define ONES ((word)-1 / 255)
+#define ONES ((word) - 1 / 255)
 #define BANE (ONES * (255 / 2 + 1))
   typedef unsigned long mayalias word;
   word w;

--- a/libc/log/check.h
+++ b/libc/log/check.h
@@ -25,7 +25,7 @@ COSMOPOLITAN_C_START_
 
 #define CHECK_ALIGNED(BYTES, VAR, ...)                                \
   do {                                                                \
-    if (((uintptr_t)VAR & ((BYTES)-1u))) {                            \
+    if (((uintptr_t)VAR & ((BYTES) - 1u))) {                          \
       __check_fail_aligned(BYTES, (uintptr_t)VAR, __FILE__, __LINE__, \
                            "" __VA_ARGS__);                           \
       __builtin_unreachable();                                        \
@@ -35,7 +35,7 @@ COSMOPOLITAN_C_START_
 
 #define DCHECK_ALIGNED(BYTES, VAR, ...)                      \
   do {                                                       \
-    if (((uintptr_t)VAR & ((BYTES)-1u))) {                   \
+    if (((uintptr_t)VAR & ((BYTES) - 1u))) {                 \
       __DCHK_ALIGNED(BYTES, (uintptr_t)VAR, "" __VA_ARGS__); \
       __builtin_unreachable();                               \
     }                                                        \

--- a/libc/macros.internal.h
+++ b/libc/macros.internal.h
@@ -21,8 +21,8 @@
 #define TRUE  1
 #define FALSE 0
 
-#define IS2POW(X)       (!((X) & ((X)-1)))
-#define ROUNDUP(X, K)   (((X) + (K)-1) & -(K))
+#define IS2POW(X)       (!((X) & ((X) - 1)))
+#define ROUNDUP(X, K)   (((X) + (K) - 1) & -(K))
 #define ROUNDDOWN(X, K) ((X) & -(K))
 #ifndef __ASSEMBLER__
 #define ABS(X)    ((X) >= 0 ? (X) : -(X))
@@ -40,7 +40,7 @@
 #define STRINGIFY(A)        __STRINGIFY(A)
 #define EQUIVALENT(X, Y)    (__builtin_constant_p((X) == (Y)) && ((X) == (Y)))
 #define TYPE_BIT(type)      (sizeof(type) * CHAR_BIT)
-#define TYPE_SIGNED(type)   (((type)-1) < 0)
+#define TYPE_SIGNED(type)   (((type) - 1) < 0)
 #define TYPE_INTEGRAL(type) (((type)0.5) != 0.5)
 
 #define ARRAYLEN(A) \

--- a/libc/mem/radix_sort_int32.c
+++ b/libc/mem/radix_sort_int32.c
@@ -25,7 +25,7 @@
 //         Sort for double-precision floating points. (2009).
 
 #define HIST_SIZE               (size_t)2048
-#define get_byte_0(v)           ((v)&0x7FF)
+#define get_byte_0(v)           ((v) & 0x7FF)
 #define get_byte_1(v)           (((v) >> 11) & 0x7FF)
 #define get_byte_2_flip_sign(v) (((unsigned)(v) >> 22) ^ 0x200)
 

--- a/libc/mem/radix_sort_int64.c
+++ b/libc/mem/radix_sort_int64.c
@@ -25,7 +25,7 @@
 //         Sort for double-precision floating points. (2009).
 
 #define HIST_SIZE               (size_t)2048
-#define get_byte_0(v)           ((v)&0x7FF)
+#define get_byte_0(v)           ((v) & 0x7FF)
 #define get_byte_1(v)           (((v) >> 11) & 0x7FF)
 #define get_byte_2(v)           (((v) >> 22) & 0x7FF)
 #define get_byte_3(v)           (((v) >> 33) & 0x7FF)

--- a/libc/mem/shuffle.internal.h
+++ b/libc/mem/shuffle.internal.h
@@ -13,7 +13,7 @@
 #define shuffle(R, A, n)                      \
   do {                                        \
     autotype(A) Array = (A);                  \
-    for (size_t i = (n)-1; i >= 1; --i) {     \
+    for (size_t i = (n) - 1; i >= 1; --i) {   \
       xchg(&Array[i], &Array[R() % (i + 1)]); \
     }                                         \
   } while (0)

--- a/libc/nexgen32e/rdtscp.h
+++ b/libc/nexgen32e/rdtscp.h
@@ -5,7 +5,7 @@
 #include "libc/nexgen32e/x86feature.h"
 COSMOPOLITAN_C_START_
 
-#define TSC_AUX_CORE(MSR) ((MSR)&0xfff)
+#define TSC_AUX_CORE(MSR) ((MSR) & 0xfff)
 #define TSC_AUX_NODE(MSR) (((MSR) >> 12) & 0xfff)
 
 /**

--- a/libc/nt/enum/status.h
+++ b/libc/nt/enum/status.h
@@ -74,10 +74,10 @@ typedef uint32_t NtStatus;
 #define NtInformation(s)  (NtSeverity(s) == 1)
 #define NtWarning(s)      (NtSeverity(s) == 2)
 #define NtError(s)        (NtSeverity(s) == 3)
-#define NtCode(s)         ((NtStatus)(s)&0xffff)
+#define NtCode(s)         ((NtStatus)(s) & 0xffff)
 #define NtSeverity(s)     ((NtStatus)(s) >> 30)
 #define NtFacility(s)     (((NtStatus)(s) >> 16) & 0xfff)
-#define NtFacilityCode(s) ((NtStatus)(s)&0x0FFFFFFF)
+#define NtFacilityCode(s) ((NtStatus)(s) & 0x0FFFFFFF)
 
 #endif /* !(__ASSEMBLER__ + __LINKER__ + 0) */
 #endif /* COSMOPOLITAN_LIBC_NT_STATUS_H_ */

--- a/libc/nt/pedef.internal.h
+++ b/libc/nt/pedef.internal.h
@@ -198,8 +198,8 @@
 #define kNtImageScnScaleIndex     0x00000001
 
 #define kNtImageSymUndefined            ((uint16_t)0)
-#define kNtImageSymAbsolute             ((uint16_t)-1)
-#define kNtImageSymDebug                ((uint16_t)-2)
+#define kNtImageSymAbsolute             ((uint16_t) - 1)
+#define kNtImageSymDebug                ((uint16_t) - 2)
 #define kNtImageSymSectionMax           0xFEFF
 #define kNtImageSymSectionMaxEx         __LONG_MAX__
 #define kNtImageSymTypeNull             0x0000

--- a/libc/runtime/getinterpreterexecutablename.c
+++ b/libc/runtime/getinterpreterexecutablename.c
@@ -68,6 +68,7 @@ char *GetInterpreterExecutableName(char *p, size_t n) {
     p[rc] = 0;
     return p;
   } else if (IsFreebsd() || IsNetbsd()) {
+    // clang-format off
     cmd[0] = 1;         // CTL_KERN
     cmd[1] = 14;        // KERN_PROC
     if (IsFreebsd()) {  //
@@ -76,6 +77,7 @@ char *GetInterpreterExecutableName(char *p, size_t n) {
       cmd[2] = 5;       // KERN_PROC_PATHNAME
     }                   //
     cmd[3] = -1;        // current process
+    // clang-format on
     if (sysctl(cmd, ARRAYLEN(cmd), p, &n, 0, 0) != -1) {
       errno = e;
       return p;

--- a/libc/sock/epoll.c
+++ b/libc/sock/epoll.c
@@ -108,11 +108,10 @@ https://github.com/piscisaureus/wepoll");
   (EPOLLIN | EPOLLPRI | EPOLLOUT | EPOLLERR | EPOLLHUP | EPOLLRDNORM | \
    EPOLLRDBAND | EPOLLWRNORM | EPOLLWRBAND | EPOLLMSG | EPOLLRDHUP)
 
-#define RTL_CONSTANT_STRING(s) \
-  { sizeof(s) - sizeof((s)[0]), sizeof(s), s }
+#define RTL_CONSTANT_STRING(s) {sizeof(s) - sizeof((s)[0]), sizeof(s), s}
 
 #define RTL_CONSTANT_OBJECT_ATTRIBUTES(ObjectName, Attributes) \
-  { sizeof(struct NtObjectAttributes), 0, ObjectName, Attributes, NULL, NULL }
+  {sizeof(struct NtObjectAttributes), 0, ObjectName, Attributes, NULL, NULL}
 
 #define RETURN_MAP_ERROR(value) \
   do {                          \
@@ -127,7 +126,7 @@ https://github.com/piscisaureus/wepoll");
   } while (0)
 
 #define CONTAINOF(ptr, type, member) \
-  ((type *)((uintptr_t)(ptr)-offsetof(type, member)))
+  ((type *)((uintptr_t)(ptr) - offsetof(type, member)))
 
 #define TREE__ROTATE(cis, trans)       \
   struct TreeNode *p = node;           \

--- a/libc/sock/epoll.c
+++ b/libc/sock/epoll.c
@@ -108,10 +108,11 @@ https://github.com/piscisaureus/wepoll");
   (EPOLLIN | EPOLLPRI | EPOLLOUT | EPOLLERR | EPOLLHUP | EPOLLRDNORM | \
    EPOLLRDBAND | EPOLLWRNORM | EPOLLWRBAND | EPOLLMSG | EPOLLRDHUP)
 
-#define RTL_CONSTANT_STRING(s) {sizeof(s) - sizeof((s)[0]), sizeof(s), s}
+#define RTL_CONSTANT_STRING(s) \
+  { sizeof(s) - sizeof((s)[0]), sizeof(s), s }
 
 #define RTL_CONSTANT_OBJECT_ATTRIBUTES(ObjectName, Attributes) \
-  {sizeof(struct NtObjectAttributes), 0, ObjectName, Attributes, NULL, NULL}
+  { sizeof(struct NtObjectAttributes), 0, ObjectName, Attributes, NULL, NULL }
 
 #define RETURN_MAP_ERROR(value) \
   do {                          \

--- a/libc/sock/select.h
+++ b/libc/sock/select.h
@@ -13,9 +13,9 @@ typedef struct fd_set {
   unsigned long fds_bits[FD_SETSIZE / (sizeof(long) * 8)];
 } fd_set;
 
-#define FD_ISSET(FD, SET) (((SET)->fds_bits[(FD) >> 6] >> ((FD)&63)) & 1)
-#define FD_SET(FD, SET)   ((SET)->fds_bits[(FD) >> 6] |= 1ull << ((FD)&63))
-#define FD_CLR(FD, SET)   ((SET)->fds_bits[(FD) >> 6] &= ~(1ull << ((FD)&63)))
+#define FD_ISSET(FD, SET) (((SET)->fds_bits[(FD) >> 6] >> ((FD) & 63)) & 1)
+#define FD_SET(FD, SET)   ((SET)->fds_bits[(FD) >> 6] |= 1ull << ((FD) & 63))
+#define FD_CLR(FD, SET)   ((SET)->fds_bits[(FD) >> 6] &= ~(1ull << ((FD) & 63)))
 #define FD_ZERO(SET)      bzero((SET)->fds_bits, sizeof((SET)->fds_bits))
 #define FD_SIZE(bits)     (((bits) + (sizeof(long) * 8) - 1) / sizeof(long))
 

--- a/libc/stdio/sysparam.h
+++ b/libc/stdio/sysparam.h
@@ -23,8 +23,8 @@ COSMOPOLITAN_C_START_
 
 #undef roundup
 #define roundup(n, d) (howmany(n, d) * (d))
-#define powerof2(n)   !(((n)-1) & (n))
-#define howmany(n, d) (((n) + ((d)-1)) / (d))
+#define powerof2(n)   !(((n) - 1) & (n))
+#define howmany(n, d) (((n) + ((d) - 1)) / (d))
 
 #ifdef MIN
 #undef MIN

--- a/libc/str/locale.h
+++ b/libc/str/locale.h
@@ -21,7 +21,7 @@
 
 COSMOPOLITAN_C_START_
 
-#define LC_GLOBAL_LOCALE ((locale_t)-1)
+#define LC_GLOBAL_LOCALE ((locale_t) - 1)
 
 struct __locale_map {
   const void *map;

--- a/libc/str/mb.internal.h
+++ b/libc/str/mb.internal.h
@@ -5,7 +5,7 @@ COSMOPOLITAN_C_START_
 #define SA             0xc2u
 #define SB             0xf4u
 #define CODEUNIT(c)    (0xdfff & (signed char)(c))
-#define IS_CODEUNIT(c) ((unsigned)(c)-0xdf80 < 0x80)
+#define IS_CODEUNIT(c) ((unsigned)(c) - 0xdf80 < 0x80)
 #define R(a, b)        ((uint32_t)((a == 0x80 ? 0x40u - b : 0u - a) << 23))
 #define FAILSTATE      R(0x80, 0x80)
 #define OOB(c, b) \

--- a/libc/str/utf16.h
+++ b/libc/str/utf16.h
@@ -13,14 +13,14 @@ COSMOPOLITAN_C_START_
 #define IsLowSurrogate(wc)  ((UTF16_MASK & (wc)) == UTF16_CONT)
 #define IsUcs2(wc)          (((65535 & (wc)) >> 11) != 27)
 #define IsUtf16Cont(wc)     IsLowSurrogate(wc) /* TODO: DELETE */
-#define MergeUtf16(hi, lo)  ((((hi)-0xD800) << 10) + ((lo)-0xDC00) + 0x10000)
-#define EncodeUtf16(wc)                                       \
-  (LIKELY((0x0000 <= (wc) && (wc) <= 0xFFFF) ||               \
-          (0xE000 <= (wc) && (wc) <= 0xFFFF))                 \
-       ? (wc)                                                 \
-   : 0x10000 <= (wc) && (wc) <= 0x10FFFF                      \
-       ? (((((wc)-0x10000) >> 10) + 0xD800) |                 \
-          (unsigned)((((wc)-0x10000) & 1023) + 0xDC00) << 16) \
+#define MergeUtf16(hi, lo)  ((((hi) - 0xD800) << 10) + ((lo) - 0xDC00) + 0x10000)
+#define EncodeUtf16(wc)                                         \
+  (LIKELY((0x0000 <= (wc) && (wc) <= 0xFFFF) ||                 \
+          (0xE000 <= (wc) && (wc) <= 0xFFFF))                   \
+       ? (wc)                                                   \
+   : 0x10000 <= (wc) && (wc) <= 0x10FFFF                        \
+       ? (((((wc) - 0x10000) >> 10) + 0xD800) |                 \
+          (unsigned)((((wc) - 0x10000) & 1023) + 0xDC00) << 16) \
        : 0xFFFD)
 
 COSMOPOLITAN_C_END_

--- a/libc/sysv/consts/ioprio.h
+++ b/libc/sysv/consts/ioprio.h
@@ -12,10 +12,10 @@
 
 #define IOPRIO_PRIO_CLASS(ioprio) \
   (((ioprio) >> IOPRIO_CLASS_SHIFT) & IOPRIO_CLASS_MASK)
-#define IOPRIO_PRIO_DATA(ioprio) ((ioprio)&IOPRIO_PRIO_MASK)
+#define IOPRIO_PRIO_DATA(ioprio) ((ioprio) & IOPRIO_PRIO_MASK)
 #define IOPRIO_PRIO_VALUE(class, data)                     \
   ((((class) & IOPRIO_CLASS_MASK) << IOPRIO_CLASS_SHIFT) | \
-   ((data)&IOPRIO_PRIO_MASK))
+   ((data) & IOPRIO_PRIO_MASK))
 
 #define IOPRIO_CLASS_NONE 0
 #define IOPRIO_CLASS_RT   1

--- a/libc/sysv/consts/s.h
+++ b/libc/sysv/consts/s.h
@@ -30,13 +30,13 @@
 #define S_IWRITE 0000200 /* just use octal */
 #define S_ISTXT  0001000 /* just use octal */
 
-#define S_ISDIR(mode)  (((mode)&S_IFMT) == S_IFDIR)
-#define S_ISCHR(mode)  (((mode)&S_IFMT) == S_IFCHR)
-#define S_ISBLK(mode)  (((mode)&S_IFMT) == S_IFBLK)
-#define S_ISREG(mode)  (((mode)&S_IFMT) == S_IFREG)
-#define S_ISFIFO(mode) (((mode)&S_IFMT) == S_IFIFO)
-#define S_ISLNK(mode)  (((mode)&S_IFMT) == S_IFLNK)
-#define S_ISSOCK(mode) (((mode)&S_IFMT) == S_IFSOCK)
+#define S_ISDIR(mode)  (((mode) & S_IFMT) == S_IFDIR)
+#define S_ISCHR(mode)  (((mode) & S_IFMT) == S_IFCHR)
+#define S_ISBLK(mode)  (((mode) & S_IFMT) == S_IFBLK)
+#define S_ISREG(mode)  (((mode) & S_IFMT) == S_IFREG)
+#define S_ISFIFO(mode) (((mode) & S_IFMT) == S_IFIFO)
+#define S_ISLNK(mode)  (((mode) & S_IFMT) == S_IFLNK)
+#define S_ISSOCK(mode) (((mode) & S_IFMT) == S_IFSOCK)
 
 #define S_BLKSIZE   512
 #define ALLPERMS    (S_ISUID | S_ISGID | S_ISTXT | S_IRWXU | S_IRWXG | S_IRWXO)

--- a/libc/thread/thread.h
+++ b/libc/thread/thread.h
@@ -44,7 +44,9 @@ COSMOPOLITAN_C_START_
 #define PTHREAD_COND_INITIALIZER   _PTHREAD_INIT
 #define PTHREAD_RWLOCK_INITIALIZER _PTHREAD_INIT
 #define PTHREAD_MUTEX_INITIALIZER  _PTHREAD_INIT
-#define _PTHREAD_INIT              {0}
+
+#define _PTHREAD_INIT \
+  { 0 }
 
 typedef uintptr_t pthread_t;
 typedef int pthread_id_np_t;

--- a/test/ctl/optional_test.cc
+++ b/test/ctl/optional_test.cc
@@ -117,7 +117,14 @@ main()
     }
 
     {
-        struct A { int* p = &g; A() {++*p; } };
+        struct A
+        {
+            int* p = &g;
+            A()
+            {
+                ++*p;
+            }
+        };
         ctl::optional<A> x;
         if (g != 0)
             return 25;

--- a/test/libc/intrin/magicu_test.c
+++ b/test/libc/intrin/magicu_test.c
@@ -22,7 +22,6 @@
 #include "libc/runtime/runtime.h"
 #include "libc/testlib/ezbench.h"
 #include "libc/testlib/testlib.h"
-#include "libc/intrin/magicu.h"
 
 #define T    uint32_t
 #define TBIT (sizeof(T) * CHAR_BIT - 1)

--- a/test/libc/runtime/memtrack_test.c
+++ b/test/libc/runtime/memtrack_test.c
@@ -30,8 +30,7 @@
 
 #define OPEN_MAX 16
 
-#define I(x, y) \
-  { x, y, 0, (y - x) * FRAMESIZE + FRAMESIZE }
+#define I(x, y) {x, y, 0, (y - x) * FRAMESIZE + FRAMESIZE}
 
 void SetUpOnce(void) {
   ASSERT_SYS(0, 0, pledge("stdio rpath", 0));

--- a/test/libc/runtime/memtrack_test.c
+++ b/test/libc/runtime/memtrack_test.c
@@ -30,7 +30,8 @@
 
 #define OPEN_MAX 16
 
-#define I(x, y) {x, y, 0, (y - x) * FRAMESIZE + FRAMESIZE}
+#define I(x, y) \
+  { x, y, 0, (y - x) * FRAMESIZE + FRAMESIZE }
 
 void SetUpOnce(void) {
   ASSERT_SYS(0, 0, pledge("stdio rpath", 0));

--- a/tool/plinko/lib/plinko.h
+++ b/tool/plinko/lib/plinko.h
@@ -9,7 +9,7 @@ COSMOPOLITAN_C_START_
 
 #define LO(x)      (int)(x)
 #define HI(x)      (int)((x) >> 32)
-#define MASK(x)    ((x)-1u)
+#define MASK(x)    ((x) - 1u)
 #define ROR(x, k)  ((unsigned)(x) >> k | ((unsigned)(x) << (32 - k)))
 #define MAKE(l, h) (((unsigned)(l)) | (dword)(h) << 32)
 #define SHAD(i)    g_dispatch[(i) & (BANE | MASK(BANE))]

--- a/tool/viz/lib/unsharp.c
+++ b/tool/viz/lib/unsharp.c
@@ -49,14 +49,15 @@ long unsharp(long cn, long yw, long xw, unsigned char img[cn][yw][xw], long yn,
         }
         if (y < yn) {
           for (x = 0; x < xn; ++x) {
-            (*t)[y % 3][x] = CONVOLVE5X5(/* clang-format off */
+            (*t)[y % 3][x] =
+                CONVOLVE5X5(/* clang-format off */
                     7, (-1 / 256.), img[c],
                           1,  4,   6,  4, 1,
                           4, 16,  24, 16, 4,
                           6, 24,-476, 24, 6,
                           4, 16,  24, 16, 4,
                           1,  4,   6,  4, 1
-                                         /* clang-format on */);
+                            /* clang-format on */);
           }
         }
       }

--- a/tool/viz/life.c
+++ b/tool/viz/life.c
@@ -225,10 +225,10 @@ static char16_t statusline16[256];
 #define GODOWN(x)    ((x) << 8)
 #define GORIGHT(x)   (((x) & ~RIGHT) << 1)
 #define GOLEFT(x)    (((x) & ~LEFT) >> 1)
-#define LEFTMOST(x)  ((x)&LEFT)
-#define RIGHTMOST(x) ((x)&RIGHT)
-#define TOPMOST(x)   ((x)&TOP)
-#define BOTMOST(x)   ((x)&BOTTOM)
+#define LEFTMOST(x)  ((x) & LEFT)
+#define RIGHTMOST(x) ((x) & RIGHT)
+#define TOPMOST(x)   ((x) & TOP)
+#define BOTMOST(x)   ((x) & BOTTOM)
 
 #define ADD(X)       \
   do {               \


### PR DESCRIPTION
🚨 clang-format changes output per version!

This is with version 19.0.0. The modifications seem to be fixing the old version’s errors - mainly involving omitted whitespace around binary ops and inserted whitespace between goto labels and colons (if followed by a curly brace.)

Also fixes a few mistakes made by e.g. someone (ahem) forgetting to pass his ctl/string.h modifications through it.

We should add this to .git-blame-ignore-revs once we have its final hash on master.