### PR TITLE
Update labeler.yml to remove testing label from the autolabeler 

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,10 +9,6 @@ documentation:
             - libc/README.md
             - tool/cosmocc/README.md
             - third_party/getopt/README.txt
-testing:
-    - changed-files:
-        - any-glob-to-any-file:
-            - test/**
 build:
     - changed-files:
         - any-glob-to-any-file:


### PR DESCRIPTION
https://github.com/jart/cosmopolitan/issues/1219 had an issue with noisy testing label. Investigated if there is a syntax to make it more exclusive, but turns out there isn't one yet. So let's remove an manually add it in as needed.