### PR TITLE
fix: cleanup remnants of kErrnoNames

### DIFF
--- a/libc/fmt/magnumstrs.internal.h
+++ b/libc/fmt/magnumstrs.internal.h
@@ -17,7 +17,6 @@ struct MagnumStr {
 };
 
 extern const struct MagnumStr kClockNames[];
-extern const struct MagnumStr kErrnoNames[];
 extern const struct MagnumStr kIpOptnames[];
 extern const struct MagnumStr kIpv6Optnames[];
 extern const struct MagnumStr kSockOptnames[];

--- a/libc/intrin/BUILD.mk
+++ b/libc/intrin/BUILD.mk
@@ -165,8 +165,6 @@ o/$(MODE)/libc/intrin/kipoptnames.o: libc/intrin/kipoptnames.S
 	@$(COMPILE) -AOBJECTIFY.S $(OBJECTIFY.S) $(OUTPUT_OPTION) -c $<
 o/$(MODE)/libc/intrin/kipv6optnames.o: libc/intrin/kipv6optnames.S
 	@$(COMPILE) -AOBJECTIFY.S $(OBJECTIFY.S) $(OUTPUT_OPTION) -c $<
-o/$(MODE)/libc/intrin/kerrnonames.o: libc/intrin/kerrnonames.S
-	@$(COMPILE) -AOBJECTIFY.S $(OBJECTIFY.S) $(OUTPUT_OPTION) -c $<
 o/$(MODE)/libc/intrin/ksockoptnames.o: libc/intrin/ksockoptnames.S
 	@$(COMPILE) -AOBJECTIFY.S $(OBJECTIFY.S) $(OUTPUT_OPTION) -c $<
 o/$(MODE)/libc/intrin/ktcpoptnames.o: libc/intrin/ktcpoptnames.S

--- a/test/libc/fmt/strerror_r_test.c
+++ b/test/libc/fmt/strerror_r_test.c
@@ -23,8 +23,7 @@
 
 /*
  * If these tests break, it's probably because
- * libc/sysv/consts.sh changed and
- * libc/sysv/kErrnoNames.S needs updating.
+ * libc/sysv/consts/ changed.
  */
 
 TEST(strerror, e2big) {


### PR DESCRIPTION
https://github.com/jart/cosmopolitan/commit/5ddb5c2adad79407fb800fce47f389611f90a511 removed kErrnoNames , but left it in the header.