### PR TITLE
ctl::unique_ptr improvements and cleanup

### DIFF
--- a/ctl/unique_ptr.h
+++ b/ctl/unique_ptr.h
@@ -68,26 +68,26 @@ struct unique_ptr
 
     unique_ptr(const unique_ptr&) = delete;
 
-    ~unique_ptr() /* noexcept */
+    constexpr ~unique_ptr() /* noexcept */
     {
         if (p)
             d(p);
     }
 
-    unique_ptr& operator=(unique_ptr r) noexcept
+    constexpr unique_ptr& operator=(unique_ptr r) noexcept
     {
         swap(r);
         return *this;
     }
 
-    pointer release() noexcept
+    constexpr pointer release() noexcept
     {
         pointer r = p;
         p = nullptr;
         return r;
     }
 
-    void reset(const pointer p2 = pointer()) noexcept
+    constexpr void reset(const pointer p2 = pointer()) noexcept
     {
         const pointer r = p;
         p = p2;
@@ -95,29 +95,29 @@ struct unique_ptr
             d(r);
     }
 
-    void swap(unique_ptr& r) noexcept
+    constexpr void swap(unique_ptr& r) noexcept
     {
         using ctl::swap;
         swap(p, r.p);
         swap(d, r.d);
     }
 
-    pointer get() const noexcept
+    constexpr pointer get() const noexcept
     {
         return p;
     }
 
-    deleter_type& get_deleter() noexcept
+    constexpr deleter_type& get_deleter() noexcept
     {
         return d;
     }
 
-    const deleter_type& get_deleter() const noexcept
+    constexpr const deleter_type& get_deleter() const noexcept
     {
         return d;
     }
 
-    explicit operator bool() const noexcept
+    constexpr explicit operator bool() const noexcept
     {
         return p;
     }

--- a/ctl/unique_ptr.h
+++ b/ctl/unique_ptr.h
@@ -144,14 +144,14 @@ struct unique_ptr
 };
 
 template<typename T, typename... Args>
-unique_ptr<T>
+constexpr unique_ptr<T>
 make_unique(Args&&... args)
 {
     return unique_ptr<T>(new T(ctl::forward<Args>(args)...));
 }
 
 template<typename T>
-unique_ptr<T>
+constexpr unique_ptr<T>
 make_unique_for_overwrite()
 {
 #if 0

--- a/ctl/unique_ptr.h
+++ b/ctl/unique_ptr.h
@@ -70,7 +70,8 @@ struct unique_ptr
 
     ~unique_ptr() /* noexcept */
     {
-        reset();
+        if (p)
+            d(p);
     }
 
     unique_ptr& operator=(unique_ptr r) noexcept
@@ -86,19 +87,12 @@ struct unique_ptr
         return r;
     }
 
-    void reset(const nullptr_t = nullptr) noexcept
+    void reset(const pointer p2 = pointer()) noexcept
     {
-        if (p)
-            d(p);
-        p = nullptr;
-    }
-
-    void reset(auto* const p2)
-    {
-        if (p) {
-            d(p);
-        }
+        const pointer r = p;
         p = p2;
+        if (r)
+            d(r);
     }
 
     void swap(unique_ptr& r) noexcept

--- a/ctl/unique_ptr.h
+++ b/ctl/unique_ptr.h
@@ -53,7 +53,7 @@ struct unique_ptr
     {
     }
 
-    constexpr unique_ptr(auto* const p, auto&& d) noexcept
+    constexpr unique_ptr(const pointer p, auto&& d) noexcept
       : p(p), d(ctl::forward<decltype(d)>(d))
     {
     }

--- a/test/ctl/unique_ptr_test.cc
+++ b/test/ctl/unique_ptr_test.cc
@@ -91,6 +91,12 @@ struct SetsGDtor
     }
 };
 
+struct Base
+{};
+
+struct Derived : Base
+{};
+
 int
 main()
 {
@@ -209,6 +215,14 @@ main()
         // Should compile.
         Ptr<int, FinalDeleter> x(&a);
         Ptr<int, StatefulDeleter> y(&a);
+    }
+
+    {
+        Ptr<Base> x(new Base);
+        x.reset(new Derived);
+
+        Ptr<Derived> y(new Derived);
+        Ptr<Base> z(std::move(y));
     }
 
     // next is 18

--- a/test/ctl/unique_ptr_test.cc
+++ b/test/ctl/unique_ptr_test.cc
@@ -227,5 +227,6 @@ main()
 
     // next is 18
 
+    CheckForMemoryLeaks();
     return 0;
 }


### PR DESCRIPTION
```
Explicitly value-initializes the deleter, even though I have not found a
way to get the deleter to act like it’s been default-initialized in unit
tests so far.

Uses auto in reset. The static cast is apparently not needed (unless I’m
missing some case I didn’t think of.)

Implements the general move constructor - turns out that the reason this
didn’t work before was that default_delete<U> was not move constructible
from default_delete<T>.

Drop inline specifiers from functions defined entirely inside the struct
definition since they are implicitly inline.

* Cleans up reset to match spec

Remove the variants from the T[] specialization. Also follow the spec on
the order of operations in reset, which may matter if we are deleting an
object that has a reference to the unique_ptr that is being reset. (?)

* Tests Base/Derived reset.

* Adds some constexpr declarations.

* Adds default_delete specialization for T[].

* Makes parameters const.
```