### PR TITLE
Build a nightly cosmocc artifact

### DIFF
--- a/.github/workflows/nightly-cosmocc.yml
+++ b/.github/workflows/nightly-cosmocc.yml
@@ -16,7 +16,7 @@ jobs:
           sudo cp build/bootstrap/ape.elf /usr/bin/ape
           sudo sh -c "echo ':APE:M::MZqFpD::/usr/bin/ape:' >/proc/sys/fs/binfmt_misc/register"
       - run: tool/cosmocc/package.sh
-      # v4.3.6 doesn't preserve symlinks. v4.3.5 does. https://github.com/actions/upload-artifact/issues/590
+      # https://github.com/actions/upload-artifact/issues/590
       - uses: actions/upload-artifact@v4.3.5
         with:
           name: cosmocc

--- a/.github/workflows/nightly-cosmocc.yml
+++ b/.github/workflows/nightly-cosmocc.yml
@@ -1,0 +1,24 @@
+name: Nightly cosmocc
+on:
+  schedule:
+    # https://crontab.guru/#37_4_*_*_*
+    - cron: "37 4 * * *"
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+jobs:
+  build-cosmocc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          sudo cp build/bootstrap/ape.elf /usr/bin/ape
+          sudo sh -c "echo ':APE:M::MZqFpD::/usr/bin/ape:' >/proc/sys/fs/binfmt_misc/register"
+      - run: tool/cosmocc/package.sh
+      # v4.3.6 doesn't preserve symlinks. v4.3.5 does. https://github.com/actions/upload-artifact/issues/590
+      - uses: actions/upload-artifact@v4.3.5
+        with:
+          name: cosmocc
+          path: cosmocc
+          compression-level: 9


### PR DESCRIPTION
Using https://nightly.link/ with GitHub actions artifacts you can have a nightly build (but not a _release_ -- there's no releasing or pre-releasing happening) of cosmocc.

Example URL if this PR were merged:

https://nightly.link/jart/cosmopolitan/workflows/nightly-cosmocc/master/cosmocc.zip

Or you can just download it directly from the GitHub "Actions" https://github.com/jart/cosmopolitan/actions workflow summary page of a particular run

example from my own fork:

![image](https://github.com/user-attachments/assets/8ba708dd-8289-4f8b-932c-cf535ee86f62) could download by clicking on the artifact

or by using third-party service to provide a link for unauthenticated requests (like wget or curl)
https://nightly.link/jcbhmr/cosmopolitan/workflows/tool-cosmocc-package-sh/master/cosmocc.zip

this would be useful for users who don't want to or can't figure out how to build cosmocc themselves (like Windows) but still want to use a nightly build since a fix hasn't been released as a release version yet.

this would also be a good way to test the release process but instead of pushing the `cosmocc.zip` to _wherever it goes now_ you publish it as a github actions artifact for the very few nightly bleeding edge users to use & test.

you don't have to use https://nightly.link or recommend it or anything; i just know its a cool way to wget or curl the URLs instead of downloading it via your browser web UI. particularly useful for remote/ssh/web-ide development.
