### PR TITLE
Feature: Do not reuse different architecture version of temporary APE Loader on Darwin

### DIFF
--- a/ape/ape.S
+++ b/ape/ape.S
@@ -613,6 +613,11 @@ apesh:	.ascii	"\n@\n#'\"\n"			// sixth edition shebang
 	.ascii	    "t=\"${TMPDIR:-${HOME:-.}}/.ape-"
 	.ascii	     APE_VERSION_STR
 	.ascii	     "\"\n"
+#if SupportsXnu()
+// Add an architecture suffix to the temporary APE Loader
+// name to differentiate between x86_64 and arm64.
+	.ascii    "[ -d /Applications ] && t=\"${t}-$(uname -m 2>/dev/null || printf 'unknown')\"\n"
+#endif /* SupportsXnu() */
 	.ascii	    "[ -x \"$t\" ] || {\n"
 	.ascii	      "mkdir -p \"${t%/*}\" &&\n"
 	.ascii	      "dd if=\"$o\" of=\"$t.$$\" skip="

--- a/ape/ape.h
+++ b/ape/ape.h
@@ -10,4 +10,12 @@
 #define APE_VERSION_STR_(x, y)  APE_VERSION_STR__(x, y)
 #define APE_VERSION_NOTE_(x, y) (100000000 * (x) + 1000000 * (y))
 
+#if defined(__x86_64__)
+#define GetXnuSuffix() "-x86_64"
+#elif defined(__aarch64__)
+#define GetXnuSuffix() "-arm64"
+#else
+#define GetXnuSuffix() "-unknown"
+#endif
+
 #endif /* COSMOPOLITAN_APE_APE_H_ */

--- a/ape/apeuninstall.sh
+++ b/ape/apeuninstall.sh
@@ -60,7 +60,6 @@ for x in .ape \
          .ape-1.8 \
          .ape-1.9 \
          .ape-1.10-arm64 \
-         .ape-1.10-arm64.c \
          .ape-1.10-x86_64 \
          .ape-1.10; do
   rm -f \
@@ -68,4 +67,9 @@ for x in .ape \
      /tmp/$x \
      o/tmp/$x \
      "${TMPDIR:-/tmp}/$x"
+  rm -f \
+     ~/$x \
+     /tmp/$x \
+     o/tmp/$x \
+     "${TMPDIR:-/tmp}/$x.c"
 done

--- a/ape/apeuninstall.sh
+++ b/ape/apeuninstall.sh
@@ -59,6 +59,9 @@ for x in .ape \
          .ape-1.7 \
          .ape-1.8 \
          .ape-1.9 \
+         .ape-1.10-arm64 \
+         .ape-1.10-arm64.c \
+         .ape-1.10-x86_64 \
          .ape-1.10; do
   rm -f \
      ~/$x \

--- a/libc/proc/execve-sysv.c
+++ b/libc/proc/execve-sysv.c
@@ -132,7 +132,13 @@ int sys_execve(const char *prog, char *const argv[], char *const envp[]) {
       RetryExecve("/usr/bin/ape", shargs, envp);
     }
     char *buf = alloca(PATH_MAX);
-    const char *name = "/.ape-" APE_VERSION_STR;
+    const char *name = "";
+    if (IsXnu()) {
+        name = "/.ape-" APE_VERSION_STR GetXnuSuffix();
+    }
+    else {
+        name = "/.ape-" APE_VERSION_STR;
+    }
     InitExecve();
     RetryExecve(Join(g_execve.tmpdir, name, buf), shargs, envp);
     RetryExecve(Join(g_execve.home, name, buf), shargs, envp);

--- a/tool/build/apelink.c
+++ b/tool/build/apelink.c
@@ -2016,7 +2016,13 @@ int main(int argc, char *argv[]) {
 
     // otherwise try to use the ad-hoc self-extracted loader, securely
     if (loaders.n) {
-      p = stpcpy(p, "t=\"${TMPDIR:-${HOME:-.}}/.ape-" APE_VERSION_STR "\"\n"
+      p = stpcpy(p, "t=\"${TMPDIR:-${HOME:-.}}/.ape-" APE_VERSION_STR);
+      if (support_vector & _HOSTXNU) {
+        // Add the current architecture to the temporary APE Loader
+        // name to differentiate between x86_64 and arm64 Ape Loaders.
+        p = stpcpy(p, "$([ -d /Applications ] && ( printf '-'; ( uname -m 2>/dev/null || printf 'unknown')))");
+      }
+      p = stpcpy(p, "\"\n"
                     "[ x\"$1\" != x--assimilate ] && "
                     "[ -x \"$t\" ] && "
                     "exec \"$t\" \"$o\" \"$@\"\n");

--- a/tool/build/pledge.c
+++ b/tool/build/pledge.c
@@ -555,10 +555,14 @@ void ApplyFilesystemPolicy(unsigned long ipromises) {
       if ((p = getenv("TMPDIR"))) {
         UnveilIfExists(
             __join_paths(buf, sizeof(buf), p, ".ape-" APE_VERSION_STR), "rx");
+        UnveilIfExists(
+            __join_paths(buf, sizeof(buf), p, ".ape-" APE_VERSION_STR GetXnuSuffix()), "rx");
       }
       if ((p = getenv("HOME"))) {
         UnveilIfExists(
             __join_paths(buf, sizeof(buf), p, ".ape-" APE_VERSION_STR), "rx");
+        UnveilIfExists(
+            __join_paths(buf, sizeof(buf), p, ".ape-" APE_VERSION_STR GetXnuSuffix()), "rx");
       }
     }
   }

--- a/tool/cosmocc/README.md
+++ b/tool/cosmocc/README.md
@@ -136,7 +136,8 @@ On Apple Silicon, `aarch64-unknown-cosmo-cc` produces ELF binaries. If
 you build a hello world program, then you need to say `ape ./hello`. If
 you don't have an `ape` command then run `cc -o ape bin/ape-m1.c` which
 should be moved to `/usr/local/bin/ape`. Your APE interpreter might
-already exist under a path like `$TMPDIR/.ape-1.10`. It's important to
+already exist under a path like `$TMPDIR/.ape-1.10-arm64` or
+`$TMPDIR/.ape-1.10-x86_64` if you are using Rosetta. It's important to
 note this is only a gotcha for the cross compiler. Your `cosmocc`
 compiler wraps the actual ELF binaries with a shell script that'll
 extract and compile an APE loader automatically, as needed. This also


### PR DESCRIPTION
Addresses #1409 

Disclaimer: It has been more than a decade I last worked with C/C++ and I have no clue what am I doing, so please scrutinize everything I do and say.

So I thought I'll attempt to address the issue which caused me large headache few days ago.

As far as I can see the solution in this PR addresses the issue: Now on Apple Silicon Mac the APE loader is created as 
`${TMPDIR:-${HOME:-.}}/.ape-1.10-x86_64`
`${TMPDIR:-${HOME:-.}}/.ape-1.10-arm64`
`${TMPDIR:-${HOME:-.}}/.ape-1.10-arm64.c`

This way one can use Cosmo apps with both Rosetta and native ARM mode, even at the same time.

What I actually don't understand is why it appears that the same logic is implemented twice:
The code from [`ape/ape.S:613`](https://github.com/jart/cosmopolitan/blob/master/ape/ape.S#L613) and [`tool/build/apelink.c:2019`](https://github.com/jart/cosmopolitan/blob/master/tool/build/apelink.c#L2019) seems to do the same thing.

Ihave attempted to make sure they behave the same in my PR as well, but actually Idon't know what `ape/ape.S` does or when it is used, so I could not test if they indeed are fully compatible after my changes.