### PR TITLE
Fix bare metal boot loop

### DIFF
--- a/libc/calls/metalfile.c
+++ b/libc/calls/metalfile.c
@@ -34,6 +34,7 @@
 #include "libc/intrin/weaken.h"
 #include "libc/macros.h"
 #include "libc/mem/mem.h"
+#include "libc/runtime/internal.h"
 #include "libc/runtime/pc.internal.h"
 #include "libc/runtime/runtime.h"
 #include "libc/str/str.h"
@@ -78,6 +79,11 @@ textstartup void InitializeMetalFile(void) {
     //               to its functions need to be weak
     // KINFOF("%s @ %p,+%#zx", APE_COM_NAME, copied_base, size);
   }
+}
+
+textstartup void SetMetalPid(void) {
+  if (IsMetal())
+    __pid = 1;
 }
 
 #endif /* __x86_64__ */

--- a/libc/calls/metalfile_init.S
+++ b/libc/calls/metalfile_init.S
@@ -31,6 +31,7 @@
 	push	%rdi
 	push	%rsi
 	call	InitializeMetalFile
+	call	SetMetalPid
 	pop	%rsi
 	pop	%rdi
 	.init.end 203,_init_metalfile

--- a/libc/calls/metalfile_init.S
+++ b/libc/calls/metalfile_init.S
@@ -27,12 +27,12 @@
 #include "libc/macros.h"
 #include "libc/calls/metalfile.internal.h"
 
-	.init.start 102,_init_metalfile
+	.init.start 203,_init_metalfile
 	push	%rdi
 	push	%rsi
 	call	InitializeMetalFile
 	pop	%rsi
 	pop	%rdi
-	.init.end 102,_init_metalfile
+	.init.end 203,_init_metalfile
 APE_COM_NAME:
 	.endobj	APE_COM_NAME,globl,hidden


### PR DESCRIPTION
This PR fixes the boot looping on bare metal.
- One of the init stubs `_init_metalfile` calls `memmove()` before the jump table is set up
- The global variable `__pid` is never set on metal. Causing lock acquisitions by `mmap()` to always fail.