### PR TITLE
Fix occasional crash in test/libc/intrin/mmap_test

### DIFF
--- a/test/libc/intrin/mmap_test.c
+++ b/test/libc/intrin/mmap_test.c
@@ -32,7 +32,7 @@
 #include "libc/sysv/consts/msync.h"
 #include "libc/sysv/consts/o.h"
 #include "libc/sysv/consts/prot.h"
-#include "libc/testlib/ezbench.h"
+#include "libc/testlib/benchmark.h"
 #include "libc/testlib/testlib.h"
 #include "libc/x/xspawn.h"
 
@@ -524,7 +524,7 @@ TEST(mmap, sharedFileMapFork) {
 ////////////////////////////////////////////////////////////////////////////////
 // BENCHMARKS
 
-#define N (EZBENCH_COUNT * EZBENCH_TRIES)
+#define N 1000
 
 int count;
 void *ptrs[N];
@@ -561,8 +561,8 @@ void BenchBigMunmap(void) {
 }
 
 TEST(mmap, bench) {
-  EZBENCH2("mmap", donothing, BenchMmapPrivate());
-  EZBENCH2("munmap", donothing, BenchUnmap());
-  // EZBENCH2("big mmap", donothing, BenchBigMmap());
-  // EZBENCH2("big munmap", donothing, BenchBigMunmap());
+  BENCHMARK(N, 1, BenchMmapPrivate());
+  BENCHMARK(N, 1, BenchUnmap());
+  // BENCHMARK(N, 1, BenchBigMmap());
+  // BENCHMARK(N, 1, BenchBigMunmap());
 }


### PR DESCRIPTION
This test would sometimes crash due to the EZBENCH2() macro occasionally
running the first benchmark (BenchMmapPrivate()) less times than it does
the second benchmark (BenchUnmap()) - this would then lead to a crash in
BenchUnmap() because BenchUnmap() expects that BenchMmapPrivate() has to
previously have been called at least as many times as it has itself such
that a region of memory has been mapped, for BenchUnmap() to then unmap.

This commit fixes this by utilizing the newer BENCHMARK() macro (instead
of the EZBENCH2() macro) which runs the benchmark using an count of runs
specified directly by the benchmark itself, which allows us to make sure
that the two benchmark functions get ran the exact same amount of times.