### PR TITLE
Add weak self make_shared variant

### DIFF
--- a/ctl/shared_ptr.h
+++ b/ctl/shared_ptr.h
@@ -5,6 +5,7 @@
 
 #include "exception.h"
 #include "is_base_of.h"
+#include "is_constructible.h"
 #include "is_convertible.h"
 #include "remove_extent.h"
 #include "unique_ptr.h"
@@ -437,6 +438,9 @@ class weak_ptr
     template<typename U>
     friend class shared_ptr;
 
+    template<typename U, typename... Args>
+    friend shared_ptr<U> make_shared(Args&&...);
+
     element_type* p = nullptr;
     __::shared_ref* rc = nullptr;
 };
@@ -497,19 +501,70 @@ shared_ptr<T>::shared_ptr(U* const p, D d)
     }
 }
 
+// Our make_shared supports passing a weak self reference as the first parameter
+// to your constructor, e.g.:
+//
+//     struct Tree : ctl::weak_self_base
+//     {
+//         ctl::shared_ptr<Tree> l, r;
+//         ctl::weak_ptr<Tree> parent;
+//         Tree(weak_ptr<Tree> const& self, auto&& l2, auto&& r2)
+//           : l(ctl::forward<decltype(l2)>(l2)),
+//             r(ctl::forward<decltype(r2)>(r2))
+//         {
+//             if (l) l->parent = self;
+//             if (r) r->parent = self;
+//         }
+//     };
+//
+//     int main() {
+//         auto t = ctl::make_shared<Tree>(
+//             ctl::make_shared<Tree>(nullptr, nullptr), nullptr);
+//         return t->l->parent.lock().get() == t.get() ? 0 : 1;
+//     }
+//
+// As shown, passing the parameter at object construction time lets you complete
+// object construction without needing a separate Init method. But because we go
+// off spec as far as the STL is concerned, there is a potential ambiguity where
+// you might have a constructor with a weak_ptr first parameter that is intended
+// to be something other than a self-reference. So this feature is opt-in by way
+// of inheriting from the following struct.
+struct weak_self_base
+{};
+
 template<typename T, typename... Args>
 shared_ptr<T>
 make_shared(Args&&... args)
 {
     auto rc = __::shared_emplace<T>::make();
-    rc->construct(forward<Args>(args)...);
-    shared_ptr<T> r;
-    r.p = &rc->t;
-    r.rc = rc.release();
-    if constexpr (is_base_of_v<enable_shared_from_this<T>, T>) {
-        r->weak_this = r;
+    if constexpr (is_base_of_v<weak_self_base, T> &&
+                  is_constructible_v<T, const weak_ptr<T>&, Args...>) {
+        weak_ptr<T> w;
+        w.p = &rc->t;
+        w.rc = rc.get();
+        try {
+            rc->construct(const_cast<const weak_ptr<T>&>(w),
+                          forward<Args>(args)...);
+        } catch (...) {
+            w.p = nullptr;
+            w.rc = nullptr;
+            throw;
+        }
+        rc.release();
+        shared_ptr<T> r;
+        swap(r.p, w.p);
+        swap(r.rc, w.rc);
+        return r;
+    } else {
+        rc->construct(forward<Args>(args)...);
+        shared_ptr<T> r;
+        r.p = &rc->t;
+        r.rc = rc.release();
+        if constexpr (is_base_of_v<enable_shared_from_this<T>, T>) {
+            r->weak_this = r;
+        }
+        return r;
     }
-    return r;
 }
 
 } // namespace ctl

--- a/test/ctl/shared_ptr_test.cc
+++ b/test/ctl/shared_ptr_test.cc
@@ -16,6 +16,7 @@
 // TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
+#include "ctl/is_same.h"
 #include "ctl/shared_ptr.h"
 #include "ctl/vector.h"
 #include "libc/mem/leaks.h"
@@ -87,6 +88,21 @@ class SharedThis : public enable_shared_from_this<SharedThis>
 
 class CanShareThis : public enable_shared_from_this<CanShareThis>
 {};
+
+// Sample class used to demonstrate the CTL shared_ptr's weak_self feature.
+struct Tree : ctl::weak_self_base
+{
+    ctl::shared_ptr<Tree> l, r;
+    ctl::weak_ptr<Tree> p;
+    Tree(ctl::weak_ptr<Tree> const& self, auto&& l2, auto&& r2)
+      : l(ctl::forward<decltype(l2)>(l2)), r(ctl::forward<decltype(r2)>(r2))
+    {
+        if (l)
+            l->p = self;
+        if (r)
+            r->p = self;
+    }
+};
 
 int
 main()
@@ -274,6 +290,19 @@ main()
         auto v = w->shared_from_this();
         if (w.use_count() != 2 || w.get() != v.get())
             return 25;
+    }
+
+    if constexpr (ctl::is_same_v<shared_ptr<Tree>, ctl::shared_ptr<Tree>>) {
+        // Exercise our off-STL make_shared with weak self support.
+        auto t = ctl::make_shared<Tree>(
+          ctl::make_shared<Tree>(ctl::make_shared<Tree>(nullptr, nullptr),
+                                 nullptr),
+          ctl::make_shared<Tree>(nullptr, nullptr));
+        auto t2 = t->l->l->p.lock()->p.lock();
+        if (t.owner_before(t2) || t2.owner_before(t))
+            return 26;
+        if (!t.owner_before(t->l) && !t->l.owner_before(t))
+            return 27;
     }
 
     // TODO(mrdomino): exercise threads / races. The reference count should be


### PR DESCRIPTION
This extends the CTL version of make_shared with functionality not found
in the STL, with inspiration taken from Rust's Rc class.