### PR TITLE
Add POSIX's apostrophe flag for printf-based funcs

### DIFF
--- a/libc/stdio/fmt.c
+++ b/libc/stdio/fmt.c
@@ -78,7 +78,7 @@
 #define FLAGS_ISSIGNED  0x40
 #define FLAGS_NOQUOTE   0x80
 #define FLAGS_REPR      0x100
-#define FLAGS_QUOTE     FLAGS_SPACE
+#define FLAGS_QUOTE     0x200
 #define FLAGS_GROUPING  FLAGS_NOQUOTE
 
 #define __FMT_PUT(C)              \

--- a/test/libc/stdio/snprintf_test.c
+++ b/test/libc/stdio/snprintf_test.c
@@ -250,3 +250,10 @@ TEST(snprintf, testAConversionSpecifier) {
   ASSERT_STREQ("0x1.8p+4", buf);
 }
 */
+
+TEST(snprintf, apostropheFlag) {
+  char buf[20];
+  int i = snprintf(buf, sizeof(buf), "%'d", 1000000);
+  ASSERT_EQ(7, i);
+  ASSERT_STREQ("1000000", buf);
+}


### PR DESCRIPTION
POSIX specifies the <apostrophe> flag character for printf as formatting
decimal conversions with the thousands' grouping characters specified by
the current locale. Given that cosmopolitan currently has no support for
obtaining the locale's grouping character, all that is required (when in
the C/POSIX locale) for supporting this flag is ignoring it, and as it's
already used to indicate quoting (for non-decimal conversions), all that
has to be done is to avoid having it be an alias for the <space> flag so
that decimal conversions don't accidentally behave as though the <space>
flag has also been specified whenever the <apostrophe> flag is utilized.

This patch adds this flag, as described above, along with a test for it.