### PR TITLE
Replace "comprised of" with better expressions

### DIFF
--- a/ape/ape.lds
+++ b/ape/ape.lds
@@ -113,7 +113,7 @@
 
   Your linker and assemblies were designed provide extensibility through
   the use of link-time data structures we call "decentralized sections".
-  They allow functions like _init() to be comprised of many small pieces
+  They allow functions like _init() to comprise many small pieces
   defined throughout the codebase. The same applies to ELF / PE headers.
 
   Extending that content usually entails writing a .S file. The process

--- a/libc/runtime/init.S
+++ b/libc/runtime/init.S
@@ -28,7 +28,7 @@
 //	that's restricted to read-only after initialization by PIRO.
 //
 //	This is fast, since the linker is able to roll-up initialization
-//	for large codebases comprised of many modules, into a perfectly
+//	for large codebases made up of many modules, into a perfectly
 //	linear order. It also enables a common pattern we use, which we
 //	call “Referencing Is Initialization” (RII).
 //

--- a/libc/str/lz4cpy.c
+++ b/libc/str/lz4cpy.c
@@ -26,7 +26,7 @@
  * Decompresses LZ4 block.
  *
  * This is a 103 byte implementation of the LZ4 algorithm. Please note
- * LZ4 files are comprised of multiple frames, which may be decoded
+ * LZ4 files are a sequence of multiple frames, which may be decoded
  * together using the wrapper function lz4decode().
  *
  * @see rldecode() for a 16-byte decompressor

--- a/tool/build/runitd.c
+++ b/tool/build/runitd.c
@@ -92,7 +92,7 @@
  *
  * Here's how it handles connections:
  *
- * 1. Receives atomically-written request header, comprised of:
+ * 1. Receives atomically-written request header, comprising:
  *
  *   - 4 byte nbo magic = 0xFEEDABEEu
  *   - 1 byte command = kRunitExecute

--- a/tool/cosmocc/README.md
+++ b/tool/cosmocc/README.md
@@ -3,7 +3,7 @@
 This toolchain can be used to compile executables that run on Linux /
 MacOS / Windows / FreeBSD / OpenBSD 7.3 / NetBSD for both the x86_64 and
 AARCH64 architectures. In addition to letting you create portable
-binaries, your toolchain is itself comprised of portable binaries,
+binaries, your toolchain is itself made up of portable binaries,
 enabling you to have a consistent development environment that lets you
 reach a broader audience from the platform(s) of your choosing.
 


### PR DESCRIPTION
The expression "comprised of" is not currently considered grammatically correct. Depending on the context, either replace it with "comprises" or "comprising", or replace it by the more obvious and less controversial "made up of".

This change does not affect any third-party code where additional local delta may complicate further updates to newer upstream versions.