### PR TITLE
Fix syscall number for sys_kevent in syscalls.sh and sys_kevent.S

### DIFF
--- a/libc/sysv/calls/sys_kevent.S
+++ b/libc/sysv/calls/sys_kevent.S
@@ -1,2 +1,2 @@
 #include "libc/sysv/macros.internal.h"
-.scall sys_kevent,0x1b30482302171fff,4095,369,560,globl
+.scall sys_kevent,0x1b3048230216bfff,4095,363,560,globl

--- a/libc/sysv/syscalls.sh
+++ b/libc/sysv/syscalls.sh
@@ -395,7 +395,7 @@ scall	sys_fchmodat2		0xfffffffffffff1c4	0x1c4	globl # no wrapper Linux 6.6+
 #	Symbol                    ┌┴┐┌┴┐┌┴┐│┬┴┐┌┴┐      Arm64	Type	Directives & Commentary
 scall	sys_ktrace		0x02d02d02dfffffff	0xfff	globl # no wrapper
 scall	sys_kqueue		0x15810d16a216afff	0xfff	globl # no wrapper
-scall	sys_kevent		0x1b30482302171fff	0xfff	globl # no wrapper
+scall	sys_kevent		0x1b3048230216bfff	0xfff	globl # no wrapper
 scall	sys_revoke		0x0380380382038fff	0xfff	globl # no wrapper
 scall	sys_setlogin		0xfff0320322032fff	0xfff	globl # no wrapper
 scall	sys_getfh		0x18b0a10a120a1fff	0xfff	globl # no wrapper


### PR DESCRIPTION
SYS_KEVENT should be 363 (0x16b) instead of 0x171.

1. https://github.com/golang/go/blob/45138d477d5a7547086357218061429d3c80a6be/src/syscall/zsysnum_darwin_amd64.go#L291
2. https://github.com/golang/go/blob/45138d477d5a7547086357218061429d3c80a6be/src/syscall/zsysnum_darwin_arm64.go#L285