### PR TITLE
examples/a440.c: define M_PIf locally for portable compilation

### DIFF
--- a/examples/a440.c
+++ b/examples/a440.c
@@ -13,6 +13,10 @@
 #include <stdlib.h>
 #include <time.h>
 
+#ifndef M_PIf
+#define M_PIf 3.14159265358979323846f
+#endif
+
 /**
  * @fileoverview plays pure A.440 tone on speakers for 1 second
  * @see https://en.wikipedia.org/wiki/A440_%28pitch_standard%29


### PR DESCRIPTION
As discussed in this [issue](https://github.com/jart/cosmopolitan/issues/1495), 

When building `examples/a440.c` without `_GNU_SOURCE` or `_COSMO_SOURCE`, `M_PIf` is not defined because it is guarded by those feature-test macros in the `libc/math.h` header. This causes a compilation error:

```bash
./a440.c: In function 'main':
./a440.c:58:26: error: 'M_PIf' undeclared (first use in this function); did you mean 'M_PI'?
   58 |       float s = sinf(2 * M_PIf * WAVE_INTERVAL * t);
      |                          ^~~~~
      |                          M_PI
./a440.c:58:26: note: each undeclared identifier is reported only once for each function it appears in
```

As discussed in #1495, removing `M_PIf` entirely from the codebase would be intrusive (it is also used elsewhere, and removing it would create inconsistency with other `(x)f` macros). The cleanest, most beginner-friendly fix is to define `M_PIf` locally inside `examples/a440.c` before it is used.

This PR adds this to examples/a440.c:
```c
#ifndef M_PIf
#define M_PIf 3.14159265358979323846f
#endif
```

No other files are changed.

Tested with:
~/Projects/cosmocc/bin/x86_64-unknown-cosmo-cc examples/a440.c
No compilation errors. The binary runs.

