### PR TITLE
Standard make path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,8 @@ COMMA := ,
 PWD := $(shell pwd)
 
 # detect wsl2 running cosmopolitan binaries on the host by checking whether:
-# - user ran build/bootstrap/make, in which case make's working directory is in wsl
+# - user ran .cosmocc/current/bin/make, in which case make's working directory
+#   is in wsl
 # - user ran make, in which case cocmd's working directory is in wsl
 ifneq ($(findstring //wsl.localhost/,$(CURDIR) $(PWD)),)
 $(warning wsl2 interop is enabled)
@@ -89,7 +90,7 @@ UNAME_S := $(shell uname -s)
 
 # apple still distributes a 17 year old version of gnu make
 ifeq ($(MAKE_VERSION), 3.81)
-$(error please use build/bootstrap/make)
+$(error please use https://cosmo.zip/pub/cosmos/bin/make)
 endif
 
 LC_ALL = C

--- a/README.md
+++ b/README.md
@@ -87,14 +87,21 @@ ape/apeinstall.sh
 ```
 
 You can now build the mono repo with any modern version of GNU Make. To
-make life easier, we've included one in the cosmocc toolchain, which is
-guaranteed to be compatible and furthermore includes our extensions for
-doing build system sandboxing.
+bootstrap your build, you can install Cosmopolitan Make from this site:
+
+https://cosmo.zip/pub/cosmos/bin/make
+
+E.g.:
 
 ```sh
-build/bootstrap/make -j8
+curl -LO https://cosmo.zip/pub/cosmos/bin/make
+./make -j8
 o//examples/hello
 ```
+
+After you've built the repo once, you can also use the make from your
+cosmocc at `.cosmocc/current/bin/make`. You might even prefer to alias
+make to `$COSMO/.cosmocc/current/bin/make`.
 
 Since the Cosmopolitan repository is very large, you might only want to
 build one particular thing. Here's an example of a target that can be
@@ -103,7 +110,7 @@ depends on core LIBC packages.
 
 ```sh
 rm -rf o//libc o//test
-build/bootstrap/make o//test/posix/signal_test
+.cosmocc/current/bin/make o//test/posix/signal_test
 o//test/posix/signal_test
 ```
 
@@ -112,21 +119,21 @@ list out each individual one. For example if you wanted to build and run
 all the unit tests in the `TEST_POSIX` package, you could say:
 
 ```sh
-build/bootstrap/make o//test/posix
+.cosmocc/current/bin/make o//test/posix
 ```
 
 Cosmopolitan provides a variety of build modes. For example, if you want
 really tiny binaries (as small as 12kb in size) then you'd say:
 
 ```sh
-build/bootstrap/make m=tiny
+.cosmocc/current/bin/make m=tiny
 ```
 
 You can furthermore cut out the bloat of other operating systems, and
 have Cosmopolitan become much more similar to Musl Libc.
 
 ```sh
-build/bootstrap/make m=tinylinux
+.cosmocc/current/bin/make m=tinylinux
 ```
 
 For further details, see [//build/config.mk](build/config.mk).

--- a/ape/apeinstall.sh
+++ b/ape/apeinstall.sh
@@ -10,8 +10,8 @@ if [ ! -f ape/loader.c ]; then
   cd "$COSMO" || exit
 fi
 
-if [ -x build/bootstrap/make ]; then
-  MAKE=build/bootstrap/make
+if [ -x .cosmocc/current/bin/make ]; then
+  MAKE=.cosmocc/current/bin/make
 else
   MAKE=make
 fi

--- a/build/download-cosmocc.sh
+++ b/build/download-cosmocc.sh
@@ -99,3 +99,8 @@ rm -f cosmocc.zip cosmocc.zip.sha256sum
 # commit output directory
 cd "${OLDPWD}" || die
 mv "${OUTPUT_TMP}" "${OUTPUT_DIR}" || die
+
+# update current symlink
+BASE=$(basename "${OUTPUT_DIR}")
+DIR=$(dirname "${OUTPUT_DIR}")
+ln -sfn "$BASE" "$DIR/current"

--- a/test/posix/sigchld_test.c
+++ b/test/posix/sigchld_test.c
@@ -32,7 +32,7 @@
 #include <unistd.h>
 
 // clang-format off
-// sh -c 'build/bootstrap/make -j8 V=1 o//test/posix/sigchld_test.runs'
+// sh -c '.cosmocc/current/bin/make -j8 V=1 o//test/posix/sigchld_test.runs'
 // clang-format on
 
 void Assert(const char *file, int line, bool ok) {

--- a/tool/zsh/mmake
+++ b/tool/zsh/mmake
@@ -38,8 +38,21 @@ done
   whence nproc >/dev/null || autoload -Uz nproc
   j=-j$(nproc)
 }
-local make=${MAKE:-${COSMOCC:-/opt/cosmocc/current}/bin/make}
-[[ -x $make ]] || make=${COSMO:-$PWD}/build/bootstrap/make
+local make=$(
+  case $MAKE in
+    */*) echo $MAKE ;;
+    ?*)  command -v $MAKE ;;
+    *)   echo .cosmocc/current/bin/make
+  esac
+)
+if [[ ! -x $make ]]; then
+  { echo 'please install a suitable make, for example:'
+    echo
+    echo 'https://cosmo.zip/pub/cosmos/bin/make'
+    echo
+    echo 'then either put it on your $PATH or point to it with $MAKE.'
+  } >&2; return 1
+fi
 ( set -x
   exec $make $j $flags MODE=$mode $targs )
 # vim:ft=zsh


### PR DESCRIPTION
Modifies download-cosmocc.sh to maintain a .cosmocc/current symlink that
always points to the most recently downloaded version of cosmocc. We can
use this to point at a canonical make for a bootstrapped repository. For
first-time builds, we suggest: https://cosmo.zip/pub/cosmos/bin/make and
have updated the docs in a few places to mention this.

Fixes the other part of #1346.