### PR TITLE
Fix broken .com removals in README and BUILD.mk

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ src
 ```
 
 You normally run the `.dbg` file under gdb. If you need to debug the
-`` file itself, then you can load the debug symbols independently as
+executable itself, then you can load the debug symbols independently as
 
 ```sh
 gdb foo -ex 'add-symbol-file foo.dbg 0x401000'

--- a/examples/pyapp/BUILD.mk
+++ b/examples/pyapp/BUILD.mk
@@ -34,7 +34,7 @@
 #
 # NOTES
 #
-#   If you enjoy this tutorial, let us know jtunney@gmail. If
+#   If you enjoy this tutorial, let us know jtunney@gmail.com. If
 #   you're building something cool, then we can we can add you to
 #   our .gitowners file which grants you commit access so you can
 #   indepnedently maintain your package, as part of the mono-repo
@@ -98,7 +98,7 @@ o/$(MODE)/examples/pyapp/pyapp.dbg: \
 		$(APE_NO_MODIFY_SELF)
 	@$(COMPILE) -ALINK.ape $(LINK) $(LINKARGS) -o $@
 
-# # Unwrap the APE  binary, that's embedded within the linked file
+# # Unwrap the APE binary, that's embedded within the linked file
 # # NOTE: This line can be commented out, since it's in build/rules.mk
 # o/$(MODE)/examples/pyapp/pyapp: \
 # 		o/$(MODE)/examples/pyapp/pyapp.dbg

--- a/examples/pylife/BUILD.mk
+++ b/examples/pylife/BUILD.mk
@@ -34,7 +34,7 @@
 #
 # NOTES
 #
-#   If you enjoy this tutorial, let us know jtunney@gmail. If
+#   If you enjoy this tutorial, let us know jtunney@gmail.com. If
 #   you're building something cool, then we can we can add you to
 #   our .gitowners file which grants you commit access so you can
 #   indepnedently maintain your package, as part of the mono-repo
@@ -98,7 +98,7 @@ o/$(MODE)/examples/pylife/pylife.dbg: \
 		$(APE_NO_MODIFY_SELF)
 	@$(COMPILE) -ALINK.ape $(LINK) $(LINKARGS) -o $@
 
-# # Unwrap the APE  binary, that's embedded within the linked file
+# # Unwrap the APE binary, that's embedded within the linked file
 # # NOTE: This line can be commented out, since it's in build/rules.mk
 # o/$(MODE)/examples/pylife/pylife: \
 # 		o/$(MODE)/examples/pylife/pylife.dbg


### PR DESCRIPTION
Hello! The "debug the `` file" line confused me when I was reading the README. I used ai tools to find other incorrect removals of ".com" and fixed them.

See previous commits created in 2024:
- a6baba1b07355df93cf5a808acd1b7da2b3725e8
- 9a10adac351f5277b569daff33123f6d22d0aea9