### PR TITLE
RFC: Create API for registering `system` builtins

### DIFF
--- a/libc/runtime/runtime.h
+++ b/libc/runtime/runtime.h
@@ -93,6 +93,8 @@ void __print_maps_win32(int64_t, const char *, size_t) libcesque;
 void __printargs(const char *) libcesque;
 /* builtin sh-like system/popen dsl */
 int _cocmd(int, char **, char **) libcesque;
+/* register builtin program for the sh-like dsl */
+bool _cocmd_builtin(const char *, int (*)(void));
 /* executable program */
 char *GetProgramExecutableName(void) libcesque;
 char *GetInterpreterExecutableName(char *, size_t) libcesque;

--- a/libc/runtime/runtime.h
+++ b/libc/runtime/runtime.h
@@ -94,7 +94,7 @@ void __printargs(const char *) libcesque;
 /* builtin sh-like system/popen dsl */
 int _cocmd(int, char **, char **) libcesque;
 /* register builtin program for the sh-like dsl */
-bool _cocmd_builtin(const char *, int (*)(void));
+bool _cocmd_builtin(const char *, int (*)(void)) libcesque;
 /* executable program */
 char *GetProgramExecutableName(void) libcesque;
 char *GetInterpreterExecutableName(char *, size_t) libcesque;

--- a/libc/system/cocmd.c
+++ b/libc/system/cocmd.c
@@ -82,6 +82,10 @@ static const char *prog;
 static char argbuf[ARG_MAX];
 static bool unsupported[256];
 
+static int (*builtin_pointers[16])(void);
+static const char *builtin_names[16];
+static int builtin_index = 0;
+
 static int ShellSpawn(void);
 static int ShellExec(void);
 
@@ -820,6 +824,12 @@ static int TryBuiltin(bool wantexec) {
   if (_weaken(_curl) && !strcmp(args[0], "curl")) {
     return Fake(_weaken(_curl), wantexec);
   }
+
+  for (int i = 0; i < builtin_index; ++i) {
+    if (strcmp(args[0], builtin_names[i])) continue;
+    return builtin_pointers[i]();
+  }
+  
   return -1;
 }
 
@@ -1098,6 +1108,15 @@ static const char *GetRedirectArg(const char *prog, const char *arg, int n) {
     tinyprint(2, prog, ": error: redirect missing path\n", NULL);
     _Exit(14);
   }
+}
+
+bool _cocmd_builtin(const char *name, int (*program)(void)) {
+  if (builtin_index >= ARRAYLEN(builtin_pointers)) return false;
+
+  builtin_names[builtin_index] = name;
+  builtin_pointers[builtin_index] = program;
+  builtin_index++;
+  return true;
 }
 
 int _cocmd(int argc, char **argv, char **envp) {


### PR DESCRIPTION
This is not very thorough and has not been tested at all.
It also imposes a stupid limit of 16 programs only.

If `_cocmd_builtin` in this context is accessible to people using
`cosmocc`, this patch is useful enough to provide an "internal API"
to register these programs, without touching the filesystem, which
is the goal here. Not sure if this API can be linked against.

I only submitted this to show my intent "in code".

URL: https://discord.com/channels/927860136884699167/988730487239503942/1469002855162580992
Signed-off-by: Mahied Maruf \<contact@mechite.com\>