### PR TITLE
cosmocc: build toolchain on MacOS

### DIFF
--- a/tool/cosmocc/package.sh
+++ b/tool/cosmocc/package.sh
@@ -54,10 +54,12 @@ ARM64=${3:-aarch64}
 NPROC=$(($(_nproc)/2))
 GCCVER=14.1.0
 MAKE=$(which_make)
-APE=$(which_ape)
 
 $MAKE -j$NPROC m= \
   $APELINK
+
+APE=$(which_ape)
+$APE
 
 $MAKE -j$NPROC m=$AMD64 \
   o/cosmocc.h.txt \

--- a/tool/cosmocc/package.sh
+++ b/tool/cosmocc/package.sh
@@ -31,22 +31,6 @@ which_make() {
 
 TMPDIR=${TMPDIR:-/tmp}
 
-which_ape() {
-  case $(uname -s) in
-    Darwin)
-      case $(mode) in
-        aarch64)
-          cc -O -o "$TMPDIR/ape.$$" .cosmocc/current/bin/ape-m1.c || exit
-          trap 'rm "$TMPDIR/ape.$$"' EXIT
-          echo $TMPDIR/ape.$$
-        ;;
-        *) echo .cosmocc/current/bin/ape-x86_64.macho ;;
-      esac
-      ;;
-    *) echo .cosmocc/current/bin/ape-$(uname -m).elf ;;
-  esac
-}
-
 OUTDIR=${1:-cosmocc}
 APELINK=o/$(mode)/tool/build/apelink
 AMD64=${2:-x86_64}
@@ -58,8 +42,20 @@ MAKE=$(which_make)
 $MAKE -j$NPROC m= \
   $APELINK
 
-APE=$(which_ape)
-$APE
+case $(uname -s) in
+  Darwin)
+    case $(mode) in
+      aarch64)
+        cc -O -o "$TMPDIR/ape.$$" .cosmocc/current/bin/ape-m1.c || exit
+        trap 'rm "$TMPDIR/ape.$$"' EXIT
+        APE=$TMPDIR/ape.$$
+      ;;
+      *) APE=.cosmocc/current/bin/ape-x86_64.macho ;;
+    esac
+    ;;
+  *) APE=.cosmocc/current/bin/ape-$(uname -m).elf ;;
+esac
+stat $APE
 
 $MAKE -j$NPROC m=$AMD64 \
   o/cosmocc.h.txt \

--- a/tool/cosmocc/package.sh
+++ b/tool/cosmocc/package.sh
@@ -22,22 +22,20 @@ _nproc() {
   esac
 }
 
-which_make() {
-  case $(uname -s) in
-    Darwin) echo gmake ;;
-    *)      echo make  ;;
-  esac
-}
-
 TMPDIR=${TMPDIR:-/tmp}
-
 OUTDIR=${1:-cosmocc}
 APELINK=o/$(mode)/tool/build/apelink
 AMD64=${2:-x86_64}
 ARM64=${3:-aarch64}
 NPROC=$(($(_nproc)/2))
 GCCVER=14.1.0
-MAKE=$(which_make)
+
+if ! MAKE=$(command -v gmake); then
+  if ! MAKE=$(command -v make); then
+    echo please install gnu make >&2
+    exit 1
+  fi
+fi
 
 $MAKE -j$NPROC m= \
   $APELINK

--- a/tool/cosmocc/package.sh
+++ b/tool/cosmocc/package.sh
@@ -40,19 +40,21 @@ fi
 $MAKE -j$NPROC m= \
   $APELINK
 
-case $(uname -s) in
-  Darwin)
-    case $(mode) in
-      aarch64)
-        cc -O -o "$TMPDIR/ape.$$" .cosmocc/current/bin/ape-m1.c || exit
-        trap 'rm "$TMPDIR/ape.$$"' EXIT
-        APE=$TMPDIR/ape.$$
+if ! APE=$(command -v ape); then
+  case $(uname -s) in
+    Darwin)
+      case $(mode) in
+        aarch64)
+          cc -O -o "$TMPDIR/ape.$$" .cosmocc/current/bin/ape-m1.c || exit
+          trap 'rm "$TMPDIR/ape.$$"' EXIT
+          APE=$TMPDIR/ape.$$
+        ;;
+        *) APE=.cosmocc/current/bin/ape-x86_64.macho ;;
+      esac
       ;;
-      *) APE=.cosmocc/current/bin/ape-x86_64.macho ;;
-    esac
-    ;;
-  *) APE=.cosmocc/current/bin/ape-$(uname -m).elf ;;
-esac
+    *) APE=.cosmocc/current/bin/ape-$(uname -m).elf ;;
+  esac
+fi
 stat $APE
 
 $MAKE -j$NPROC m=$AMD64 \

--- a/tool/cosmocc/package.sh
+++ b/tool/cosmocc/package.sh
@@ -44,6 +44,7 @@ which_ape() {
       esac
       ;;
     *) echo .cosmocc/current/bin/ape-$(uname -m).elf ;;
+  esac
 }
 
 OUTDIR=${1:-cosmocc}

--- a/tool/cosmocc/package.sh
+++ b/tool/cosmocc/package.sh
@@ -26,6 +26,7 @@ which_make() {
   case $(uname -s) in
     Darwin) echo gmake ;;
     *)      echo make  ;;
+  esac
 }
 
 OUTDIR=${1:-cosmocc}

--- a/tool/cosmocc/package.sh
+++ b/tool/cosmocc/package.sh
@@ -15,17 +15,31 @@ mode() {
   esac
 }
 
+_nproc() {
+  case $(uname -s) in
+    Darwin) sysctl -n hw.logicalcpu ;;
+    *)      nproc                   ;;
+  esac
+}
+
+which_make() {
+  case $(uname -s) in
+    Darwin) echo gmake ;;
+    *)      echo make  ;;
+}
+
 OUTDIR=${1:-cosmocc}
 APELINK=o/$(mode)/tool/build/apelink
 AMD64=${2:-x86_64}
 ARM64=${3:-aarch64}
-NPROC=$(($(nproc)/2))
+NPROC=$(($(_nproc)/2))
 GCCVER=14.1.0
+MAKE=$(which_make)
 
-make -j$NPROC m= \
+$MAKE -j$NPROC m= \
   $APELINK
 
-make -j$NPROC m=$AMD64 \
+$MAKE -j$NPROC m=$AMD64 \
   o/cosmocc.h.txt \
   o/$AMD64/ape/ape.lds \
   o/$AMD64/libc/crt/crt.o \
@@ -62,7 +76,7 @@ make -j$NPROC m=$AMD64 \
   o/$AMD64/third_party/make/make.dbg \
   o/$AMD64/third_party/ctags/ctags.dbg
 
-make -j$NPROC m=$AMD64-tiny \
+$MAKE -j$NPROC m=$AMD64-tiny \
   o/cosmocc.h.txt \
   o/$AMD64-tiny/ape/ape.lds \
   o/$AMD64-tiny/libc/crt/crt.o \
@@ -74,7 +88,7 @@ make -j$NPROC m=$AMD64-tiny \
   o/$AMD64-tiny/cosmopolitan.a \
   o/$AMD64-tiny/third_party/libcxx/libcxx.a \
 
-make -j$NPROC m=$AMD64-dbg \
+$MAKE -j$NPROC m=$AMD64-dbg \
   o/cosmocc.h.txt \
   o/$AMD64-dbg/ape/ape.lds \
   o/$AMD64-dbg/libc/crt/crt.o \
@@ -86,7 +100,7 @@ make -j$NPROC m=$AMD64-dbg \
   o/$AMD64-dbg/cosmopolitan.a \
   o/$AMD64-dbg/third_party/libcxx/libcxx.a \
 
-make CONFIG_TARGET_ARCH= -j$NPROC m=$AMD64-optlinux \
+$MAKE CONFIG_TARGET_ARCH= -j$NPROC m=$AMD64-optlinux \
   o/cosmocc.h.txt \
   o/$AMD64-optlinux/ape/ape.lds \
   o/$AMD64-optlinux/libc/crt/crt.o \
@@ -98,7 +112,7 @@ make CONFIG_TARGET_ARCH= -j$NPROC m=$AMD64-optlinux \
   o/$AMD64-optlinux/cosmopolitan.a \
   o/$AMD64-optlinux/third_party/libcxx/libcxx.a \
 
-make -j$NPROC m=$ARM64 \
+$MAKE -j$NPROC m=$ARM64 \
   o/$ARM64/ape/ape.elf \
   o/$ARM64/ape/aarch64.lds \
   o/$ARM64/libc/crt/crt.o \
@@ -130,21 +144,21 @@ make -j$NPROC m=$ARM64 \
   o/$ARM64/third_party/make/make.dbg \
   o/$ARM64/third_party/ctags/ctags.dbg
 
-make -j$NPROC m=$ARM64-tiny \
+$MAKE -j$NPROC m=$ARM64-tiny \
   o/$ARM64-tiny/ape/ape.elf \
   o/$ARM64-tiny/ape/aarch64.lds \
   o/$ARM64-tiny/libc/crt/crt.o \
   o/$ARM64-tiny/cosmopolitan.a \
   o/$ARM64-tiny/third_party/libcxx/libcxx.a \
 
-make -j$NPROC m=$ARM64-dbg \
+$MAKE -j$NPROC m=$ARM64-dbg \
   o/$ARM64-dbg/ape/ape.elf \
   o/$ARM64-dbg/ape/aarch64.lds \
   o/$ARM64-dbg/libc/crt/crt.o \
   o/$ARM64-dbg/cosmopolitan.a \
   o/$ARM64-dbg/third_party/libcxx/libcxx.a \
 
-make -j$NPROC m=$ARM64-optlinux \
+$MAKE -j$NPROC m=$ARM64-optlinux \
   o/$ARM64-optlinux/ape/ape.elf \
   o/$ARM64-optlinux/ape/aarch64.lds \
   o/$ARM64-optlinux/libc/crt/crt.o \


### PR DESCRIPTION
This updates the cosmocc toolchain packaging script to work on MacOS. Tested on GitHub Actions macos-13 (x86_64) and macos-14 (arm64) runners and verified to still work on Ubuntu (GitHub Actions runners ubuntu-24.04 and ubuntu-24.04-arm). End goal is to bring cosmocc to MacPorts by running the packaging script.

`gmake` is used instead of `make` because both Homebrew and MacPorts install newer `make`'s with the `g` prefix.

Additionally, the APE loader from the bootstrapper toolchain is used instead of a system APE, which may not be available.