### PR TITLE
use --std=gnu17 for cosmocc

### DIFF
--- a/tool/cosmocc/bin/cosmocc
+++ b/tool/cosmocc/bin/cosmocc
@@ -391,10 +391,10 @@ fi
 if [ $CPLUSPLUS -eq 1 ]; then
   CC_X86_64=$CXX_X86_64
   CC_AARCH64=$CXX_AARCH64
-  CFLAGS="$CFLAGS -std=gnu++23"
+  CFLAGS="$CFLAGS -std=gnu++17"
   CPPFLAGS="-isystem $BIN/../include/third_party/libcxx $CPPFLAGS"
 else
-  CFLAGS="$CFLAGS -std=gnu23 -Wno-implicit-int"
+  CFLAGS="$CFLAGS -std=gnu17 -Wno-implicit-int"
 fi
 
 if [ x"$MODE" = x"dbg" ]; then

--- a/tool/cosmocc/bin/cosmocross
+++ b/tool/cosmocc/bin/cosmocross
@@ -129,11 +129,11 @@ else
 fi
 if [ $CPLUSPLUS -eq 1 ]; then
   CC="$BIN/$ARCH-linux-cosmo-g++"
-  CFLAGS="$CFLAGS -std=gnu++23"
+  CFLAGS="$CFLAGS -std=gnu++17"
   CPPFLAGS="-isystem $BIN/../include/third_party/libcxx $CPPFLAGS"
   LDLIBS="-lcxx $LDLIBS"
 else
-  CFLAGS="$CFLAGS -std=gnu23 -Wno-implicit-int"
+  CFLAGS="$CFLAGS -std=gnu17 -Wno-implicit-int"
 fi
 
 PAGESZ=4096


### PR DESCRIPTION
third-party libraries building in superconfigure have compiler checks that error out for the C23 standard, so the preference would be to use C17 for a while until all those libraries are updated.