### PR TITLE
Avoid modifying the nice value for XNU systems in getpriority

### DIFF
--- a/libc/proc/getpriority.c
+++ b/libc/proc/getpriority.c
@@ -82,7 +82,9 @@ int getpriority(int which, unsigned who) {
 #else
   rc = sys_getpriority(which, who);
   if (rc != -1) {
-    rc = NZERO - rc;
+    if (!IsXnu()) {
+      rc = NZERO - rc;
+    }
   }
 #endif
   STRACE("getpriority(%s, %u) → %d% m", DescribeWhichPrio(which), who, rc);


### PR DESCRIPTION
In XNU, the result from getpriority is already in the range `[-NZERO, NZERO]`. No need to adjust.