### PR TITLE
Add IPv6 support to getifaddrs() on Bsd

### DIFF
--- a/libc/intrin/bswap.c
+++ b/libc/intrin/bswap.c
@@ -45,3 +45,12 @@ uint64_t(bswap_64)(uint64_t x) {
          (0x00ff000000000000ull & x) >> 050 |
          (0xff00000000000000ull & x) >> 070;
 }
+
+#ifdef _COSMO_SOURCE
+#if (__GNUC__ + 0) * 100 + (__GNUC_MINOR__ + 0) >= 406 || defined(__llvm__)
+uint128_t(bswap_128)(uint128_t x) {
+  return ((uint128_t)bswap_64((uint64_t)x) << 64) |
+         (uint128_t)bswap_64((uint64_t)(x >> 64));
+}
+#endif /* GCC 4.6+ or LLVM */
+#endif /* _COSMO_SOURCE */

--- a/libc/intrin/bswap.h
+++ b/libc/intrin/bswap.h
@@ -6,6 +6,15 @@ libcesque uint16_t bswap_16(uint16_t) pureconst;
 libcesque uint32_t bswap_32(uint32_t) pureconst;
 libcesque uint64_t bswap_64(uint64_t) pureconst;
 
+#ifdef _COSMO_SOURCE
+#if (__GNUC__ + 0) * 100 + (__GNUC_MINOR__ + 0) >= 406 || defined(__llvm__)
+libcesque uint128_t bswap_128(uint128_t) pureconst;
+#if !defined(__STRICT_ANSI__)
+#define bswap_128(x) __builtin_bswap128(x)
+#endif /* !defined(__STRICT_ANSI__) */
+#endif /* GCC 4.6+ or LLVM */
+#endif /* _COSMO_SOURCE */
+
 #if defined(__GNUC__) && !defined(__STRICT_ANSI__)
 #define bswap_16(x) __builtin_bswap16(x)
 #define bswap_32(x) __builtin_bswap32(x)

--- a/libc/intrin/newbie.h
+++ b/libc/intrin/newbie.h
@@ -26,6 +26,18 @@
 #define htole64(x) (uint64_t)(x)
 #define le64toh(x) (uint64_t)(x)
 #define letoh64(x) (uint64_t)(x)
+
+#ifdef _COSMO_SOURCE
+#if (__GNUC__ + 0) * 100 + (__GNUC_MINOR__ + 0) >= 406 || defined(__llvm__)
+#define htobe128(x) bswap_128(x)
+#define be128toh(x) bswap_128(x)
+#define betoh128(x) bswap_128(x)
+#define htole128(x) (uint128_t)(x)
+#define le128toh(x) (uint128_t)(x)
+#define letoh128(x) (uint128_t)(x)
+#endif /* GCC 4.6+ or LLVM */
+#endif /* _COSMO_SOURCE */
+
 #else
 #define htobe16(x) (uint16_t)(x)
 #define be16toh(x) (uint16_t)(x)
@@ -45,6 +57,18 @@
 #define htole64(x) bswap_64(x)
 #define le64toh(x) bswap_64(x)
 #define letoh64(x) bswap_64(x)
+
+#ifdef _COSMO_SOURCE
+#if (__GNUC__ + 0) * 100 + (__GNUC_MINOR__ + 0) >= 406 || defined(__llvm__)
+#define htobe128(x) (uint128_t)(x)
+#define be128toh(x) (uint128_t)(x)
+#define betoh128(x) (uint128_t)(x)
+#define htole128(x) bswap_128(x)
+#define le128toh(x) bswap_128(x)
+#define letoh128(x) bswap_128(x)
+#endif /* GCC 4.6+ or LLVM */
+#endif /* _COSMO_SOURCE */
+
 #endif
 
 #endif /* COSMOPOLITAN_LIBC_BITS_NEWBIE_H_ */


### PR DESCRIPTION
- Add bswap_128()
- Add IPv6 support to getifaddrs() on Bsd
Tested on x86_64 MacOs OpenBsd FreeBsd and NetBsd.

There is extra ioctl calls on the ipv6 bsd path
because SIOCGIFCONF doesn't returns the addr flag
or the netmask.

Luckily all bsd systems share the same values for
SIOCGIFAFLAG_IN6 and SIOCGIFNETMASK_IN6.
