### PR TITLE
Fix insecure referrer policy

### DIFF
--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -2123,7 +2123,7 @@ static char *AppendContentType(char *p, const char *ct) {
       p = stpcpy(p, "; charset=utf-8");
     }
     if (!cpm.referrerpolicy && startswith(ct + 5, "html")) {
-      cpm.referrerpolicy = "no-referrer-when-downgrade";
+      cpm.referrerpolicy = "strict-origin-when-cross-origin";
     }
   }
   cpm.hascontenttype = true;


### PR DESCRIPTION
`no-referrer-when-downgrade` is dated and the new secure default is `strict-origin-when-cross-origin` [1].

[1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy#strict-origin-when-cross-origin_2