### PR TITLE
Fix ecvt/fcvt issues w.r.t. value==0 and ndigit==0

### DIFF
--- a/test/libc/stdio/ecvt_test.c
+++ b/test/libc/stdio/ecvt_test.c
@@ -31,3 +31,38 @@ TEST(fcvt, test) {
   ASSERT_EQ(1, decpt);
   ASSERT_EQ(0, sign);
 }
+
+TEST(ecvt, minus0) {
+  int decpt = 110000000, sign = 110000000;
+
+  ASSERT_STREQ("00000", ecvt(-0.0, 5, &decpt, &sign));
+  ASSERT_LE(0, decpt);
+  ASSERT_GE(1, decpt);
+  ASSERT_EQ(1, sign);
+}
+
+TEST(ecvt, minus0ndigits0) {
+  int decpt = 110000000, sign = 110000000;
+
+  ASSERT_STREQ("", ecvt(-0.0, 0, &decpt, &sign));
+  ASSERT_LE(0, decpt);
+  ASSERT_GE(1, decpt);
+  ASSERT_EQ(1, sign);
+}
+
+TEST(fcvt, ndigits0) {
+  int decpt = 110000000, sign = 110000000;
+
+  ASSERT_STREQ("1", fcvt(0.6, 0, &decpt, &sign));
+  ASSERT_EQ(1, decpt);
+  ASSERT_EQ(0, sign);
+}
+
+TEST(fcvt, minus0ndigits0) {
+  int decpt = 110000000, sign = 110000000;
+
+  ASSERT_STREQ("", fcvt(-0.0, 0, &decpt, &sign));
+  ASSERT_LE(0, decpt);
+  ASSERT_GE(1, decpt);
+  ASSERT_EQ(1, sign);
+}


### PR DESCRIPTION
Before this commit, cosmopolitan had some issues with handling arguments
of 0 and signs, such as returning an incorrect sign when the input value
== -0.0, and incorrectly handling ndigit == 0 on fcvt (ndigit determines
the amount of digits *after* the radix character on fcvt, thus the parts
before it still must be outputted before fcvt's job is completely done).

This patch fixes these issues, and adds tests with corresponding inputs.