### PR TITLE
ctl string const/value tweaks

### DIFF
--- a/ctl/string.cc
+++ b/ctl/string.cc
@@ -54,12 +54,12 @@ string::string(const string_view s) noexcept : string()
     append(s.p, s.n);
 }
 
-string::string(size_t size, char ch) noexcept : string()
+string::string(const size_t size, const char ch) noexcept : string()
 {
     resize(size, ch);
 }
 
-string::string(const char* s, size_t size) noexcept : string()
+string::string(const char* s, const size_t size) noexcept : string()
 {
     append(s, size);
 }
@@ -101,7 +101,7 @@ string::reserve(size_t c2) noexcept
 }
 
 void
-string::resize(size_t n2, char ch) noexcept
+string::resize(const size_t n2, const char ch) noexcept
 {
     size_t c2;
     if (ckd_add(&c2, n2, 1))
@@ -118,7 +118,7 @@ string::resize(size_t n2, char ch) noexcept
 }
 
 void
-string::append(char ch) noexcept
+string::append(const char ch) noexcept
 {
     size_t n2;
     if (ckd_add(&n2, size(), 2))
@@ -139,7 +139,7 @@ string::append(char ch) noexcept
 }
 
 void
-string::grow(size_t size) noexcept
+string::grow(const size_t size) noexcept
 {
     size_t need;
     if (ckd_add(&need, this->size(), size))
@@ -158,7 +158,7 @@ string::grow(size_t size) noexcept
 }
 
 void
-string::append(char ch, size_t size) noexcept
+string::append(const char ch, const size_t size) noexcept
 {
     grow(size);
     if (size)
@@ -172,7 +172,7 @@ string::append(char ch, size_t size) noexcept
 }
 
 void
-string::append(const void* data, size_t size) noexcept
+string::append(const void* data, const size_t size) noexcept
 {
     grow(size);
     if (size)
@@ -254,7 +254,7 @@ string::starts_with(const string_view s) const noexcept
 }
 
 size_t
-string::find(char ch, size_t pos) const noexcept
+string::find(const char ch, const size_t pos) const noexcept
 {
     char* q;
     if ((q = (char*)memchr(data(), ch, size())))
@@ -263,7 +263,7 @@ string::find(char ch, size_t pos) const noexcept
 }
 
 size_t
-string::find(const string_view s, size_t pos) const noexcept
+string::find(const string_view s, const size_t pos) const noexcept
 {
     char* q;
     if (pos > size())
@@ -274,7 +274,7 @@ string::find(const string_view s, size_t pos) const noexcept
 }
 
 string
-string::substr(size_t pos, size_t count) const noexcept
+string::substr(const size_t pos, size_t count) const noexcept
 {
     size_t last;
     if (pos > size())
@@ -289,7 +289,9 @@ string::substr(size_t pos, size_t count) const noexcept
 }
 
 string&
-string::replace(size_t pos, size_t count, const string_view s) noexcept
+string::replace(const size_t pos,
+                const size_t count,
+                const string_view s) noexcept
 {
     size_t last;
     if (ckd_add(&last, pos, count))
@@ -319,7 +321,7 @@ string::replace(size_t pos, size_t count, const string_view s) noexcept
 }
 
 string&
-string::insert(size_t i, const string_view s) noexcept
+string::insert(const size_t i, const string_view s) noexcept
 {
     if (i > size())
         __builtin_trap();
@@ -343,7 +345,7 @@ string::insert(size_t i, const string_view s) noexcept
 }
 
 string&
-string::erase(size_t pos, size_t count) noexcept
+string::erase(const size_t pos, size_t count) noexcept
 {
     if (pos > size())
         __builtin_trap();

--- a/ctl/string.cc
+++ b/ctl/string.cc
@@ -289,7 +289,7 @@ string::substr(size_t pos, size_t count) const noexcept
 }
 
 string&
-string::replace(size_t pos, size_t count, const string_view& s) noexcept
+string::replace(size_t pos, size_t count, const string_view s) noexcept
 {
     size_t last;
     if (ckd_add(&last, pos, count))

--- a/ctl/string.h
+++ b/ctl/string.h
@@ -201,14 +201,14 @@ class string
         return data()[i];
     }
 
-    const char& operator[](size_t i) const noexcept
+    const char& operator[](const size_t i) const noexcept
     {
         if (i >= size())
             __builtin_trap();
         return data()[i];
     }
 
-    void push_back(char ch) noexcept
+    void push_back(const char ch) noexcept
     {
         append(ch);
     }
@@ -237,7 +237,7 @@ class string
         return *this;
     }
 
-    string& operator+=(char x) noexcept
+    string& operator+=(const char x) noexcept
     {
         append(x);
         return *this;
@@ -285,14 +285,16 @@ class string
         return *(blob + __::sso_max) & 0x80;
     }
 
-    inline void set_small_size(size_t size) noexcept
+    inline void set_small_size(const size_t size) noexcept
     {
         if (size > __::sso_max)
             __builtin_trap();
         *(blob + __::sso_max) = (__::sso_max - size);
     }
 
-    inline void set_big_string(char* p, size_t n, size_t c2) noexcept
+    inline void set_big_string(char* const p,
+                               const size_t n,
+                               const size_t c2) noexcept
     {
         if (c2 > __::big_mask)
             __builtin_trap();

--- a/ctl/string.h
+++ b/ctl/string.h
@@ -8,8 +8,7 @@ namespace ctl {
 
 class string;
 
-string
-strcat(const string_view, const string_view) noexcept __wur;
+string strcat(string_view, string_view) noexcept __wur;
 
 namespace __ {
 
@@ -50,7 +49,7 @@ class string
     static constexpr size_t npos = -1;
 
     ~string() /* noexcept */;
-    string(const string_view) noexcept;
+    string(string_view) noexcept;
     string(const char*) noexcept;
     string(const string&) noexcept;
     string(const char*, size_t) noexcept;
@@ -67,17 +66,17 @@ class string
     void append(char, size_t) noexcept;
     void append(unsigned long) noexcept;
     void append(const void*, size_t) noexcept;
-    string& insert(size_t, const string_view) noexcept;
+    string& insert(size_t, string_view) noexcept;
     string& erase(size_t = 0, size_t = npos) noexcept;
     string substr(size_t = 0, size_t = npos) const noexcept;
-    string& replace(size_t, size_t, const string_view&) noexcept;
-    bool operator==(const string_view) const noexcept;
-    bool operator!=(const string_view) const noexcept;
-    bool contains(const string_view) const noexcept;
-    bool ends_with(const string_view) const noexcept;
-    bool starts_with(const string_view) const noexcept;
+    string& replace(size_t, size_t, string_view) noexcept;
+    bool operator==(string_view) const noexcept;
+    bool operator!=(string_view) const noexcept;
+    bool contains(string_view) const noexcept;
+    bool ends_with(string_view) const noexcept;
+    bool starts_with(string_view) const noexcept;
     size_t find(char, size_t = 0) const noexcept;
-    size_t find(const string_view, size_t = 0) const noexcept;
+    size_t find(string_view, size_t = 0) const noexcept;
 
     string() noexcept
     {
@@ -330,7 +329,7 @@ class string
         return reinterpret_cast<const __::big_string*>(blob);
     }
 
-    friend string strcat(const string_view, const string_view);
+    friend string strcat(string_view, string_view);
 
     alignas(union {
         __::big_string a;

--- a/ctl/string_view.cc
+++ b/ctl/string_view.cc
@@ -26,7 +26,7 @@
 namespace ctl {
 
 size_t
-string_view::find(char ch, size_t pos) const noexcept
+string_view::find(const char ch, const size_t pos) const noexcept
 {
     char* q;
     if (n && (q = (char*)memchr(p, ch, n)))
@@ -35,7 +35,7 @@ string_view::find(char ch, size_t pos) const noexcept
 }
 
 size_t
-string_view::find(const string_view s, size_t pos) const noexcept
+string_view::find(const string_view s, const size_t pos) const noexcept
 {
     char* q;
     if (pos > n)
@@ -46,7 +46,7 @@ string_view::find(const string_view s, size_t pos) const noexcept
 }
 
 string_view
-string_view::substr(size_t pos, size_t count) const noexcept
+string_view::substr(const size_t pos, size_t count) const noexcept
 {
     size_t last;
     if (pos > n)

--- a/ctl/string_view.h
+++ b/ctl/string_view.h
@@ -28,7 +28,7 @@ struct string_view
     {
     }
 
-    constexpr string_view(const char* s, size_t n) noexcept : p(s), n(n)
+    constexpr string_view(const char* s, const size_t n) noexcept : p(s), n(n)
     {
     }
 
@@ -72,14 +72,14 @@ struct string_view
         return n;
     }
 
-    constexpr const char& operator[](size_t i) const noexcept
+    constexpr const char& operator[](const size_t i) const noexcept
     {
         if (i >= n)
             __builtin_trap();
         return p[i];
     }
 
-    constexpr void remove_prefix(size_t count)
+    constexpr void remove_prefix(const size_t count)
     {
         if (count > n)
             __builtin_trap();
@@ -87,7 +87,7 @@ struct string_view
         n -= count;
     }
 
-    constexpr void remove_suffix(size_t count)
+    constexpr void remove_suffix(const size_t count)
     {
         if (count > n)
             __builtin_trap();
@@ -133,22 +133,22 @@ struct string_view
         return strcmp(*this, s);
     }
 
-    bool operator<(const string_view& s) const noexcept
+    bool operator<(const string_view s) const noexcept
     {
         return compare(s) < 0;
     }
 
-    bool operator<=(const string_view& s) const noexcept
+    bool operator<=(const string_view s) const noexcept
     {
         return compare(s) <= 0;
     }
 
-    bool operator>(const string_view& s) const noexcept
+    bool operator>(const string_view s) const noexcept
     {
         return compare(s) > 0;
     }
 
-    bool operator>=(const string_view& s) const noexcept
+    bool operator>=(const string_view s) const noexcept
     {
         return compare(s) >= 0;
     }

--- a/ctl/string_view.h
+++ b/ctl/string_view.h
@@ -36,16 +36,16 @@ struct string_view
     {
     }
 
-    bool operator==(const string_view) const noexcept;
-    bool operator!=(const string_view) const noexcept;
-    bool contains(const string_view) const noexcept;
-    bool ends_with(const string_view) const noexcept;
-    bool starts_with(const string_view) const noexcept;
+    bool operator==(string_view) const noexcept;
+    bool operator!=(string_view) const noexcept;
+    bool contains(string_view) const noexcept;
+    bool ends_with(string_view) const noexcept;
+    bool starts_with(string_view) const noexcept;
     string_view substr(size_t = 0, size_t = npos) const noexcept;
     size_t find(char, size_t = 0) const noexcept;
-    size_t find(const string_view, size_t = 0) const noexcept;
+    size_t find(string_view, size_t = 0) const noexcept;
 
-    constexpr string_view& operator=(const string_view& s) noexcept
+    constexpr string_view& operator=(const string_view s) noexcept
     {
         p = s.p;
         n = s.n;


### PR DESCRIPTION
The mangled name of a C++ function will typically not vary by const-ness of a by-value parameter; in other words, there is no meaning to a const- qualified by-value parameter in a function prototype. However, the const keyword \__does_\_ matter at function \__definition_\_ time, like it does with a variable declared in the body. So for prototypes, we strip out const for by-value parameters; but for definitions, we leave them alone.

At function definition (as opposed to prototype), we add const to values in parameters by default, unless we’re going to mutate them.

This commit also changes a couple of `const string_view&` to be simply by- value `string_view`. A `string_view` is only two words; it rarely ever makes sense to pass one by reference if it’s not going to be mutated.
