### PR TITLE
update onError in definition.lua

### DIFF
--- a/tool/net/definitions.lua
+++ b/tool/net/definitions.lua
@@ -557,7 +557,8 @@ function OnHttpRequest() end
 ---
 ---@param status uint16
 ---@param message string
-function OnError(status, message) end
+---@param details string
+function OnError(status, message, details) end
 
 --- Hooks client connection creation.
 ---


### PR DESCRIPTION
The onError definition was wrong in the definition.lua file. The details params was missing.