### PR TITLE
Fix shared_ptr<T>::owner_before

### DIFF
--- a/ctl/shared_ptr.h
+++ b/ctl/shared_ptr.h
@@ -349,7 +349,7 @@ class shared_ptr
     template<typename U>
     bool owner_before(const weak_ptr<U>& r) const noexcept
     {
-        return !r.owner_before(*this);
+        return rc < r.rc;
     }
 
   private:


### PR DESCRIPTION
`!(a < b)` is not the same as `b < a`.

I think I originally wrote it this way to avoid making weak_ptr a friend of shared_ptr, but weak_ptr already is a friend.