### PR TITLE
Make the pledge sandbox .so object work with UBSAN

### DIFF
--- a/tool/build/BUILD.mk
+++ b/tool/build/BUILD.mk
@@ -86,9 +86,11 @@ o/$(MODE)/tool/build/cocmd.zip.o: private				\
 
 # we need pic because:
 #   so it can be an LD_PRELOAD payload
+# we need fsanitize-trap=all becuase:
+#   so we don't need to pull in the entire ubsan runtime
 o/$(MODE)/tool/build/dso/sandbox.o: private				\
 		CFLAGS +=						\
-			-fPIC
+			-fPIC -fsanitize-trap=all
 
 o/$(MODE)/tool/build/dso/sandbox.o:					\
 		libc/calls/calls.h					\


### PR DESCRIPTION
Currently, cosmopolitan's pledge sandbox .so shared object wrongly tries
to use a bunch of UBSAN symbols, which are not defined when outside of a
cosmopolitan-based context (save if the sandboxed binary also happens to
be itself using UBSAN, but that's obviously very commonly not the case).

Fix this by making it such that the sandbox .so shared object traps when
UBSAN is triggered, avoiding any attempt to call into the UBSAN runtime.