### PR TITLE
Fix `getsockopt` using host `errno` when handling `level = SOL_SOCKET` and `optname = SO_ERROR`

### DIFF
--- a/libc/sock/getsockopt.c
+++ b/libc/sock/getsockopt.c
@@ -45,8 +45,8 @@
  * @see libc/sysv/consts.sh for tuning catalogue
  * @see setsockopt()
  */
-int getsockopt(int fd, int level, int optname, void *out_opt_optval,
-               uint32_t *out_optlen) {
+int getsockopt(int fd, int level, int optname, void* out_opt_optval,
+               uint32_t* out_optlen) {
   int rc;
 
   if (level == -1 || !optname) {
@@ -57,7 +57,7 @@ int getsockopt(int fd, int level, int optname, void *out_opt_optval,
     rc = sys_getsockopt(fd, level, optname, out_opt_optval, out_optlen);
     if (level == SOL_SOCKET && optname == SO_ERROR) {
       assert(*out_optlen == sizeof(int));
-      *(int *)out_opt_optval = __errno_host2linux(*((int*)out_opt_optval));
+      *(int*)out_opt_optval = __errno_host2linux(*((int*)out_opt_optval));
     }
   } else if (!__isfdopen(fd)) {
     rc = ebadf();


### PR DESCRIPTION
Hello,

Currently, when calling `getsockopt` with `level = SOL_SOCKET` and `optname = SO_ERROR` the resulting `out_opt_optval` is set to the host's `errno` and is not converted to a matching Cosmopolitan/Linux `errno`, which can cause some weird behavior in some applications. This does not affect Windows because `sys_getsockopt_nt` correctly handles this situation.