### PR TITLE
fix: built-in awk strcmp check

### DIFF
--- a/libc/system/cocmd.c
+++ b/libc/system/cocmd.c
@@ -747,7 +747,7 @@ static int TryBuiltin(bool wantexec) {
     return Fake(_tr, wantexec);
   if (!strcmp(args[0], "sed"))
     return Fake(_sed, wantexec);
-  if (_weaken(_awk) && strcmp(args[0], "awk"))
+  if (_weaken(_awk) && !strcmp(args[0], "awk"))
     return Fake(_weaken(_awk), wantexec);
   if (_weaken(_curl) && !strcmp(args[0], "curl")) {
     return Fake(_weaken(_curl), wantexec);


### PR DESCRIPTION
A small fix for the built-in awk `strcmp` check I found while wandering through the sources.