### PR TITLE
Fix c.inc

### DIFF
--- a/libc/integral/c.inc
+++ b/libc/integral/c.inc
@@ -74,7 +74,7 @@
 #endif
 
 #if __STDC_VERSION__ + 0 < 201112
-#define _Atomic(t) volatile t *
+#define _Atomic(t) volatile t
 #endif
 
 #ifdef __llvm__


### PR DESCRIPTION
c.inc (as far as I can tell erroneously) would define \``_Atomic(t)`\` to be \``vloatile t *`\` instead of just \``volatile t`\` if \``__STDC_VERSION__`\` didn’t say at least C11. This branch gets taken if we’re compiling C++; however in C++11 \``_Atomic`\` is a library define, not a language keyword. Moreover it is defined in \``<stdatomic.h>`\`, which is a morass that ultimately sets up everything to refer back to \``std::atomic<T>`\`.

The gory details are in \``third_party/libcxx/__atomic/cxx_atomic_impl.h`\`. For our purposes it seems to be enough to just have our data be volatile and use the libc/intrin/atomic.h functions on them.