### PR TITLE
Fix off-by-one FILE_INFO_BY_HANDLE_CLASS enum values

### DIFF
--- a/libc/calls/ftruncate-nt.c
+++ b/libc/calls/ftruncate-nt.c
@@ -49,7 +49,7 @@ textwindows int sys_ftruncate_nt(int64_t handle, uint64_t length) {
   }
 
   // ask operating system to extend file
-  if (!SetFileInformationByHandle(handle, kNtFileAllocationInfo, &length,
+  if (!SetFileInformationByHandle(handle, kNtFileEndOfFileInfo, &length,
                                   sizeof(length))) {
     switch (GetLastError()) {
       case kNtErrorAccessDenied:

--- a/libc/nt/enum/fileinfobyhandleclass.h
+++ b/libc/nt/enum/fileinfobyhandleclass.h
@@ -18,12 +18,12 @@
 #define kNtFileIdExtdDirectoryInfo        19 /* win8+ */
 #define kNtFileIdExtdDirectoryRestartInfo 20 /* win8+ */
 
-#define kNtFileRenameInfo         4
-#define kNtFileDispositionInfo    5
-#define kNtFileAllocationInfo     6
-#define kNtFileEndOfFileInfo      7
-#define kNtFileIoPriorityHintInfo 13
-#define kNtFileDispositionInfoEx  22 /* win10+ */
-#define kNtFileRenameInfoEx       23 /* win10+ */
+#define kNtFileRenameInfo         3
+#define kNtFileDispositionInfo    4
+#define kNtFileAllocationInfo     5
+#define kNtFileEndOfFileInfo      6
+#define kNtFileIoPriorityHintInfo 12
+#define kNtFileDispositionInfoEx  21 /* win10+ */
+#define kNtFileRenameInfoEx       22 /* win10+ */
 
 #endif /* COSMOPOLITAN_LIBC_NT_ENUM_FILEINFOBYHANDLECLASS_H_ */


### PR DESCRIPTION
## Problem

Several constants in `libc/nt/enum/fileinfobyhandleclass.h` are one greater than the actual Windows `FILE_INFO_BY_HANDLE_CLASS` values, per [the MS doc](https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ne-minwinbase-file_info_by_handle_class). The header even collides with itself by defining 7 and 13 twice each, which is impossible for a single enum.

Meanwhile `sys_ftruncate_nt()` passes `kNtFileAllocationInfo` where it means `kNtFileEndOfFileInfo`. Its wrong value 6 happened to be the real `FileEndOfFileInfo`, so the two bugs cancelled out and `ftruncate()` has always worked.

## Fix

Fix the affected constants. `ftruncate-nt.c` is also updated to name `kNtFileEndOfFileInfo`, since with the header corrected, `kNtFileAllocationInfo` would refer to the real `FileAllocationInfo`, which only preallocates and never moves EOF.