### PR TITLE
Fix rare corner case in ntspawn.c

### DIFF
--- a/libc/calls/ntspawn.c
+++ b/libc/calls/ntspawn.c
@@ -166,7 +166,7 @@ static textwindows int ntspawn2(struct NtSpawnArgs *a, struct SpawnBlock *sb) {
         alist, 0, kNtProcThreadAttributeParentProcess, &a->opt_hParentProcess,
         sizeof(a->opt_hParentProcess), 0, 0);
   }
-  if (ok && a->opt_lpExplicitHandleList) {
+  if (ok && a->dwExplicitHandleCount) {
     ok = UpdateProcThreadAttribute(
         alist, 0, kNtProcThreadAttributeHandleList, a->opt_lpExplicitHandleList,
         a->dwExplicitHandleCount * sizeof(*a->opt_lpExplicitHandleList), 0, 0);

--- a/libc/calls/ntspawn.c
+++ b/libc/calls/ntspawn.c
@@ -153,7 +153,7 @@ static textwindows int ntspawn2(struct NtSpawnArgs *a, struct SpawnBlock *sb) {
   alignas(16) char memory[128];
   size_t size = sizeof(memory);
   struct NtProcThreadAttributeList *alist = (void *)memory;
-  uint32_t items = !!a->opt_hParentProcess + !!a->opt_lpExplicitHandleList;
+  uint32_t items = !!a->opt_hParentProcess + !!a->dwExplicitHandleCount;
   ok = InitializeProcThreadAttributeList(alist, items, 0, &size);
   if (!ok && GetLastError() == kNtErrorInsufficientBuffer) {
     ok = !!(alist = freeme = ntspawn_malloc(size));


### PR DESCRIPTION
There could be cases when libc/proc/describefds.c calls calloc(handlecount, ..) with handlecount = 0
to initialize  what will later become opt_lpExplicitHandleList. But calloc(0, ..) does not always return null
according to https://learn.microsoft.com/ka-ge/cpp/c-runtime-library/reference/calloc?view=msvc-140

> In the Microsoft implementation, if number or size is zero, calloc returns a pointer to an allocated block
> of non-zero size. An attempt to read or write through the returned pointer leads to undefined behavior.

If the chosen conditional is a->opt_lpExplicitHandleList then UpdateProcThreadAttribute is called and
produces a Windows error. The modification avoids this problem.