### PR TITLE
More shared_ptr fixes

### DIFF
--- a/ctl/shared_ptr.h
+++ b/ctl/shared_ptr.h
@@ -444,6 +444,13 @@ class weak_ptr
         return *this;
     }
 
+    template <typename U>
+        requires __::shared_ptr_compatible<T, U>
+    weak_ptr& operator=(weak_ptr<U> r) noexcept
+    {
+        weak_ptr<T>(move(r)).swap(*this);
+    }
+
     shared_ptr<T> lock() const noexcept
     {
         if (expired())

--- a/ctl/shared_ptr.h
+++ b/ctl/shared_ptr.h
@@ -382,7 +382,7 @@ class weak_ptr
             rc->keep_weak();
     }
 
-    weak_ptr(weak_ptr const& r) noexcept : p(r.p), rc(r.rc)
+    weak_ptr(const weak_ptr& r) noexcept : p(r.p), rc(r.rc)
     {
         if (rc)
             rc->keep_weak();
@@ -390,7 +390,7 @@ class weak_ptr
 
     template<typename U>
         requires __::shared_ptr_compatible<T, U>
-    weak_ptr(weak_ptr<U> const& r) noexcept : p(r.p), rc(r.rc)
+    weak_ptr(const weak_ptr<U>& r) noexcept : p(r.p), rc(r.rc)
     {
         if (rc)
             rc->keep_weak();

--- a/ctl/shared_ptr.h
+++ b/ctl/shared_ptr.h
@@ -97,12 +97,12 @@ class shared_ref
 
     size_t use_count() const noexcept
     {
-        return shared + 1;
+        return __atomic_load_n(&shared, __ATOMIC_RELAXED) + 1;
     }
 
     size_t weak_count() const noexcept
     {
-        return weak;
+        return __atomic_load_n(&weak, __ATOMIC_RELAXED);
     }
 
   private:


### PR DESCRIPTION
* Make refcount reads explicitly atomic
* Consistently put `const` in the same place
* Write the general `operator=` on `weak_ptr`