### PR TITLE
Add RISC-V Linux APE loader

### DIFF
--- a/ape/BUILD.mk
+++ b/ape/BUILD.mk
@@ -102,6 +102,79 @@ o/$(MODE)/ape/systemcall.o: ape/systemcall.S
 .PHONY: o/$(MODE)/ape
 o/$(MODE)/ape: o/$(MODE)/ape/ape.elf
 
+else ifeq ($(ARCH), riscv64)
+
+APE = o/$(MODE)/ape/ape.elf
+APE_SRCS = ape/start.S ape/launch.S ape/systemcall.S ape/loader.c
+APE_OBJS =					\
+	o/$(MODE)/ape/start.o			\
+	o/$(MODE)/ape/loader.o		\
+	o/$(MODE)/ape/launch.o		\
+	o/$(MODE)/ape/systemcall.o
+APE_NO_MODIFY_SELF = $(APE)
+APE_COPY_SELF = $(APE)
+
+APE_LOADER_FLAGS =				\
+	-DNDEBUG				\
+	-DSUPPORT_VECTOR=1			\
+	-iquote.				\
+	-Wall					\
+	-Wextra				\
+	-Werror				\
+	-pedantic-errors			\
+	-Os					\
+	-ffreestanding				\
+	-fno-asynchronous-unwind-tables		\
+	-fno-pie				\
+	-fno-pic				\
+	-fno-stack-protector			\
+	-fno-tree-loop-distribute-patterns	\
+	-march=rv64imac				\
+	-mabi=lp64				\
+	-mcmodel=medany				\
+	-c					\
+	$(OUTPUT_OPTION)			\
+	$<
+
+APE_LOADER_ASFLAGS =				\
+	-I.					\
+	-march=rv64imac				\
+	-mabi=lp64				\
+	-mcmodel=medany				\
+	-c					\
+	$(OUTPUT_OPTION)			\
+	$<
+
+APE_LOADER_LDFLAGS =				\
+	-static					\
+	-nostdlib				\
+	--no-dynamic-linker			\
+	--build-id=none				\
+	-e _start				\
+	-z noexecstack				\
+	-z norelro				\
+	-z common-page-size=0x1000		\
+	-z max-page-size=0x1000			\
+	-T ape/loader.lds
+
+o/$(MODE)/ape/ape.elf: o/$(MODE)/ape/ape.elf.dbg
+	@$(COMPILE) -AOBJCOPY -T$@ $(OBJCOPY) -g $< $@
+
+o/$(MODE)/ape/ape.elf.dbg: $(APE_OBJS) ape/loader.lds
+	@$(COMPILE) -ALINK.elf $(LD) $(APE_LOADER_LDFLAGS) -o $@ $(APE_OBJS)
+
+o/$(MODE)/ape/loader.o: ape/loader.c ape/ape.h
+	@$(COMPILE) -AOBJECTIFY.c $(CC) $(APE_LOADER_FLAGS)
+o/$(MODE)/ape/start.o: ape/start.S libc/macros.h
+	@$(COMPILE) -AOBJECTIFY.S $(CC) $(APE_LOADER_ASFLAGS)
+o/$(MODE)/ape/launch.o: ape/launch.S libc/macros.h
+	@$(COMPILE) -AOBJECTIFY.S $(CC) $(APE_LOADER_ASFLAGS)
+o/$(MODE)/ape/systemcall.o: ape/systemcall.S libc/macros.h
+	@$(COMPILE) -AOBJECTIFY.S $(CC) $(APE_LOADER_ASFLAGS)
+
+.PHONY: o/$(MODE)/ape
+o/$(MODE)/ape: o/$(MODE)/ape/ape.elf
+
 else
 
 APE =	o/$(MODE)/ape/ape.o			\

--- a/ape/launch.S
+++ b/ape/launch.S
@@ -68,6 +68,14 @@ Launch:
 	mov	x30,0
 	br	x16
 
+#elif defined(__riscv)
+
+	mv	t0,a1
+	mv	sp,a4
+	li	ra,0
+	li	a0,0
+	jr	t0
+
 #else
 
 	mov	%r8,%rsp

--- a/ape/loader.c
+++ b/ape/loader.c
@@ -101,10 +101,10 @@
 #define IsOpenbsd() (SupportsOpenbsd() && os == OPENBSD)
 #define IsNetbsd()  (SupportsNetbsd() && os == NETBSD)
 
-#ifdef __aarch64__
-#define IsAarch64() 1
+#if defined(__aarch64__) || defined(__riscv)
+#define UsesLinuxGenericSyscalls() 1
 #else
-#define IsAarch64() 0
+#define UsesLinuxGenericSyscalls() 0
 #endif
 
 #ifdef __cplusplus
@@ -127,6 +127,7 @@
 #define ELFDATA2LSB                 1
 #define EM_NEXGEN32E                62
 #define EM_AARCH64                  183
+#define EM_RISCV                    243
 #define ET_EXEC                     2
 #define ET_DYN                      3
 #define PT_LOAD                     1
@@ -288,6 +289,16 @@ static const char *MemChr(const char *s, unsigned char c, unsigned long n) {
   return 0;
 }
 
+#ifdef __riscv
+void *memcpy(void *d, const void *s, unsigned long n) {
+  char *p = (char *)d;
+  const char *q = (const char *)s;
+  while (n--)
+    *p++ = *q++;
+  return d;
+}
+#endif
+
 static void *MemMove(void *a, const void *b, unsigned long n) {
   long w;
   char *d;
@@ -376,7 +387,7 @@ __attribute__((__noinline__)) static long CallSystem(long arg1, long arg2,
 __attribute__((__noreturn__)) static void Exit(long rc, int os) {
   int numba;
   if (IsLinux()) {
-    if (IsAarch64()) {
+    if (UsesLinuxGenericSyscalls()) {
       numba = 94;
     } else {
       numba = 60;
@@ -391,7 +402,7 @@ __attribute__((__noreturn__)) static void Exit(long rc, int os) {
 static int Close(int fd, int os) {
   int numba;
   if (IsLinux()) {
-    if (IsAarch64()) {
+    if (UsesLinuxGenericSyscalls()) {
       numba = 57;
     } else {
       numba = 3;
@@ -405,7 +416,7 @@ static int Close(int fd, int os) {
 static long Pread(int fd, void *data, unsigned long size, long off, int os) {
   long numba;
   if (IsLinux()) {
-    if (IsAarch64()) {
+    if (UsesLinuxGenericSyscalls()) {
       numba = 0x043;
     } else {
       numba = 0x011;
@@ -427,7 +438,7 @@ static long Pread(int fd, void *data, unsigned long size, long off, int os) {
 static long Write(int fd, const void *data, unsigned long size, int os) {
   int numba;
   if (IsLinux()) {
-    if (IsAarch64()) {
+    if (UsesLinuxGenericSyscalls()) {
       numba = 64;
     } else {
       numba = 1;
@@ -439,7 +450,7 @@ static long Write(int fd, const void *data, unsigned long size, int os) {
 }
 
 static int Access(const char *path, int mode, int os) {
-  if (IsLinux() && IsAarch64()) {
+  if (IsLinux() && UsesLinuxGenericSyscalls()) {
     return SystemCall(-100, (long)path, mode, 0, 0, 0, 0, 48);
   } else {
     return CallSystem((long)path, mode, 0, 0, 0, 0, 0, IsLinux() ? 21 : 33, os);
@@ -455,7 +466,7 @@ static int Msyscall(long p, unsigned long n, int os) {
 }
 
 static int Open(const char *path, int flags, int mode, int os) {
-  if (IsLinux() && IsAarch64()) {
+  if (IsLinux() && UsesLinuxGenericSyscalls()) {
     return SystemCall(-100, (long)path, flags, mode, 0, 0, 0, 56);
   } else {
     return CallSystem((long)path, flags, mode, 0, 0, 0, 0, IsLinux() ? 2 : 5,
@@ -466,7 +477,7 @@ static int Open(const char *path, int flags, int mode, int os) {
 static int Mprotect(void *addr, unsigned long size, int prot, int os) {
   int numba;
   if (IsLinux()) {
-    if (IsAarch64()) {
+    if (UsesLinuxGenericSyscalls()) {
       numba = 226;
     } else {
       numba = 10;
@@ -481,7 +492,7 @@ static long Mmap(void *addr, unsigned long size, int prot, int flags, int fd,
                  long off, int os) {
   long numba;
   if (IsLinux()) {
-    if (IsAarch64()) {
+    if (UsesLinuxGenericSyscalls()) {
       numba = 222;
     } else {
       numba = 9;
@@ -831,6 +842,10 @@ static const char *TryElf(struct ApeLoader *M, union ElfEhdrBuf *ebuf,
 #ifdef __aarch64__
   if (e->e_machine != EM_AARCH64) {
     return "couldn't find ELF header with AARCH64 machine type";
+  }
+#elif defined(__riscv)
+  if (e->e_machine != EM_RISCV) {
+    return "couldn't find ELF header with RISC-V machine type";
   }
 #else
   if (e->e_machine != EM_NEXGEN32E) {

--- a/ape/specification.md
+++ b/ape/specification.md
@@ -23,6 +23,9 @@ installations of the many OSes and architectures.
   - FreeBSD
   - Windows (non-native)
 
+- RISC-V RV64
+  - Linux
+
 ## File Header
 
 APE defines three separate file magics, all of which are 8 characters

--- a/ape/start.S
+++ b/ape/start.S
@@ -28,6 +28,15 @@ _start:	mov	x1,sp
 	bl	ApeLoader
 	.endfn	_start,globl
 
+#elif defined(__riscv)
+
+_start:	mv	a1,sp
+	andi	sp,sp,-16
+	li	a0,0
+	li	a2,0
+	call	ApeLoader
+	.endfn	_start,globl
+
 #else
 
 XnuEntrypoint:

--- a/ape/systemcall.S
+++ b/ape/systemcall.S
@@ -37,6 +37,9 @@ SystemCall:
 	ret
 1:	neg	x0,x0
 	ret
+#elif defined(__riscv)
+	ecall
+	ret
 #else
 	mov	%rcx,%r10
 	mov	16(%rsp),%eax

--- a/libc/macros.h
+++ b/libc/macros.h
@@ -175,6 +175,15 @@
 	.cfi_adjust_cfa_offset 16
 	.cfi_rel_offset x29,0
 	.cfi_rel_offset x30,8
+#elif defined(__riscv)
+	addi	sp,sp,-16
+	sd	s0,0(sp)
+	sd	ra,8(sp)
+	addi	s0,sp,16
+	.cfi_adjust_cfa_offset 16
+	.cfi_rel_offset s0,0
+	.cfi_rel_offset ra,8
+	.cfi_def_cfa s0,0
 #else
 #error "unsupported architecture"
 #endif
@@ -191,6 +200,14 @@
 	.cfi_adjust_cfa_offset -16
 	.cfi_restore x30
 	.cfi_restore x29
+#elif defined(__riscv)
+	.cfi_def_cfa sp,16
+	ld	ra,8(sp)
+	ld	s0,0(sp)
+	addi	sp,sp,16
+	.cfi_adjust_cfa_offset -16
+	.cfi_restore ra
+	.cfi_restore s0
 #else
 #error "unsupported architecture"
 #endif

--- a/tool/build/apelink.c
+++ b/tool/build/apelink.c
@@ -1661,6 +1661,8 @@ static char *GenerateScriptIfLoaderMachine(char *p, struct Loader *loader) {
     p = stpcpy(p, "if [ \"$m\" = ppc64le ]");
   } else if (loader->machine == EM_MIPS) {
     p = stpcpy(p, "if [ \"$m\" = mips64 ]");
+  } else if (loader->machine == EM_RISCV) {
+    p = stpcpy(p, "if [ \"$m\" = riscv64 ]");
   } else {
     Die(loader->path, "unsupported cpu architecture");
   }

--- a/tool/build/apelink.c
+++ b/tool/build/apelink.c
@@ -1643,6 +1643,8 @@ static char *GenerateScriptIfMachine(char *p, struct Input *in) {
     return stpcpy(p, "if [ \"$m\" = aarch64 ] || [ \"$m\" = arm64 ]; then\n");
   } else if (in->elf->e_machine == EM_PPC64) {
     return stpcpy(p, "if [ \"$m\" = ppc64le ]; then\n");
+  } else if (in->elf->e_machine == EM_RISCV) {
+    return stpcpy(p, "if [ \"$m\" = riscv64 ]; then\n");
   } else {
     Die(in->path, "unsupported cpu architecture");
   }


### PR DESCRIPTION
This adds a Linux RV64 APE loader and teaches apelink to select it when `uname -m` reports `riscv64`. The loader uses the Linux generic syscall ABI and currently targets static RV64IMAC/LP64 ELF executables.

This is loader support only. It does not attempt to port Cosmopolitan libc or the compiler runtime to RISC-V (will be implemented in the future).

For a minimal test, save the following as `/tmp/hello-riscv64.S`:

```asm
	.section .text
	.globl _start
	.type _start, @function
_start:
	li a0, 1
	la a1, message
	li a2, 19
	li a7, 64
	ecall

	li a0, 0
	li a7, 93
	ecall
	.size _start, . - _start

	.section .rodata
message:
	.ascii "hello from riscv64\n"
```

It uses the Linux `write` and `exit` syscalls directly and does not depend on libc. Compile it with:

```sh
riscv64-linux-gnu-gcc \
  -nostdlib -static \
  -march=rv64imac -mabi=lp64 \
  -Wl,-e,_start \
  -Wl,--build-id=none \
  -Wl,-Ttext-segment=0x400000 \
  -o /tmp/hello-riscv64.elf \
  /tmp/hello-riscv64.S
```

The explicit text address keeps the ELF load segments above the 2 MiB userspace limit enforced by apelink.

Build `apelink` and the three loaders with:

```sh
make -j16 o//tool/build/apelink
make -j16 o//ape/ape.elf
make -j16 MODE=aarch64 o/aarch64/ape/ape.elf
make -j16 MODE=riscv64 ARCH=riscv64 \
  TOOLCHAIN=riscv64-linux-gnu- \
  o/riscv64/ape/ape.elf
```

The existing example ELFs can be used as the x86-64 and AArch64 payloads:

```sh
make -j16 o//examples/hello
make -j16 MODE=aarch64 o/aarch64/examples/hello

o//tool/build/apelink \
  -l o//ape/ape.elf \
  -l o/aarch64/ape/ape.elf \
  -l o/riscv64/ape/ape.elf \
  -o /tmp/hello.com \
  o//examples/hello.dbg \
  o/aarch64/examples/hello.dbg \
  /tmp/hello-riscv64.elf
```

Running the resulting file on x86-64 prints `hello world`. Running the same file on a Linux machine where `uname -m` reports `riscv64` prints:

```text
hello from riscv64
```

The RISC-V path was tested on real hardware, including repeated runs through the extracted loader cache. The existing x86-64 and AArch64 loader builds also continue to pass. (AArch64 execution was not tested on our hardware.)