### PR TITLE
Fix: Potential Vulnerability in bzip2 Library

### DIFF
--- a/third_party/bzip2/README.cosmo
+++ b/third_party/bzip2/README.cosmo
@@ -9,3 +9,6 @@ ORIGIN
   Author: Mark Wielaard <mark@klomp.org>
   Date:   Sat Jul 13 17:17:58 2019 +0200
   Prepare for 1.0.8 release.
+
+local vulnerability fix:
+- Fix CVE-2019-12900

--- a/third_party/bzip2/decompress.c
+++ b/third_party/bzip2/decompress.c
@@ -287,7 +287,7 @@ Int32 BZ2_decompress ( DState* s )
       GET_BITS(BZ_X_SELECTOR_1, nGroups, 3);
       if (nGroups < 2 || nGroups > BZ_N_GROUPS) RETURN(BZ_DATA_ERROR);
       GET_BITS(BZ_X_SELECTOR_2, nSelectors, 15);
-      if (nSelectors < 1) RETURN(BZ_DATA_ERROR);
+      if (nSelectors < 1 || nSelectors > BZ_MAX_SELECTORS) RETURN(BZ_DATA_ERROR);
       for (i = 0; i < nSelectors; i++) {
          j = 0;
          while (True) {


### PR DESCRIPTION
This PR fixes a security vulnerability in inflate() that was cloned from zlib but did not receive the security patch applied in zlib. The original issue was reported and fixed under https://gitlab.com/federicomenaquintero/bzip2/-/commit/74de1e2e6ffc9d51ef9824db71a8ffee5962cdbc.

This PR applies the same patch as the one in zlib to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2019-12900
https://gitlab.com/federicomenaquintero/bzip2/-/commit/74de1e2e6ffc9d51ef9824db71a8ffee5962cdbc