### PR TITLE
redbean: enable sqlite3 serialization

### DIFF
--- a/tool/net/BUILD.mk
+++ b/tool/net/BUILD.mk
@@ -117,7 +117,8 @@ o/$(MODE)/tool/net/redbean.dbg:						\
 
 o/$(MODE)/tool/net/lsqlite3.o: private					\
 		CFLAGS +=						\
-			-DSQLITE_ENABLE_SESSION
+			-DSQLITE_ENABLE_SESSION				\
+			-DSQLITE_ENABLE_DESERIALIZE
 
 # REDBEAN-DEMO
 #


### PR DESCRIPTION
Fix for failing demo page that requires to enable the serialization for lsqlite3 being used in redbean server.