### PR TITLE
Make new.cc definitions weak

### DIFF
--- a/ctl/new.cc
+++ b/ctl/new.cc
@@ -16,23 +16,18 @@
 // TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
+/* We do not actually use anything defined in new.h, but it is included here
+   to follow the usual pattern that the source file for a header file is the
+   place that makes sure that the header can be included without an implicit
+   dependency picked up out of a prior include. */
 #include "new.h"
 
 #include "libc/mem/mem.h"
 
-using ctl::align_val_t;
+COSMOPOLITAN_C_START_
 
-namespace {
-
-constexpr auto a1 = align_val_t(1);
-
-} // namespace
-
-// clang-format off
-
-extern "C" {
-
-void* ctl_alloc(size_t n, size_t a)
+void*
+ctl_alloc(size_t n, size_t a)
 {
     void* p;
     if (!(p = memalign(a, n)))
@@ -40,12 +35,14 @@ void* ctl_alloc(size_t n, size_t a)
     return p;
 }
 
-void* ctl_alloc1(size_t n)
+void*
+ctl_alloc1(size_t n)
 {
     return ctl_alloc(n, 1);
 }
 
-void* ctl_ret(size_t, void* p)
+void*
+ctl_ret(size_t, void* p)
 {
     return p;
 }
@@ -108,4 +105,4 @@ __weak_reference(free, _ZdlPvS_);
 // operator delete[](void*, void*)
 __weak_reference(free, _ZdaPvS_);
 
-} // extern "C"
+COSMOPOLITAN_C_END_

--- a/ctl/new.cc
+++ b/ctl/new.cc
@@ -79,11 +79,10 @@ __weak_reference(void* operator new[](size_t), ctl_alloc1);
 __weak_reference(void* operator new(size_t, void*), ctl_ret);
 __weak_reference(void* operator new[](size_t, void*), ctl_ret);
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wattribute-alias="
-
 __weak_reference(void operator delete(void*) noexcept, ctl_free);
 __weak_reference(void operator delete[](void*) noexcept, ctl_free);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattribute-alias="
 __weak_reference(void operator delete(void*, ctl::align_val_t) noexcept,
                  ctl_free);
 __weak_reference(void operator delete[](void*, ctl::align_val_t) noexcept,
@@ -94,7 +93,6 @@ __weak_reference(void operator delete(void*, size_t, ctl::align_val_t) noexcept,
                  ctl_free);
 __weak_reference(void operator delete[](void*, size_t, ctl::align_val_t)
                  noexcept, ctl_free);
-
 #pragma GCC diagnostic pop
 
 __weak_reference(void operator delete(void*, void*) noexcept, ctl_nop);

--- a/ctl/new.cc
+++ b/ctl/new.cc
@@ -28,91 +28,74 @@ constexpr auto a1 = align_val_t(1);
 
 } // namespace
 
-#define WEAK __attribute__((weak))
+// clang-format off
 
-WEAK void*
-operator new(size_t n, align_val_t a)
+extern "C" {
+
+void* ctl_alloc(size_t n, size_t a)
 {
     void* p;
-    if (!(p = memalign(static_cast<size_t>(a), n))) {
+    if (!(p = memalign(a, n)))
         __builtin_trap();
-    }
     return p;
 }
 
-WEAK void*
-operator new[](size_t n, align_val_t a)
+void* ctl_alloc1(size_t n)
 {
-    return operator new(n, a);
-}
-WEAK void*
-operator new(size_t n)
-{
-    return operator new(n, a1);
-}
-WEAK void*
-operator new[](size_t n)
-{
-    return operator new(n, a1);
+    return ctl_alloc(n, 1);
 }
 
-WEAK void*
-operator new(size_t, void* p)
-{
-    return p;
-}
-WEAK void*
-operator new[](size_t, void* p)
+void* ctl_ret(size_t, void* p)
 {
     return p;
 }
 
-WEAK void
-operator delete(void* p) noexcept
-{
-    free(p);
-}
-WEAK void
-operator delete[](void* p) noexcept
-{
-    free(p);
-}
-WEAK void
-operator delete(void* p, align_val_t) noexcept
-{
-    free(p);
-}
-WEAK void
-operator delete[](void* p, align_val_t) noexcept
-{
-    free(p);
-}
-WEAK void
-operator delete(void* p, size_t) noexcept
-{
-    free(p);
-}
-WEAK void
-operator delete[](void* p, size_t) noexcept
-{
-    free(p);
-}
-WEAK void
-operator delete(void* p, size_t, align_val_t) noexcept
-{
-    free(p);
-}
-WEAK void
-operator delete[](void* p, size_t, align_val_t) noexcept
-{
-    free(p);
-}
+// operator new(size_t, align_val_t)
+__weak_reference(ctl_alloc, _ZnwmN3ctl11align_val_tE);
 
-WEAK void
-operator delete(void*, void*) noexcept
-{
-}
-WEAK void
-operator delete[](void*, void*) noexcept
-{
-}
+// operator new[](size_t, align_val_t)
+__weak_reference(ctl_alloc, _ZnamN3ctl11align_val_tE);
+
+// operator new(size_t)
+__weak_reference(ctl_alloc1, _Znwm);
+
+// operator new[](size_t)
+__weak_reference(ctl_alloc1, _Znam);
+
+// operator new(size_t, void*)
+__weak_reference(ctl_ret, _ZnwmPv);
+
+// operator new[](size_t, void*)
+__weak_reference(ctl_ret, _ZnamPv);
+
+// operator delete(void*)
+__weak_reference(free, _ZdlPv);
+
+// operator delete[](void*)
+__weak_reference(free, _ZdaPv);
+
+// operator delete(void*, align_val_t)
+__weak_reference(free, _ZdlPvN3ctl11align_val_tE);
+
+// operator delete[](void*, align_val_t)
+__weak_reference(free, _ZdaPvN3ctl11align_val_tE);
+
+// operator delete(void*, size_t)
+__weak_reference(free, _ZdlPvm);
+
+// operator delete[](void*, size_t)
+__weak_reference(free, _ZdaPvm);
+
+// operator delete(void*, size_t, align_val_t)
+__weak_reference(free, _ZdlPvmN3ctl11align_val_tE);
+
+// operator delete[](void*, size_t, align_val_t)
+__weak_reference(free, _ZdaPvmN3ctl11align_val_tE);
+
+// operator delete(void*, void*) noexcept
+__weak_reference(free, _ZdlPvS_);
+
+// operator delete[](void*, void*)
+__weak_reference(free, _ZdaPvS_);
+
+} // extern "C"

--- a/ctl/new.cc
+++ b/ctl/new.cc
@@ -23,7 +23,7 @@
 COSMOPOLITAN_C_START_
 
 void*
-ctl_alloc(size_t n, size_t a)
+_ctl_alloc(size_t n, size_t a)
 {
     void* p;
     if (!(p = memalign(a, n)))
@@ -32,25 +32,25 @@ ctl_alloc(size_t n, size_t a)
 }
 
 void*
-ctl_alloc1(size_t n)
+_ctl_alloc1(size_t n)
 {
-    return ctl_alloc(n, 1);
+    return _ctl_alloc(n, 1);
 }
 
 void*
-ctl_ret(size_t, void* p)
+_ctl_ret(size_t, void* p)
 {
     return p;
 }
 
 void
-ctl_free(void* p)
+_ctl_free(void* p)
 {
     free(p);
 }
 
 void
-ctl_nop(void*, void*)
+_ctl_nop(void*, void*)
 {
 }
 
@@ -68,32 +68,32 @@ COSMOPOLITAN_C_END_
    now. If you have any brain cells left after reading this comment then go
    look at the eight operator delete weak references to free in the below. */
 
-__weak_reference(void* operator new(size_t, ctl::align_val_t), ctl_alloc);
-__weak_reference(void* operator new[](size_t, ctl::align_val_t), ctl_alloc);
-__weak_reference(void* operator new(size_t), ctl_alloc1);
-__weak_reference(void* operator new[](size_t), ctl_alloc1);
+__weak_reference(void* operator new(size_t, ctl::align_val_t), _ctl_alloc);
+__weak_reference(void* operator new[](size_t, ctl::align_val_t), _ctl_alloc);
+__weak_reference(void* operator new(size_t), _ctl_alloc1);
+__weak_reference(void* operator new[](size_t), _ctl_alloc1);
 
 // XXX clang-format currently mutilates these for some reason.
 // clang-format off
 
-__weak_reference(void* operator new(size_t, void*), ctl_ret);
-__weak_reference(void* operator new[](size_t, void*), ctl_ret);
+__weak_reference(void* operator new(size_t, void*), _ctl_ret);
+__weak_reference(void* operator new[](size_t, void*), _ctl_ret);
 
-__weak_reference(void operator delete(void*) noexcept, ctl_free);
-__weak_reference(void operator delete[](void*) noexcept, ctl_free);
+__weak_reference(void operator delete(void*) noexcept, _ctl_free);
+__weak_reference(void operator delete[](void*) noexcept, _ctl_free);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wattribute-alias="
 __weak_reference(void operator delete(void*, ctl::align_val_t) noexcept,
-                 ctl_free);
+                 _ctl_free);
 __weak_reference(void operator delete[](void*, ctl::align_val_t) noexcept,
-                 ctl_free);
-__weak_reference(void operator delete(void*, size_t) noexcept, ctl_free);
-__weak_reference(void operator delete[](void*, size_t) noexcept, ctl_free);
+                 _ctl_free);
+__weak_reference(void operator delete(void*, size_t) noexcept, _ctl_free);
+__weak_reference(void operator delete[](void*, size_t) noexcept, _ctl_free);
 __weak_reference(void operator delete(void*, size_t, ctl::align_val_t) noexcept,
-                 ctl_free);
+                 _ctl_free);
 __weak_reference(void operator delete[](void*, size_t, ctl::align_val_t)
-                 noexcept, ctl_free);
+                 noexcept, _ctl_free);
 #pragma GCC diagnostic pop
 
-__weak_reference(void operator delete(void*, void*) noexcept, ctl_nop);
-__weak_reference(void operator delete[](void*, void*) noexcept, ctl_nop);
+__weak_reference(void operator delete(void*, void*) noexcept, _ctl_nop);
+__weak_reference(void operator delete[](void*, void*) noexcept, _ctl_nop);

--- a/ctl/new.cc
+++ b/ctl/new.cc
@@ -51,13 +51,14 @@ void* ctl_ret(size_t, void* p)
 }
 
 /* The ISO says that these should be replaceable by user code. It also says
-   that the declarations for the first four (i.e. non–placement-) operators
+   that the declarations for the first four (i.e. non placement-) operators
    new are implicitly available in each translation unit, including the std
    align_val_t parameter. (?) However, <new> also _defines_ the align_val_t
    type so you can’t just write your own. Our way through this morass is to
    supply ours as ctl::align_val_t and not implicitly declare anything, for
    now. If you have any brain cells left after reading this comment then go
-   look at the ten operator delete weak references to free in the below. */
+   look at the ten operator delete weak references to free in the following.
+*/
 
 // operator new(size_t, align_val_t)
 __weak_reference(ctl_alloc, _ZnwmN3ctl11align_val_tE);

--- a/ctl/new.cc
+++ b/ctl/new.cc
@@ -28,7 +28,9 @@ constexpr auto a1 = align_val_t(1);
 
 } // namespace
 
-void*
+#define WEAK __attribute__((weak))
+
+WEAK void*
 operator new(size_t n, align_val_t a)
 {
     void* p;
@@ -38,79 +40,79 @@ operator new(size_t n, align_val_t a)
     return p;
 }
 
-void*
+WEAK void*
 operator new[](size_t n, align_val_t a)
 {
     return operator new(n, a);
 }
-void*
+WEAK void*
 operator new(size_t n)
 {
     return operator new(n, a1);
 }
-void*
+WEAK void*
 operator new[](size_t n)
 {
     return operator new(n, a1);
 }
 
-void*
+WEAK void*
 operator new(size_t, void* p)
 {
     return p;
 }
-void*
+WEAK void*
 operator new[](size_t, void* p)
 {
     return p;
 }
 
-void
+WEAK void
 operator delete(void* p) noexcept
 {
     free(p);
 }
-void
+WEAK void
 operator delete[](void* p) noexcept
 {
     free(p);
 }
-void
+WEAK void
 operator delete(void* p, align_val_t) noexcept
 {
     free(p);
 }
-void
+WEAK void
 operator delete[](void* p, align_val_t) noexcept
 {
     free(p);
 }
-void
+WEAK void
 operator delete(void* p, size_t) noexcept
 {
     free(p);
 }
-void
+WEAK void
 operator delete[](void* p, size_t) noexcept
 {
     free(p);
 }
-void
+WEAK void
 operator delete(void* p, size_t, align_val_t) noexcept
 {
     free(p);
 }
-void
+WEAK void
 operator delete[](void* p, size_t, align_val_t) noexcept
 {
     free(p);
 }
 
-void
+WEAK void
 operator delete(void*, void*) noexcept
 {
 }
-void
+WEAK void
 operator delete[](void*, void*) noexcept
 {
 }

--- a/ctl/new.cc
+++ b/ctl/new.cc
@@ -50,6 +50,15 @@ void* ctl_ret(size_t, void* p)
     return p;
 }
 
+/* The ISO says that these should be replaceable by user code. It also says
+   that the declarations for the first four (i.e. non–placement-) operators
+   new are implicitly available in each translation unit, including the std
+   align_val_t parameter. (?) However, <new> also _defines_ the align_val_t
+   type so you can’t just write your own. Our way through this morass is to
+   supply ours as ctl::align_val_t and not implicitly declare anything, for
+   now. If you have any brain cells left after reading this comment then go
+   look at the ten operator delete weak references to free in the below. */
+
 // operator new(size_t, align_val_t)
 __weak_reference(ctl_alloc, _ZnwmN3ctl11align_val_tE);
 

--- a/ctl/new.cc
+++ b/ctl/new.cc
@@ -22,7 +22,7 @@
 
 COSMOPOLITAN_C_START_
 
-void*
+static void*
 _ctl_alloc(size_t n, size_t a)
 {
     void* p;
@@ -31,25 +31,25 @@ _ctl_alloc(size_t n, size_t a)
     return p;
 }
 
-void*
+static void*
 _ctl_alloc1(size_t n)
 {
     return _ctl_alloc(n, 1);
 }
 
-void*
+static void*
 _ctl_ret(size_t, void* p)
 {
     return p;
 }
 
-void
+static void
 _ctl_free(void* p)
 {
     free(p);
 }
 
-void
+static void
 _ctl_nop(void*, void*)
 {
 }

--- a/ctl/new.h
+++ b/ctl/new.h
@@ -3,12 +3,11 @@
 #ifndef COSMOPOLITAN_CTL_NEW_H_
 #define COSMOPOLITAN_CTL_NEW_H_
 
-// XXX clang-format currently mutilates these for some reason.
-// clang-format off
-
 namespace ctl {
 
-enum class align_val_t : size_t {};
+enum class align_val_t : size_t
+{
+};
 
 } // namespace ctl
 
@@ -16,6 +15,10 @@ void* operator new(size_t);
 void* operator new[](size_t);
 void* operator new(size_t, ctl::align_val_t);
 void* operator new[](size_t, ctl::align_val_t);
+
+// XXX clang-format currently mutilates these for some reason.
+// clang-format off
+
 void* operator new(size_t, void*);
 void* operator new[](size_t, void*);
 


### PR DESCRIPTION
```
The STL says that these should be replaceable by user code.

new.cc now defines only a few direct functions (including a free wrapper
that perplexingly is needed since g++ didn’t want to alias "free".) Now,
all of the operators are weak references to those functions.
```