### PR TITLE
Fix nsync_waiter_wipe_ zeroing mutexes held by surviving thread after fork

### DIFF
--- a/test/libc/thread/nsync_fork_wipe_test.c
+++ b/test/libc/thread/nsync_fork_wipe_test.c
@@ -1,0 +1,70 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│ vi: set et ft=c ts=2 sts=2 sw=2 fenc=utf-8                               :vi │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "libc/intrin/atomic.h"
+#include "libc/calls/calls.h"
+#include "libc/runtime/runtime.h"
+#include "libc/testlib/testlib.h"
+#include "libc/thread/thread.h"
+#include <sys/wait.h>
+
+// Reproducer for nsync_waiter_wipe_ bug:
+// After fork(), nsync_waiter_wipe_() zeroes the word of every mutex
+// that has a waiter, even if the surviving (forking) thread holds it.
+// This causes nsync_mu_unlock to panic with:
+//   "attempt to nsync_mu_unlock() an nsync_mu not held in write mode"
+
+static pthread_mutex_t shared_mu = PTHREAD_MUTEX_INITIALIZER;
+static atomic_int worker_waiting;
+
+static void *worker_thread(void *arg) {
+  atomic_store_explicit(&worker_waiting, 1, memory_order_release);
+  // This will BLOCK because main thread holds shared_mu.
+  // Blocking creates an nsync waiter with wipe_mu = &shared_mu.
+  pthread_mutex_lock(&shared_mu);
+  pthread_mutex_unlock(&shared_mu);
+  return NULL;
+}
+
+TEST(nsync_fork_wipe, mutexHeldByForkerIsNotZeroed) {
+  pthread_t th;
+  pid_t pid;
+  int status;
+
+  atomic_store_explicit(&worker_waiting, 0, memory_order_relaxed);
+
+  // Main thread acquires the mutex
+  ASSERT_EQ(0, pthread_mutex_lock(&shared_mu));
+
+  // Spawn a worker that will BLOCK trying to acquire the same mutex.
+  // This creates an nsync waiter with wipe_mu pointing to shared_mu.
+  ASSERT_EQ(0, pthread_create(&th, NULL, worker_thread, NULL));
+
+  // Wait for worker to be contending on the mutex
+  while (!atomic_load_explicit(&worker_waiting, memory_order_acquire))
+    usleep(1000);
+  // Give it a moment to actually enter the nsync wait
+  usleep(50000);
+
+  // Fork while holding shared_mu, with worker waiting on it.
+  // In the child, nsync_waiter_wipe_() will zero shared_mu's word.
+  pid = fork();
+  ASSERT_NE(-1, pid);
+
+  if (pid == 0) {
+    // CHILD: shared_mu should still be held by us (the surviving thread).
+    // This unlock should succeed, but nsync_waiter_wipe_ zeroed the word,
+    // so nsync_mu_unlock will panic.
+    int err = pthread_mutex_unlock(&shared_mu);
+    _Exit(err ? 1 : 0);
+  }
+
+  // PARENT: clean up
+  ASSERT_NE(-1, waitpid(pid, &status, 0));
+  ASSERT_TRUE(WIFEXITED(status));
+  EXPECT_EQ(0, WEXITSTATUS(status));
+
+  // Let worker finish
+  pthread_mutex_unlock(&shared_mu);
+  pthread_join(th, NULL);
+}

--- a/third_party/nsync/common.c
+++ b/third_party/nsync/common.c
@@ -334,11 +334,29 @@ void nsync_waiter_wipe_ (void) {
 		dll_init (&w->same_condition);
 		dll_init (&w->nw.q);
 		if (w->wipe_mu) {
-			atomic_init(&w->wipe_mu->word, 0);
+			uint32_t mw = atomic_load_explicit (&w->wipe_mu->word,
+							    memory_order_relaxed);
+			if (mw & (MU_WLOCK | MU_RLOCK_FIELD)) {
+				/* After fork, only the forking thread survives.
+				   If a mutex is held, it must be held by the
+				   survivor — preserve lock state but strip
+				   stale waiter metadata. */
+				atomic_init (&w->wipe_mu->word,
+					     mw & (MU_WLOCK | MU_RLOCK_FIELD));
+			} else {
+				atomic_init (&w->wipe_mu->word, 0);
+			}
 			w->wipe_mu->waiters = 0;
 		}
 		if (w->wipe_cv) {
-			atomic_init(&w->wipe_cv->word, 0);
+			uint32_t cw = atomic_load_explicit (&w->wipe_cv->word,
+							    memory_order_relaxed);
+			if (cw & (MU_WLOCK | MU_RLOCK_FIELD)) {
+				atomic_init (&w->wipe_cv->word,
+					     cw & (MU_WLOCK | MU_RLOCK_FIELD));
+			} else {
+				atomic_init (&w->wipe_cv->word, 0);
+			}
 			w->wipe_cv->waiters = 0;
 		}
 		if (!nsync_mu_semaphore_init (&w->sem))


### PR DESCRIPTION
## Summary

`nsync_waiter_wipe_()` (introduced in 98c5847) unconditionally zeroes every mutex pointed to by `wipe_mu` after `fork()`. This is incorrect when the forking (surviving) thread holds the mutex — the child inherits the lock but `nsync_mu_unlock()` sees `word=0` and panics:

```
nsync panic: attempt to nsync_mu_unlock() an nsync_mu not held in write mode
```

## Root cause

1. Thread A acquires mutex M
2. Thread B blocks waiting on M → creates waiter with `wipe_mu = M`
3. Thread A calls `fork()`
4. In child, `nsync_waiter_wipe_()` zeroes M's word (from Thread B's waiter)
5. Thread A tries to unlock M → `(0 - MU_WLOCK)` underflows → panic

## Fix

Before zeroing a mutex in `nsync_waiter_wipe_()`, check if it's currently held (`MU_WLOCK` or `MU_RLOCK_FIELD` bits set). After fork, only the forking thread survives, so any held mutex must be held by it. For held mutexes: preserve lock state but strip stale waiter metadata (`MU_WAITING`, `MU_WRITER_WAITING`, etc.) since those waiters are dead. Same logic applied to `wipe_cv`.

## Test plan

- [x] New test `test/libc/thread/nsync_fork_wipe_test.c` — reproduces the exact crash without the fix, passes with it
- [x] Verified fix resolves 2 test failures in Ruby 4.0.0 bootstrap suite (`test_ractor.rb` #1414, #1415) which hit this bug via Ractor threads + `fork()` inside `RB_VM_LOCKING()`