### PR TITLE
Ip6 getifaddrs

### DIFF
--- a/libc/sock/struct/ifreq.h
+++ b/libc/sock/struct/ifreq.h
@@ -1,6 +1,7 @@
 #ifndef COSMOPOLITAN_LIBC_SOCK_STRUCT_IFREQ_H_
 #define COSMOPOLITAN_LIBC_SOCK_STRUCT_IFREQ_H_
 #include "libc/sock/struct/sockaddr.h"
+#include "libc/sock/struct/sockaddr6.h"
 COSMOPOLITAN_C_START_
 
 #define IF_NAMESIZE 16
@@ -11,6 +12,14 @@ struct ifreq {
     char ifrn_name[IFNAMSIZ]; /* Interface name, e.g. "en0".  */
   } ifr_ifrn;
   union {
+    struct {
+      uint16_t sa_family;
+      uint16_t ifr6_ifindex;  /* Interface index */
+      uint16_t ifr6_flags;    /* Flags */
+      uint8_t ifr6_scope;     /* Addr scope */
+      uint8_t ifr6_prefixlen; /* Prefix length */
+      struct in6_addr ifr6_addr;
+    } in6;
     struct sockaddr ifru_addr;      /* SIOCGIFADDR */
     struct sockaddr ifru_dstaddr;   /* SIOCGIFDSTADDR */
     struct sockaddr ifru_netmask;   /* SIOCGIFNETMASK */
@@ -28,6 +37,12 @@ struct ifreq {
 #define ifr_dstaddr   ifr_ifru.ifru_dstaddr   /* destination address */
 #define ifr_flags     ifr_ifru.ifru_flags     /* flags */
 #define ifr_ifindex   ifr_ifru.ifru_ivalue
+
+#define ifr6_addr      ifr_ifru.in6.ifr6_addr      /* IP6 Addr */
+#define ifr6_scope     ifr_ifru.in6.ifr6_scope     /* IP6 Addr scope */
+#define ifr6_prefixlen ifr_ifru.in6.ifr6_prefixlen /* IP6 Prefix length */
+#define ifr6_ifindex   ifr_ifru.in6.ifr6_ifindex   /* IP6 If index */
+#define ifr6_flags     ifr_ifru.in6.ifr6_flags     /* IP6 If flags */
 
 COSMOPOLITAN_C_END_
 #endif /* COSMOPOLITAN_LIBC_SOCK_STRUCT_IFREQ_H_ */

--- a/tool/viz/getifaddrs.c
+++ b/tool/viz/getifaddrs.c
@@ -33,7 +33,7 @@
    eth0
    addr: 10.10.10.237
    netmask: 255.255.255.0
-   broadcast: 255.255.255.0
+   broadcast: 10.10.10.255
    flags: IFF_UP IFF_BROADCAST IFF_MULTICAST IFF_RUNNING
 
    lo
@@ -74,7 +74,7 @@ int main(int argc, char *argv[]) {
       tinyprint(1, "netmask: ", buf, "\n", NULL);
     }
     if ((ifa->ifa_flags & IFF_BROADCAST) &&
-        sockaddr2str(ifa->ifa_netmask, buf, sizeof(buf))) {
+        sockaddr2str(ifa->ifa_broadaddr, buf, sizeof(buf))) {
       tinyprint(1, "broadcast: ", buf, "\n", NULL);
     } else if ((ifa->ifa_flags & IFF_POINTOPOINT) &&
                sockaddr2str(ifa->ifa_dstaddr, buf, sizeof(buf))) {

--- a/tool/viz/getifaddrs.c
+++ b/tool/viz/getifaddrs.c
@@ -81,6 +81,80 @@ int main(int argc, char *argv[]) {
       tinyprint(1, "dstaddr: ", buf, "\n", NULL);
     }
 
+    if (ifa->ifa_addr->sa_family == AF_INET6) {
+      int scope = ((int *)ifa->ifa_data)[0];
+      int aflags = ((int *)ifa->ifa_data)[1];
+      // #define IPV6_ADDR_LOOPBACK	0x0010U
+      // #define IPV6_ADDR_LINKLOCAL	0x0020U
+      // #define IPV6_ADDR_SITELOCAL	0x0040U
+
+      // #define IFA_F_TEMPORARY		0x01
+      // #define	IFA_F_NODAD		0x02
+      // #define IFA_F_OPTIMISTIC	0x04
+      // #define IFA_F_DADFAILED		0x08
+      // #define	IFA_F_HOMEADDRESS	0x10
+      // #define IFA_F_DEPRECATED	0x20
+      // #define IFA_F_TENTATIVE		0x40
+      // #define IFA_F_PERMANENT		0x80
+      // #define IFA_F_MANAGETEMPADDR	0x100
+      // #define IFA_F_NOPREFIXROUTE	0x200
+      // #define IFA_F_MCAUTOJOIN	0x400
+      // #define IFA_F_STABLE_PRIVACY	0x800
+      tinyprint(1, "scope:", NULL);
+      if (scope == 0x10) {
+        tinyprint(1, " loopback", NULL);
+      }
+      if (scope == 0x20) {
+        tinyprint(1, " linklocal", NULL);
+      }
+      if (scope == 0x40) {
+        tinyprint(1, " sitelocal", NULL);
+      }
+      if (scope == 0x00) {
+        tinyprint(1, " global", NULL);
+      }
+      tinyprint(1, "\n", NULL);
+
+      tinyprint(1, "addr flags:", NULL);
+      if (aflags & 0x01) {
+        tinyprint(1, " temporary", NULL);
+      }
+      if (aflags & 0x02) {
+        tinyprint(1, " nodad", NULL);
+      }
+      if (aflags & 0x04) {
+        tinyprint(1, " optimistic", NULL);
+      }
+      if (aflags & 0x08) {
+        tinyprint(1, " dadfailed", NULL);
+      }
+      if (aflags & 0x10) {
+        tinyprint(1, " homeaddress", NULL);
+      }
+      if (aflags & 0x20) {
+        tinyprint(1, " deprecated", NULL);
+      }
+      if (aflags & 0x40) {
+        tinyprint(1, " tentative", NULL);
+      }
+      if (aflags & 0x80) {
+        tinyprint(1, " permanent", NULL);
+      }
+      if (aflags & 0x100) {
+        tinyprint(1, " managetempaddr", NULL);
+      }
+      if (aflags & 0x200) {
+        tinyprint(1, " noprefixroute", NULL);
+      }
+      if (aflags & 0x400) {
+        tinyprint(1, " mcautojoin", NULL);
+      }
+      if (aflags & 0x800) {
+        tinyprint(1, " stable_privacy", NULL);
+      }
+      tinyprint(1, "\n", NULL);
+    }
+
     tinyprint(1, "flags:", NULL);
     if (ifa->ifa_flags & IFF_UP) {
       tinyprint(1, " IFF_UP", NULL);


### PR DESCRIPTION
Github discussion: https://github.com/jart/cosmopolitan/discussions/1412

This is Linux only, I don't known how to implement this for other platforms, any help is welcome.

Reading the `/proc/net/if_inet6` pseudo-file allows parsing IPv6 addresses,
which are now included in the list returned by `getifaddrs()`.

This patch:
- Adds support for AF_INET6 entries by reading from the procfs
- Parses scope, prefix length, and flags from the if_inet6 format
- Constructs `sockaddr_in6` and attaches them to `ifaddrs` structs
- Maintains compatibility with existing AF_INET handling
- Adds `IfAddr6` and supporting structures to represent IPv6 info