### PR TITLE
Fix two problems regarding fork() and async IO for Windows

### DIFF
--- a/libc/calls/ntspawn.c
+++ b/libc/calls/ntspawn.c
@@ -68,7 +68,7 @@ static textwindows ssize_t ntspawn_read(intptr_t fh, char *buf, size_t len) {
   uint32_t got;
   struct NtOverlapped overlap = {.hEvent = CreateEvent(0, 0, 0, 0)};
   ok = overlap.hEvent &&
-       (ReadFile(fh, buf, len, 0, &overlap) ||
+       (ReadFile(fh, buf, len, &got, &overlap) ||
         GetLastError() == kNtErrorIoPending) &&
        GetOverlappedResult(fh, &overlap, &got, true);
   if (overlap.hEvent)

--- a/libc/calls/winexec.c
+++ b/libc/calls/winexec.c
@@ -81,7 +81,7 @@ textwindows int IsWindowsExecutable(int64_t handle, const char16_t *path) {
   BLOCK_SIGNALS;
   struct NtOverlapped overlap = {.hEvent = CreateEvent(0, 0, 0, 0)};
   ok = overlap.hEvent &&
-       (ReadFile(handle, buf, 2, 0, &overlap) ||
+       (ReadFile(handle, buf, 2, &got, &overlap) ||
         GetLastError() == kNtErrorIoPending) &&
        GetOverlappedResult(handle, &overlap, &got, true);
   CloseHandle(overlap.hEvent);

--- a/libc/intrin/kprintf.greg.c
+++ b/libc/intrin/kprintf.greg.c
@@ -362,8 +362,7 @@ ABI void klog(const char *b, size_t n) {
       struct NtOverlapped overlap = {.hEvent = ev};
       ok = !!__imp_WriteFile(h, b, n, 0, &overlap);
       if (!ok && __imp_GetLastError() == kNtErrorIoPending)
-        ok = true;
-      ok &= !!__imp_GetOverlappedResult(h, &overlap, &wrote, true);
+        ok = !!__imp_GetOverlappedResult(h, &overlap, &wrote, true);
       if (!ok)
         __klog_handle = 0;
       __imp_CloseHandle(ev);

--- a/libc/runtime/winmain.greg.c
+++ b/libc/runtime/winmain.greg.c
@@ -147,7 +147,7 @@ abi static void DeduplicateStdioHandles(void) {
       int64_t h2 = __imp_GetStdHandle(kNtStdio[j]);
       if (h1 == h2) {
         int64_t h3;
-        __imp_DuplicateHandle(-1, h2, -1, &h3, 0, false,
+        __imp_DuplicateHandle(-1, h2, -1, &h3, 0, true,
                               kNtDuplicateSameAccess);
         __imp_SetStdHandle(kNtStdio[j], h3);
       }


### PR DESCRIPTION
**1. `DeduplicateStdioHandles()` should mark the new handles inheritable**

[sys_fork_nt_parent()](https://github.com/hsfzxjy/cosmopolitan/blob/e7e5856b8312c9d34de67b40cd6b8522ae33ced9/libc/proc/fork-nt.c#L191) is directly passing std handles to child process. It would be a problem if those handles are non-inheritable.

**2. Async IO on Windows might be synchronous**

Even if the `OVERLAPPED` parameter supplied, IO functions like `ReadFile`/`WriteFile` may still complete their jobs before they return. In that case, the `numberOfBytes` result from the IO functions should be respected, and `GetOverlappedResult` should not be called.

[WriteFile](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-writefile#synchronization-and-file-position)
[Asynchronous disk I/O appears as synchronous on Windows](https://learn.microsoft.com/en-us/previous-versions/troubleshoot/windows/win32/asynchronous-disk-io-synchronous)