### PR TITLE
Fix generating ELF header when building with -msysv flag

### DIFF
--- a/tool/build/apelink.c
+++ b/tool/build/apelink.c
@@ -1996,7 +1996,7 @@ int main(int argc, char *argv[]) {
         p = stpcpy(p, "jartsr='\n\n");
         p = FinishGeneratingDosHeader(p);
       } else {
-        p = stpcpy(p, "jartsr=\n");
+        p = stpcpy(p, "jartsr=''\n");
       }
     }
     if (support_vector & _HOSTMETAL) {


### PR DESCRIPTION
Currently building with `-msysv` flag results in executables that fail with message `ape error: ./hello: didn't embed ELF magic`.

Tested on Ubuntu and WSL (running Ubuntu).