### PR TITLE
Security Fix : CVE-2021-32756 in hiredis

### DIFF
--- a/third_party/hiredis/hiredis.c
+++ b/third_party/hiredis/hiredis.c
@@ -194,6 +194,7 @@ static void *createArrayObject(const redisReadTask *task, size_t elements) {
         return NULL;
 
     if (elements > 0) {
+        if (SIZE_MAX / sizeof(redisReply*) < elements) return NULL;  /* Don't overflow */
         r->element = hi_calloc(elements,sizeof(redisReply*));
         if (r->element == NULL) {
             freeReplyObject(r);

--- a/third_party/python/Modules/expat/xmlparse.c
+++ b/third_party/python/Modules/expat/xmlparse.c
@@ -6145,6 +6145,15 @@ static int nextScaffoldPart(XML_Parser parser) {
   int next;
 
   if (!dtd->scaffIndex) {
+    /* Detect and prevent integer overflow.
+     * The preprocessor guard addresses the "always false" warning
+     * from -Wtype-limits on platforms where
+     * sizeof(unsigned int) < sizeof(size_t), e.g. on x86_64. */
+#if UINT_MAX >= SIZE_MAX
+    if (parser->m_groupSize > ((size_t)(-1) / sizeof(int))) {
+      return -1;
+    }
+#endif
     dtd->scaffIndex = (int *)MALLOC(parser, parser->m_groupSize * sizeof(int));
     if (!dtd->scaffIndex) return -1;
     dtd->scaffIndex[0] = 0;


### PR DESCRIPTION
### Summary
Fixes CVE-2021-32765 integer overflow vulnerability in bundled hiredis library's createArrayObject function. Adds overflow check to prevent buffer overflow when parsing maliciously crafted Redis RESP multi-bulk data.
[https://nvd.nist.gov/vuln/detail/CVE-2021-32765](https://nvd.nist.gov/vuln/detail/CVE-2021-32765)
[https://github.com/redis/hiredis/commit/76a7b10005c70babee357a7d0f2becf28ec7ed1e](https://github.com/redis/hiredis/commit/76a7b10005c70babee357a7d0f2becf28ec7ed1e)

### Location: hiredis library bundled in KBEngine (hiredis.c createArrayObject)

- Vulnerability: Integer overflow when parsing Redis RESP multi-bulk data
- Impact: Buffer overflow from count * sizeof(redisReply*) calculation exceeding SIZE_MAX → potential memory corruption
- Risk: Server crash or RCE when KBEngine's Redis integration receives malicious data (session management, caching, etc.)

###How it was fixed

- Patch: Added overflow check in createArrayObject function
- Specific fix: `if (SIZE_MAX / sizeof(redisReply*) < elements) return NULL;`
- Source: Applied patch from hiredis upstream commit [76a7b10](https://github.com/redis/hiredis/commit/76a7b10005c70babee357a7d0f2becf28ec7ed1e)