### PR TITLE
Fix typeof definition in TRAMPOLINE macro

### DIFF
--- a/libc/nexgen32e/trampoline.h
+++ b/libc/nexgen32e/trampoline.h
@@ -3,7 +3,7 @@
 
 #define TRAMPOLINE(FUNCTION, THUNK)   \
   ({                                  \
-    typeof(FUNCTION) *Tramp;          \
+    __typeof__(FUNCTION) *Tramp;          \
     asm(".section .text.trampoline\n" \
         "183:\n\t"                    \
         "mov\t%1,%%eax\n\t"           \


### PR DESCRIPTION
Changed `typeof` to `__typeof__` to make it work on more compilers/systems:

### typeof
```
  FAIL x86_64-unknown-cosmo-cc -xc -std=c99  typeof
  OK   x86_64-unknown-cosmo-cc -xc -std=gnu99  typeof
  FAIL x86_64-unknown-cosmo-cc -xc -std=c11  typeof
  OK   x86_64-unknown-cosmo-cc -xc -std=c23  typeof
  FAIL x86_64-unknown-cosmo-c++ -xc++ -std=c++17  typeof
  FAIL x86_64-unknown-cosmo-c++ -xc++ -std=c++23  typeof
  OK   x86_64-unknown-cosmo-c++ -xc++ -std=gnu++23  typeof
  FAIL aarch64-unknown-cosmo-c++ -xc++ -std=c++23  typeof
```

### \_\_typeof\_\_
```
  OK   x86_64-unknown-cosmo-cc -xc -std=c99  __typeof__
  OK   x86_64-unknown-cosmo-cc -xc -std=gnu99  __typeof__
  OK   x86_64-unknown-cosmo-cc -xc -std=c11  __typeof__
  OK   x86_64-unknown-cosmo-cc -xc -std=c23  __typeof__
  OK   x86_64-unknown-cosmo-c++ -xc++ -std=c++17  __typeof__
  OK   x86_64-unknown-cosmo-c++ -xc++ -std=c++23  __typeof__
  OK   x86_64-unknown-cosmo-c++ -xc++ -std=gnu++23  __typeof__
  OK   aarch64-unknown-cosmo-c++ -xc++ -std=c++23  __typeof__

```
Clang supports `__typeof__` in every mode too.
The change matters because it allows using the NT2SYSV macro in C++ (for Windows calls).

I don't claim any rights to the code and surely intend to assign @jart the copyright to the change.
Come on, that's literally only `__typeof__` :)