### PR TITLE
add support for getcpu() system call to pledge()

### DIFF
--- a/libc/calls/pledge-linux.c
+++ b/libc/calls/pledge-linux.c
@@ -694,6 +694,7 @@ static const uint16_t kPledgeStdio[] = {
     __NR_linux_sched_getaffinity,  //
     __NR_linux_sched_setaffinity,  //
     __NR_linux_sigtimedwait,       //
+    __NR_linux_getcpu,             //
 };
 
 static const uint16_t kPledgeFlock[] = {


### PR DESCRIPTION
This change fixes the following redbean lua tests:

- `encodelua_test.lua`
- `encodejson_test.lua`
- `jsonorg_fail_test.lua`
- `base64_test.lua`
- `jsonorg_pass_test.lua`
- `futex_test.lua`

Without it, these tests fail with SIGSYS on Linux