### PR TITLE
launch.c: replaced "/c/windows/explorer.exe" with just "explorer.exe"

### DIFF
--- a/tool/net/launch.c
+++ b/tool/net/launch.c
@@ -66,7 +66,7 @@ void launch_browser(const char *url) {
   // determine which command opens browser tab
   const char *cmd;
   if (IsWindows()) {
-    cmd = "/c/windows/explorer.exe";
+    cmd = "explorer.exe";
   } else if (IsXnu()) {
     cmd = "open";
   } else {


### PR DESCRIPTION
In launch.c, when run under Windows, the following command is launched: 
```
cmd = "/c/windows/explorer.exe";
```

However the Windows main folder is not always located in C:\Windows, it can be on a different drive and (less common) also have different folder name, so a call to "/c/windows/explorer.exe" might fail. But since explorer.exe on Windows is in the global path, the posix_spawnp call does not need an absolute path anyway and "explorer.exe" is enough and more universal.