### PR TITLE
Support additional architectures in apelink

### DIFF
--- a/libc/elf/def.h
+++ b/libc/elf/def.h
@@ -68,6 +68,7 @@
 #define EM_NONE      0
 #define EM_M32       1
 #define EM_386       3
+#define EM_MIPS      8
 #define EM_PPC64     21
 #define EM_S390      22
 #define EM_ARM       40


### PR DESCRIPTION
This updates apelink to support machine architectures not in the source program input list by adding additional loaders, extracting the correct one that matches the host uname machine. With this change, blink can be supplied as the additional loader to run the program in x86_64 VMs. The change has been verified against blink 1.0, powerpc64le and mips64el in Docker using QEMU.