### PR TITLE
fix(execve-sysv): on shell fallback always terminate argv even when argc == 0

### DIFF
--- a/libc/intrin/getmainstack.c
+++ b/libc/intrin/getmainstack.c
@@ -76,7 +76,8 @@ static int __get_length(const char *s) {
 static uintptr_t __get_main_top(int pagesz) {
   uintptr_t top;
   const char *s;
-  if ((s = __get_last(__envp)) || (s = __get_last(__argv))) {
+  if ((s = __get_last(__envp)) || (s = __get_last(__argv)) ||
+      (s = __program_executable_name)) {
     top = (uintptr_t)s + __get_length(s);
   } else {
     unsigned long *xp = __auxv;

--- a/libc/intrin/getmainstack.c
+++ b/libc/intrin/getmainstack.c
@@ -74,16 +74,19 @@ static int __get_length(const char *s) {
 }
 
 static uintptr_t __get_main_top(int pagesz) {
-  uintptr_t top;
+  uintptr_t top, alttop;
   const char *s;
-  if ((s = __get_last(__envp)) || (s = __get_last(__argv)) ||
-      (s = __program_executable_name)) {
+  if ((s = __get_last(__envp)) || (s = __get_last(__argv))) {
     top = (uintptr_t)s + __get_length(s);
   } else {
     unsigned long *xp = __auxv;
     while (*xp)
       xp += 2;
     top = (uintptr_t)xp;
+  }
+  if ((s = __program_executable_name)) {
+    alttop = (uintptr_t)s + __get_length(s);
+    top = MAX(top, alttop);
   }
   return ROUNDUP(top, pagesz);
 }

--- a/test/libc/calls/BUILD.mk
+++ b/test/libc/calls/BUILD.mk
@@ -20,7 +20,6 @@ TEST_LIBC_CALLS_BINS =							\
 	$(TEST_LIBC_CALLS_COMS:%=%.dbg)					\
 	o/$(MODE)/test/libc/calls/life-nomod				\
 	o/$(MODE)/test/libc/calls/life-classic				\
-	o/$(MODE)/test/libc/calls/zipread.dbg				\
 	o/$(MODE)/test/libc/calls/zipread
 
 TEST_LIBC_CALLS_TESTS =							\
@@ -71,6 +70,16 @@ o/$(MODE)/test/libc/calls/%.dbg:					\
 		$(APE_NO_MODIFY_SELF)
 	@$(APELINK)
 
+o/$(MODE)/test/libc/calls/getprogramexecutablename_test.dbg:					\
+		$(TEST_LIBC_CALLS_DEPS)						\
+		o/$(MODE)/test/libc/calls/getprogramexecutablename_test.o	\
+		o/$(MODE)/test/libc/calls/ape.elf.zip.o				\
+		o/$(MODE)/test/libc/calls/calls.pkg				\
+		$(LIBC_TESTMAIN)						\
+		$(CRT)								\
+		$(APE_NO_MODIFY_SELF)
+	@$(APELINK)
+
 o/$(MODE)/test/libc/calls/stat_test.dbg:				\
 		$(TEST_LIBC_CALLS_DEPS)					\
 		o/$(MODE)/test/libc/calls/stat_test.o			\
@@ -117,6 +126,23 @@ o/$(MODE)/test/libc/calls/life-nomod.dbg:				\
 		$(APE_NO_MODIFY_SELF)
 	@$(APELINK)
 
+o/$(MODE)/test/libc/calls/zipread.dbg:				\
+		$(LIBC_RUNTIME)						\
+		o/$(MODE)/test/libc/calls/zipread.o			\
+		o/$(MODE)/test/libc/mem/prog/life.elf.zip.o		\
+		$(CRT)							\
+		$(APE_NO_MODIFY_SELF)
+	@$(APELINK)
+
+o/$(MODE)/test/libc/calls/ape.elf:			\
+		o/$(MODE)/tool/build/cp		\
+		o/$(MODE)/ape/ape.elf
+	@$(COMPILE) -wACP -T$@					\
+		o/$(MODE)/tool/build/cp				\
+		o/$(MODE)/ape/ape.elf			\
+		o/$(MODE)/test/libc/calls/ape.elf
+
+o/$(MODE)/test/libc/calls/ape.elf.zip.o					\
 o/$(MODE)/test/libc/calls/tiny64.elf.zip.o				\
 o/$(MODE)/test/libc/calls/life-nomod.zip.o				\
 o/$(MODE)/test/libc/calls/life-classic.zip.o				\

--- a/test/libc/calls/getprogramexecutablename_test.c
+++ b/test/libc/calls/getprogramexecutablename_test.c
@@ -22,6 +22,7 @@
 #include "libc/calls/syscall-sysv.internal.h"
 #include "libc/calls/syscall_support-sysv.internal.h"
 #include "libc/dce.h"
+#include "libc/intrin/kprintf.h"
 #include "libc/limits.h"
 #include "libc/runtime/runtime.h"
 #include "libc/serialize.h"
@@ -89,6 +90,28 @@ __attribute__((__constructor__)) static void Child(int argc, char *argv[]) {
       }
     }
     exit(0);
+  } else if (argc == 0) {
+    // test argc == 0 childs
+    int rc;
+    if (!IsWindows()) {
+      rc = sys_chdir("/");
+    } else {
+      rc = sys_chdir_nt("/");
+    }
+    if (rc) {
+      exit(122);
+    }
+    if (loaded && kisdangerous(__program_executable_name)) {
+      exit(125);
+    }
+    const char *name = GetProgramExecutableName();
+    if (kisdangerous(name)) {
+      exit(126);
+    }
+    if (strlen(name) == 0) {
+      exit(127);
+    }
+    exit(0);
   }
 }
 
@@ -152,6 +175,19 @@ TEST(GetProgramExecutableName, movedSelf) {
   SPAWN(fork);
   execve("./test", (char *[]){"hello", "Child", buf, skiparg0 ? 0 : "hello", 0},
          (char *[]){0});
+  abort();
+  EXITS(0);
+}
+
+TEST(GetProgramExecutableName, nullArgvAPELoader) {
+  // TODO(G4Vi): Confirm if OpenBSD actually has an issue running elfs. See note
+  //             in posix_spawn_test.c
+  if (skiptests || IsOpenbsd() || IsXnu() || IsWindows() || IsMetal())
+    return;
+  testlib_extract("/zip/ape.elf", "ape.elf", 0555);
+  char *prog = "./ape.elf";
+  SPAWN(fork);
+  execve(prog, (char *const[]){prog, "-", self, NULL}, (char *[]){0});
   abort();
   EXITS(0);
 }

--- a/test/libc/proc/BUILD.mk
+++ b/test/libc/proc/BUILD.mk
@@ -99,6 +99,7 @@ o/$(MODE)/test/libc/proc/execve_test.dbg:				\
 		$(TEST_LIBC_PROC_DEPS)					\
 		o/$(MODE)/test/libc/proc/execve_test.o			\
 		o/$(MODE)/test/libc/calls/life-nomod.zip.o		\
+		o/$(MODE)/test/libc/calls/zipread.zip.o			\
 		o/$(MODE)/test/libc/proc/execve_test_prog1.zip.o	\
 		o/$(MODE)/test/libc/proc/execve_test_prog2.zip.o	\
 		o/$(MODE)/test/libc/mem/prog/life.elf.zip.o		\

--- a/test/libc/proc/execve_test.c
+++ b/test/libc/proc/execve_test.c
@@ -24,6 +24,7 @@
 #include "libc/fmt/conv.h"
 #include "libc/fmt/itoa.h"
 #include "libc/intrin/kprintf.h"
+#include "libc/mem/mem.h"
 #include "libc/runtime/runtime.h"
 #include "libc/str/str.h"
 #include "libc/temp.h"
@@ -62,6 +63,17 @@ TEST(execve, testArgPassing) {
     kprintf("execve failed: %m\n");
     EXITS(0);
   }
+}
+
+TEST(execve, APEwithZipos) {
+  testlib_extract("/zip/zipread", "zipread", 0555);
+  char *zipread = realpath("zipread", NULL);
+  ASSERT_NE(NULL, zipread);
+  SPAWN(fork);
+  execve(zipread, (char *const[]){0}, (char *const[]){0});
+  kprintf("execve failed: %m\n");
+  EXITS(42);
+  free(zipread);
 }
 
 TEST(execve, ziposELF) {


### PR DESCRIPTION
Includes #1519, will rebase after that's merged, 2a390c2 is the only commit to look at here.

Before, when empty `argv` was passed and the shell fallback was called, uninitialized values appeared in `argv` as the `memcpy` would not copy anything in that scenario so no terminating `NULL` would be set. The new code terminates `argv` in case no further values are copied. Additionally, the `memcpy` only occurs if `argc > 0`  so it isn't invoked with an invalid src pointer even though when size is zero it should be a no-op.

Alternatively, we could fail with `ENOTSUP` when the fallback is reached as empty argv isn't supported in this scenario. I figure `execve` succeeding when incorrect argv is preferred to failing and is already the behavior for the shell fallback as it does not fail if `argv[0] != prog`. If that is preferred, I can close this and create a PR with https://github.com/jart/cosmopolitan/commit/22cd1dc8d800221ed5e642143b33dcddabb2e6a8
