### PR TITLE
Fix %[hl]s field length/precision on printf funcs

### DIFF
--- a/libc/stdio/printf.c
+++ b/libc/stdio/printf.c
@@ -33,11 +33,13 @@
  *   consistent with glibc, musl, and uclibc.
  *
  * - `%hs` converts UTF-16/UCS-2 → UTF-8, which can be helpful on Windows.
- *   Formatting (e.g. %-10hs) will use monospace display width rather
- *   than string length or codepoint count.
+ *   Formatting (e.g. %-10hs) will use output byte length (rounded down to
+ *   ensure only full multibyte characters are output) rather than string
+ *   length or codepoint count.
  *
  * - `%ls` (or `%Ls`) converts UTF-32 → UTF-8. Formatting (e.g. %-10ls)
- *   will use monospace display width rather than string length.
+ *   will use output byte length (rounded down to ensure only full multibyte
+ *   characters are output) rather than string length.
  *
  * - The `%#s` and `%#c` alternate forms display values using the
  *   standard IBM standard 256-letter alphabet. Using `%#.*s` to specify

--- a/test/libc/stdio/snprintf_test.c
+++ b/test/libc/stdio/snprintf_test.c
@@ -35,3 +35,81 @@ TEST(snprintf, testPlusFlagOnChar) {
   ASSERT_EQ(i, 1);
   ASSERT_STREQ(buf, "=");
 }
+
+TEST(snprintf, testStringWidth) {
+  char buf[100] = {};
+  int i = snprintf(buf, sizeof(buf), "<%9ls>", L"éée");
+
+  ASSERT_EQ(i, 11);
+  ASSERT_STREQ(buf, "<    éée>");
+
+  i = snprintf(buf, sizeof(buf), "<%9s>", "éée");
+  ASSERT_EQ(i, 11);
+  ASSERT_STREQ(buf, "<    éée>");
+
+  i = snprintf(buf, sizeof(buf), "<%9hs>", u"éée");
+  ASSERT_EQ(i, 11);
+  ASSERT_STREQ(buf, "<    éée>");
+}
+
+TEST(snprintf, testStringPrecision) {
+  char buf[100] = {};
+  int i = snprintf(buf, sizeof(buf), "%.4ls", L"eeée");
+
+  ASSERT_EQ(i, 4);
+  ASSERT_STREQ(buf, "eeé");
+
+  i = snprintf(buf, sizeof(buf), "%.4s", "eeée");
+  ASSERT_EQ(i, 4);
+  ASSERT_STREQ(buf, "eeé");
+
+  i = snprintf(buf, sizeof(buf), "%.4hs", u"eeée");
+  ASSERT_EQ(i, 4);
+  ASSERT_STREQ(buf, "eeé");
+}
+
+TEST(snprintf, testStringPrecisionPartialChar) {
+  char buf[100] = {};
+  int i = snprintf(buf, sizeof(buf), "%.4ls", L"eéée");
+
+  ASSERT_EQ(i, 3);
+  ASSERT_STREQ(buf, "eé");
+
+  // Note that partial multibyte characters are fine on non-wide conversions
+  // (whereas they are not written on wide conversions,
+  // according to the standard)
+  i = snprintf(buf, sizeof(buf), "%.4s", "eéée");
+  ASSERT_EQ(i, 4);
+  ASSERT_STREQ(buf, "eé\xc3");
+
+  i = snprintf(buf, sizeof(buf), "%.4hs", u"eéée");
+  ASSERT_EQ(i, 3);
+  ASSERT_STREQ(buf, "eé");
+}
+
+TEST(snprintf, testWideChar) {
+  char buf[100] = { 'a', 'b', 'c' };
+  int i = snprintf(buf, sizeof(buf), "%lc", L'\0');
+
+  ASSERT_EQ(i, 1);
+  ASSERT_EQ(buf[0], '\0');
+  ASSERT_EQ(buf[1], '\0');
+  ASSERT_EQ(buf[2], 'c');
+
+  buf[0] = 'a';
+  buf[1] = 'b';
+  i = snprintf(buf, sizeof(buf), "%hc", u'\0');
+
+  ASSERT_EQ(i, 1);
+  ASSERT_EQ(buf[0], '\0');
+  ASSERT_EQ(buf[1], '\0');
+  ASSERT_EQ(buf[2], 'c');
+
+  i = snprintf(buf, sizeof(buf), "%lc", L'þ');
+  ASSERT_EQ(i, 2);
+  ASSERT_STREQ(buf, "þ");
+
+  i = snprintf(buf, sizeof(buf), "%hc", u'þ');
+  ASSERT_EQ(i, 2);
+  ASSERT_STREQ(buf, "þ");
+}

--- a/test/libc/stdio/sprintf_s.inc
+++ b/test/libc/stdio/sprintf_s.inc
@@ -34,23 +34,33 @@ TEST(SUITE(sprintf), testStringLength) {
 }
 
 TEST(SUITE(sprintf), testCharacterCounting) {
-  ASSERT_STREQ("         ♥♦♣♠☺☻▲", Format(FORMAT("%16"), STRING("♥♦♣♠☺☻▲")));
+  ASSERT_STREQ("         ♥♦♣♠☺☻▲", Format(FORMAT("%30"), STRING("♥♦♣♠☺☻▲")));
+  ASSERT_STREQ("♥♦♣♠☺☻▲", Format(FORMAT("%16"), STRING("♥♦♣♠☺☻▲")));
 }
 
 TEST(SUITE(snprintf), testTableFlip) {
   EXPECT_STREQ("Table flip          ", Format("%-20ls", L"Table flip"));
-  EXPECT_STREQ("(╯°□°)╯︵L┻━┻       ", Format("%-20ls", L"(╯°□°)╯︵L┻━┻"));
-  EXPECT_STREQ("(╯°□°)╯︵u┻━┻       ", Format("%-20hs", u"(╯°□°)╯︵u┻━┻"));
-  EXPECT_STREQ("ちゃぶ台返し        ", Format("%-20ls", L"ちゃぶ台返し"));
-  EXPECT_STREQ("       (╯°□°)╯︵L┻━┻", Format("%20ls", L"(╯°□°)╯︵L┻━┻"));
-  EXPECT_STREQ("        ちゃぶ台返し", Format("%20ls", L"ちゃぶ台返し"));
+  EXPECT_STREQ("(╯°□°)╯︵L┻━┻", Format("%-20ls", L"(╯°□°)╯︵L┻━┻"));
+  EXPECT_STREQ("(╯°□°)╯︵L┻━┻       ", Format("%-35ls", L"(╯°□°)╯︵L┻━┻"));
+  EXPECT_STREQ("(╯°□°)╯︵u┻━┻", Format("%-20hs", u"(╯°□°)╯︵u┻━┻"));
+  EXPECT_STREQ("(╯°□°)╯︵u┻━┻       ", Format("%-35hs", u"(╯°□°)╯︵u┻━┻"));
+  EXPECT_STREQ("ちゃぶ台返し  ", Format("%-20ls", L"ちゃぶ台返し"));
+  EXPECT_STREQ("ちゃぶ台返し        ", Format("%-26ls", L"ちゃぶ台返し"));
+  EXPECT_STREQ("(╯°□°)╯︵L┻━┻", Format("%20ls", L"(╯°□°)╯︵L┻━┻"));
+  EXPECT_STREQ("       (╯°□°)╯︵L┻━┻", Format("%35ls", L"(╯°□°)╯︵L┻━┻"));
+  EXPECT_STREQ("  ちゃぶ台返し", Format("%20ls", L"ちゃぶ台返し"));
+  EXPECT_STREQ("        ちゃぶ台返し", Format("%26ls", L"ちゃぶ台返し"));
 }
 
 TEST(SUITE(snprintf), testCombiningWidth) {
-  EXPECT_STREQ("H̲E̲L̲L̲O̲     ",
+  EXPECT_STREQ("H̲E̲L̲L̲O̲",
                Format("%-10ls", L"H\u0332E\u0332L\u0332L\u0332O\u0332"));
-  EXPECT_STREQ("     H̲E̲L̲L̲O̲",
+  EXPECT_STREQ("H̲E̲L̲L̲O̲     ",
+               Format("%-20ls", L"H\u0332E\u0332L\u0332L\u0332O\u0332"));
+  EXPECT_STREQ("H̲E̲L̲L̲O̲",
                Format("%10hs", u"H\u0332E\u0332L\u0332L\u0332O\u0332"));
+  EXPECT_STREQ("     H̲E̲L̲L̲O̲",
+               Format("%20hs", u"H\u0332E\u0332L\u0332L\u0332O\u0332"));
 }
 
 TEST(SUITE(snprintf), testQuoting) {


### PR DESCRIPTION
Cosmopolitan currently has a completely wrong understanding (according to the C Standard) of how to handle precision and field length for wide strings, which have to be handled not by using the monospace display width but instead by using the outputted byte width (i.e. the UTF-8 length of the wide string).

This patch corrects this, corrects comments documenting the previous behavior, adds tests for the behavior and refactors tests that tested for the previous behavior to correctly use the new correct behavior.