### PR TITLE
Add the uppercase B conversion specifier to printf

### DIFF
--- a/libc/stdio/fmt.c
+++ b/libc/stdio/fmt.c
@@ -1090,9 +1090,10 @@ int __fmt(void *fn, void *arg, const char *format, va_list va, int *wrote) {
       case 'x':
         log2base = 4;
         goto FormatNumber;
+      case 'B':
       case 'b':
         log2base = 1;
-        alphabet = "0123456789abcdefpb";
+        alphabet = (d == 'b' ? "0123456789abcdefpb" : "0123456789ABCDEFPB");
         goto FormatNumber;
       case 'o':
         log2base = 3;


### PR DESCRIPTION
The (uppercase) B conversion specifier is specified by the C standard to
have the same behavior as the (lowercase) b conversion specifier, except
that whenever the # flag is used, the (uppercase) B conversion specifier
alters a nonzero result by prefixing it with "0B", instead of with "0b".

This commit adds this conversion specifier alongside a few tests for it.