### PR TITLE
Use std::swap in string

### DIFF
--- a/ctl/string.h
+++ b/ctl/string.h
@@ -87,10 +87,7 @@ class string
 
     void swap(string& s) noexcept
     {
-        char tmp[__::string_size];
-        __builtin_memcpy(tmp, blob, __::string_size);
-        __builtin_memcpy(blob, s.blob, __::string_size);
-        __builtin_memcpy(s.blob, tmp, __::string_size);
+        std::swap(blob, s.blob);
     }
 
     string(string&& s) noexcept

--- a/ctl/string_view.h
+++ b/ctl/string_view.h
@@ -2,6 +2,7 @@
 // vi: set et ft=cpp ts=4 sts=4 sw=4 fenc=utf-8 :vi
 #ifndef COSMOPOLITAN_CTL_STRINGVIEW_H_
 #define COSMOPOLITAN_CTL_STRINGVIEW_H_
+#include <__utility/swap.h>
 
 namespace ctl {
 


### PR DESCRIPTION
The STL spec says that swap is located in the string_view header anyway. Performance-wise this is a noop, but it’s slightly cleaner.