### PR TITLE
test/libc: fix cachestat() test on recent Linux kernels.

### DIFF
--- a/test/libc/calls/cachestat_test.c
+++ b/test/libc/calls/cachestat_test.c
@@ -53,7 +53,7 @@ void SetUpOnce(void) {
 
 TEST(cachestat, testCachestatOnDevices) {
   const char *const files[] = {
-      "/dev/zero", "/dev/null", "/dev/urandom", "/proc/version", "/proc",
+      "/dev/zero", "/dev/null", "/dev/urandom", "/proc/self/comm",
   };
   struct cachestat_range range = {0, 4 * pagesize};
   struct cachestat cs;


### PR DESCRIPTION
On Linux kernels which contain the fix for CVE-2025-21691, i.e. 5f537664e705b0bf8b7e329861f20128534f6a83 or its backports such as 780ab8329672464984cf1344bd5c3993af0226c7 , cachestat() requires that the file is writable or owned.
Use /proc/self/comm instead of /proc/version and /proc.