### PR TITLE
tool/lambda: fix Bye() exit-code interpretation at non-exit ABS

### DIFF
--- a/tool/lambda/lambda.c
+++ b/tool/lambda/lambda.c
@@ -172,11 +172,36 @@ void Put(void) {
   ip = newip;
 }
 
+/*
+ * Called from Abs() when a lambda is reached with no continuation. The
+ * original code unconditionally treated mem[ip+2] as an exit code. That
+ * assumes ip is at a `λ.N` ABS whose body is exactly `VAR N`, in which
+ * case mem[ip+1]==VAR and mem[ip+2]==N. The intent is to reach this via
+ * the exit ABS at ROM position 24 (mem[24]=ABS, mem[25]=VAR, mem[26]=0),
+ * giving a clean exit(0).
+ *
+ * In practice the wrapper allows execution to terminate at other ABS
+ * positions whose bodies are not `VAR N`. For example, in bit mode, when
+ * the lazy input list bottoms out via NIL, control commonly returns to
+ * ip=14 (the inner `\\.0 wr0 wr1`). There mem[15]=APP and mem[16]=4 (a
+ * span operand), so the old code reported a spurious "CONTINUATIONS
+ * EXHAUSTED" error and exited 4. Reproducer:
+ *
+ *   ( cat tromp_AIT/take1k.blc; printf 'hello world!' ) | ./lambda
+ *
+ * Tromp's `uni` (https://github.com/tromp/AIT) exits 0 with identical
+ * output bytes on the same input.
+ *
+ * Only interpret mem[ip+2] as an exit code when the body looks like
+ * `VAR N`. Otherwise exit cleanly.
+ */
 void Bye(void) {
-  int rc = mem[ip + 2];  // (λ 0) [exitcode]
-  if (rc)
-    Error(rc, "CONTINUATIONS EXHAUSTED");
-  if (postdump && !rc)
+  if (mem[ip + 1] == VAR) {
+    int rc = mem[ip + 2];
+    if (rc)
+      Error(rc, "CONTINUATIONS EXHAUSTED");
+  }
+  if (postdump)
     Dump(0, end, stderr);
   exit(0);
 }


### PR DESCRIPTION
`Bye()` in `tool/lambda/lambda.c` reads `mem[ip+2]` as an exit code:

```c
int rc = mem[ip + 2];  // (λ 0) [exitcode]
if (rc) Error(rc, "CONTINUATIONS EXHAUSTED");
```

That assumes `ip` is at a `λ.N` ABS whose body is exactly `VAR N`, which holds at the exit ABS at ROM position 24 (`mem[24]=ABS`, `mem[25]=VAR`, `mem[26]=0`) and gives a clean `exit(0)`.

But `Abs()` calls `Bye()` for **any** ABS with empty `contp`, and the wrapper allows execution to terminate at other ABS positions whose bodies are not `VAR N`. The clearest case in bit mode: when the lazy input list bottoms out via `NIL`, control returns to `ip=14` (the inner `λ. 0 wr0 wr1`). There `mem[15]=APP` and `mem[16]=4` (a span operand), so the old code reports `CONTINUATIONS EXHAUSTED` and exits 4.

## Reproducer

```sh
( cat /tmp/AIT/bin/take1k.blc; printf 'hello world!' ) | ./lambda
```

`take1k.blc` is from https://github.com/tromp/AIT.

**Before:**
```
010010110001
ERROR:	CONTINUATIONS EXHAUSTED
   ip:	14
  end:	211
 term:	put
[exit 4]
```

**After:**
```
010010110001
[exit 0]
```

Tromp's `uni -b` from AIT produces the same 12 output bytes and exits 0 on the same input.

## Fix

Only interpret `mem[ip+2]` as an exit code when the body actually looks like `VAR N` (i.e. `mem[ip+1] == VAR`). This preserves the original intent — clean exit through the exit ABS at ROM position 24 is unchanged — and removes the spurious error in cases where the program terminates at a non-exit ABS.

```c
void Bye(void) {
  if (mem[ip + 1] == VAR) {
    int rc = mem[ip + 2];
    if (rc) Error(rc, "CONTINUATIONS EXHAUSTED");
  }
  if (postdump) Dump(0, end, stderr);
  exit(0);
}
```

This is the bug Justine mentioned in the redbean `#topics/lambda` channel on 2026-04-19 ("mostly works however I think it has a subtle bug I never got around to fixing"). I haven't audited for other bugs.

## Verification

Standalone build + 4 regression tests at https://github.com/calvinbeighle/lambda-c-fix, including byte-for-byte parity vs Tromp's `uni` on `take1k.blc + 'hello world!'`.